### PR TITLE
MaxQuant scores added 

### DIFF
--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -20083,10 +20083,39 @@ is_a: MS:1000494 ! Thermo Scientific instrument model
 
 [Term]
 id: MS:1003097
-name: MaxQuant: protein group-level score
+name: MaxQuant:protein group-level score
 def: "The probability based MaxQuant protein group score." [PSI:MS]
 is_a: MS:1002368 ! search engine specific score for protein groups
 
+[Term]
+id: MS:1003098
+name: Andromeda:peptide PEP
+def: "Peptide probability from Andromeda." [PSI:MS]
+is_a: MS:1002358 ! search engine specific peptide sequence-level identification statistic
+
+[Term]
+id: MS:1003099
+name: MaxQuant-DIA:peptide PEP
+def: "Peptide probability from MaxQuant-DIA algorithm." [PSI:MS]
+is_a: MS:1002358 ! search engine specific peptide sequence-level identification statistic
+
+[Term]
+id: MS:1003100
+name: MaxQuant-DIA:score
+def: "PSM evidence score from MAxQuant-DIA algorithm." [PSI:MS]
+is_a: MS:1001143 ! PSM-level search engine specific statistic
+
+[Term]
+id: MS:1003101
+name: MaxQuant-DIA:PEP
+def: "PSM evidence PEP probability from MAxQuant-DIA algorithm." [PSI:MS]
+is_a: MS:1001143 ! PSM-level search engine specific statistic
+
+[Term]
+id: MS:1003102
+name: NIST msp spectrum reference
+def: "NIST msp spectrum reference name and comment" [PSI:MS]
+is_a: MS:1000499 ! spectrum attribute
 
 [Term]
 id: PEFF:0000001

--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -20114,7 +20114,7 @@ is_a: MS:1001143 ! PSM-level search engine specific statistic
 [Term]
 id: MS:1003102
 name: NIST msp comment
-def: "NIST msp comment" [PSI:MS]
+def: "Term for a comment field withing the NIST msp file format" [PSI:MS]
 is_a: MS:1000499 ! spectrum attribute
 
 [Term]

--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -20083,31 +20083,31 @@ is_a: MS:1000494 ! Thermo Scientific instrument model
 
 [Term]
 id: MS:1003097
-name: MaxQuant:protein group-level score
+name: MaxQuant protein group-level score
 def: "The probability based MaxQuant protein group score." [PSI:MS]
 is_a: MS:1002368 ! search engine specific score for protein groups
 
 [Term]
 id: MS:1003098
-name: Andromeda:peptide PEP
+name: Andromeda peptide PEP
 def: "Peptide probability from Andromeda." [PSI:MS]
 is_a: MS:1002358 ! search engine specific peptide sequence-level identification statistic
 
 [Term]
 id: MS:1003099
-name: MaxQuant-DIA:peptide PEP
+name: MaxQuant-DIA peptide PEP
 def: "Peptide probability from MaxQuant-DIA algorithm." [PSI:MS]
 is_a: MS:1002358 ! search engine specific peptide sequence-level identification statistic
 
 [Term]
 id: MS:1003100
-name: MaxQuant-DIA:score
+name: MaxQuant-DIA score
 def: "PSM evidence score from MAxQuant-DIA algorithm." [PSI:MS]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 
 [Term]
 id: MS:1003101
-name: MaxQuant-DIA:PEP
+name: MaxQuant-DIA PEP
 def: "PSM evidence PEP probability from MAxQuant-DIA algorithm." [PSI:MS]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 

--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -20082,6 +20082,13 @@ def: "Thermo Scientific LTQ Orbitrap Velos Pro, often just referred to as the Or
 is_a: MS:1000494 ! Thermo Scientific instrument model
 
 [Term]
+id: MS:1003097
+name: MaxQuant: protein group-level score
+def: "The probability based MaxQuant protein group score." [PSI:MS]
+is_a: MS:1002368 ! search engine specific score for protein groups
+
+
+[Term]
 id: PEFF:0000001
 name: PEFF CV term
 def: "PSI Extended FASTA Format controlled vocabulary term." [PSI:PEFF]

--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -20085,36 +20085,42 @@ is_a: MS:1000494 ! Thermo Scientific instrument model
 id: MS:1003097
 name: MaxQuant protein group-level score
 def: "The probability based MaxQuant protein group score." [PSI:MS]
+xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002368 ! search engine specific score for protein groups
 
 [Term]
 id: MS:1003098
 name: Andromeda peptide PEP
 def: "Peptide probability from Andromeda." [PSI:MS]
+xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002358 ! search engine specific peptide sequence-level identification statistic
 
 [Term]
 id: MS:1003099
 name: MaxQuant-DIA peptide PEP
 def: "Peptide probability from MaxQuant-DIA algorithm." [PSI:MS]
+xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002358 ! search engine specific peptide sequence-level identification statistic
 
 [Term]
 id: MS:1003100
 name: MaxQuant-DIA score
 def: "PSM evidence score from MaxQuant-DIA algorithm." [PSI:MS]
+xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 
 [Term]
 id: MS:1003101
 name: MaxQuant-DIA PEP
 def: "PSM evidence PEP probability from MaxQuant-DIA algorithm." [PSI:MS]
+xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 
 [Term]
 id: MS:1003102
 name: NIST msp comment
 def: "Term for a comment field withing the NIST msp file format" [PSI:MS]
+xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000499 ! spectrum attribute
 
 [Term]

--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -20113,8 +20113,8 @@ is_a: MS:1001143 ! PSM-level search engine specific statistic
 
 [Term]
 id: MS:1003102
-name: NIST msp spectrum reference
-def: "NIST msp spectrum reference name and comment" [PSI:MS]
+name: NIST msp comment
+def: "NIST msp comment" [PSI:MS]
 is_a: MS:1000499 ! spectrum attribute
 
 [Term]

--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -20102,13 +20102,13 @@ is_a: MS:1002358 ! search engine specific peptide sequence-level identification 
 [Term]
 id: MS:1003100
 name: MaxQuant-DIA score
-def: "PSM evidence score from MAxQuant-DIA algorithm." [PSI:MS]
+def: "PSM evidence score from MaxQuant-DIA algorithm." [PSI:MS]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 
 [Term]
 id: MS:1003101
 name: MaxQuant-DIA PEP
-def: "PSM evidence PEP probability from MAxQuant-DIA algorithm." [PSI:MS]
+def: "PSM evidence PEP probability from MaxQuant-DIA algorithm." [PSI:MS]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 
 [Term]


### PR DESCRIPTION
This PR includes a set of scores for MaxQuant-DIA experiments. In addition, we added a NIST msp reference to spectra 