### PR TITLE
Demonstrate encoding value types with relationships

### DIFF
--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -48,6 +48,12 @@ name: has_order
 id: has_domain
 name: has_domain
 
+[Typedef]
+id: has_value_type
+name: has value type
+def: "'Entity A' has value type 'Entity B', such as xsd:float." []
+is_transitive: true
+
 [Term]
 id: MS:0000000
 name: Proteomics Standards Initiative Mass Spectrometry Vocabularies

--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -63,8 +63,8 @@ def: "Proteomics Standards Initiative Mass Spectrometry Vocabularies." [PSI:MS]
 id: MS:1000001
 name: sample number
 def: "A reference number relevant to the sample under study." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000548 ! sample attribute
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000002
@@ -83,9 +83,9 @@ is_a: MS:1000548 ! sample attribute
 id: MS:1000004
 name: sample mass
 def: "Total mass of sample used." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000548 ! sample attribute
 relationship: has_units UO:0000021 ! gram
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000005
@@ -19183,9 +19183,9 @@ is_a: MS:1001143 ! PSM-level search engine specific statistic
 id: MS:1002954
 name: collisional cross sectional area
 def: "Structural molecular descriptor for the effective interaction area between the ion and neutral gas measured in ion mobility mass spectrometry." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1000861 ! molecular entity property
 relationship: has_units UO:0000324 ! square angstrom
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002955
@@ -19454,8 +19454,8 @@ is_a: MS:1000560 ! mass spectrometer file format
 id: MS:1002997
 name: ProteomeXchange dataset identifier reanalysis number
 def: "Index number of a reanalysis within a ProteomeXchange reprocessed dataset identifier container (RPXD)." [PSI:PI]
-xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
+relationship: has_value_type xsd:nonNegativeInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002998


### PR DESCRIPTION
Many terms seem to be annotating their types using formations like this:
```
[Term]
id: MS:1000005
name: sample volume
def: "Total volume of solution used." [PSI:MS]
xref: value-type:xsd\:float "The allowed value-type for this CV term."
is_a: MS:1000548 ! sample attribute
relationship: has_units UO:0000098 ! milliliter
```

This isn't typically how xrefs are used. I think it would be better to create a new `[Typedef]` for `value-type` that would allow a relationship like

`relationship: has_value_type xsd:float`

I accidentally opened an issue on the PSI-MI controlled vocabulary (https://github.com/HUPO-PSI/psi-mi-CV/issues/434) where I had a short discussion with @pporrasebi. Here in this PR, I would like to demonstrate what this kind of update could look like by doing the following:

1. Introduce a typedef appropriate for connecting PSI-MS terms to their allowed value types

   ```
   [Typedef]
   id: has_value_type
   name: has value type
   def: "'Entity A' has value type 'Entity B', such as xsd:float." []
   is_transitive: true
   ```
2. Demonstrate for usages of various datatypes (string, float, double, nonNegativeInteger)

This PR is meant to be a demonstration of what this kind of change would look like and is not complete. It would be easy enough to do some find/replace to fix the rest, but I'm not sure if that follows the typical rules for how OBO terms are laid out.