### PR TITLE
Add has_value_type

### DIFF
--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -1,5 +1,5 @@
 format-version: 1.2
-data-version: 4.1.56
+data-version: 4.1.57
 date: 21:05:2021 00:00
 saved-by: Joshua Klein
 auto-generated-by: OBO-Edit 2.3.1

--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -17799,21 +17799,18 @@ id: MS:1002711
 name: list of strings
 def: "A list of xsd:string." []
 is_a: MS:1002710 ! list of type
-relationship: has_value_type xsd\:string ! None
 
 [Term]
 id: MS:1002712
 name: list of integers
 def: "A list of xsd:integer." []
 is_a: MS:1002710 ! list of type
-relationship: has_value_type xsd\:integer ! None
 
 [Term]
 id: MS:1002713
 name: list of floats
 def: "A list of xsd:float." []
 is_a: MS:1002710 ! list of type
-relationship: has_value_type xsd\:float ! None
 
 [Term]
 id: MS:1002719
@@ -20872,7 +20869,7 @@ id: MS:1003162
 name: analyte mixture members
 def: "The set of analyte identifiers that compose an interpretation of a spectrum." [PSI:PI]
 is_a: MS:1003078 ! interpreted spectrum attribute
-relationship: has_value_type MS:1002711 ! list of strings
+relationship: has_value_type MS:1002712 ! list of integers
 
 [Term]
 id: PEFF:0000001

--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -1,7 +1,7 @@
 format-version: 1.2
-data-version: 4.1.55
+data-version: 4.1.56
 date: 21:05:2021 00:00
-saved-by: Joshua Klei
+saved-by: Joshua Klein
 auto-generated-by: OBO-Edit 2.3.1
 import: http://ontologies.berkeleybop.org/pato.obo
 import: http://ontologies.berkeleybop.org/uo.obo

--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -20893,6 +20893,13 @@ def: "Grouping term for quality control data formats." [PSI:MS]
 is_a: MS:1001459 ! file format
 
 [Term]
+id: MS:1003162
+name: analyte mixture members
+def: "The set of analyte identifiers that compose an interpretation of a spectrum." [PSI:PI]
+is_a: MS:1003078 ! interpreted spectrum attribute
+relationship: has_value_type MS:1002711 ! list of strings
+
+[Term]
 id: PEFF:0000001
 name: PEFF CV term
 def: "PSI Extended FASTA Format controlled vocabulary term." [PSI:PEFF]

--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -1,7 +1,7 @@
 format-version: 1.2
-data-version: 4.1.57
-date: 02:07:2021 00:00
-saved-by: Joshua Klein
+data-version: 4.1.55
+date: 21:05:2021 00:00
+saved-by: Joshua Klei
 auto-generated-by: OBO-Edit 2.3.1
 import: http://ontologies.berkeleybop.org/pato.obo
 import: http://ontologies.berkeleybop.org/uo.obo
@@ -29,20 +29,6 @@ remark: To view a copy of this license, visit https://creativecommons.org/licens
 ontology: ms
 
 [Typedef]
-id: has_domain
-name: has_domain
-
-[Typedef]
-id: has_element_type
-name: has element type
-def: "'Entity A' is a collection of elements of value type element 'Entity B'." []
-is_transitive: true
-
-[Typedef]
-id: has_order
-name: has_order
-
-[Typedef]
 id: has_regexp
 name: has regexp
 
@@ -51,15 +37,17 @@ id: has_units
 name: has_units
 
 [Typedef]
-id: has_value_type
-name: has value type
-def: "'Entity A' has value type 'Entity B', such as xsd:float." []
-is_transitive: true
-
-[Typedef]
 id: part_of
 name: part_of
 is_transitive: true
+
+[Typedef]
+id: has_order
+name: has_order
+
+[Typedef]
+id: has_domain
+name: has_domain
 
 [Term]
 id: MS:0000000
@@ -72,7 +60,6 @@ name: sample number
 def: "A reference number relevant to the sample under study." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000548 ! sample attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000002
@@ -80,7 +67,6 @@ name: sample name
 def: "A reference string relevant to the sample under study." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000548 ! sample attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000003
@@ -95,7 +81,6 @@ def: "Total mass of sample used." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000548 ! sample attribute
 relationship: has_units UO:0000021 ! gram
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000005
@@ -104,7 +89,6 @@ def: "Total volume of solution used." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000548 ! sample attribute
 relationship: has_units UO:0000098 ! milliliter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000006
@@ -113,7 +97,6 @@ def: "Concentration of sample in picomol/ul, femtomol/ul or attomol/ul solution 
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000548 ! sample attribute
 relationship: has_units UO:0000175 ! gram per liter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000007
@@ -131,11 +114,15 @@ relationship: part_of MS:1000458 ! source
 id: MS:1000009
 name: ionization mode
 def: "OBSOLETE Whether positive or negative ions are selected for analysis by the spectrometer." [PSI:MS]
+comment: This term was made obsolete because it was replaced by scan polarity (MS:1000465).
+is_obsolete: true
 
 [Term]
 id: MS:1000010
 name: analyzer type
 def: "OBSOLETE The common name of the particular analyzer stage being described. Synonym of mass analyzer, should be obsoleted." [PSI:MS]
+comment: This former purgatory term was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000011
@@ -143,7 +130,6 @@ name: mass resolution
 def: "Smallest mass difference between two equal magnitude peaks so that the valley between them is a specified fraction of the peak height." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000503 ! scan attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000012
@@ -155,6 +141,8 @@ is_a: MS:1000596 ! measurement method
 id: MS:1000013
 name: resolution type
 def: "OBSOLETE Specify the nature of resolution for the mass analyzer. Resolution is usually either constant with respect to m/z or proportional to m/z." [PSI:MS]
+comment: This former purgatory term was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000014
@@ -164,7 +152,6 @@ xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000480 ! mass analyzer attribute
 relationship: has_units MS:1000040 ! m/z
 relationship: has_units UO:0000169 ! parts per million
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000015
@@ -173,7 +160,6 @@ def: "Rate in Th/sec for scanning analyzers." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000503 ! scan attribute
 relationship: has_units MS:1000807 ! Th/s
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000016
@@ -184,12 +170,13 @@ is_a: MS:1000503 ! scan attribute
 is_a: MS:1002345 ! PSM-level attribute
 relationship: has_units UO:0000010 ! second
 relationship: has_units UO:0000031 ! minute
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000017
 name: Scan Function
 def: "OBSOLETE Describes the type of mass analysis being performed. Two primary modes are: typical acquisition over a range of masses (Mass Scan), and Selected Ion Detection. The primary difference is that Selected Ion Detection produces a single value for the signal at the selected mass rather than producing a mass spectrum." [PSI:MS]
+comment: OBSOLETE This former purgatory term was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000018
@@ -207,6 +194,9 @@ relationship: part_of MS:1000441 ! scan
 id: MS:1000020
 name: scanning method
 def: "Describes the acquisition data type produced by a tandem mass spectrometry experiment." [PSI:MS]
+comment: OBSOLETE This former purgatory term was made obsolete.
+synonym: "Tandem Scanning Method" RELATED []
+is_obsolete: true
 
 [Term]
 id: MS:1000021
@@ -221,15 +211,15 @@ def: "The length of the field free drift space in a time of flight mass spectrom
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000480 ! mass analyzer attribute
 relationship: has_units UO:0000008 ! meter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000023
 name: isolation width
 def: "OBSOLETE The total width (i.e. not half for plus-or-minus) of the gate applied around a selected precursor ion." [PSI:MS]
+comment: This former purgatory term was made obsolete.
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 relationship: has_units MS:1000040 ! m/z
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
+is_obsolete: true
 
 [Term]
 id: MS:1000024
@@ -237,16 +227,16 @@ name: final MS exponent
 def: "Final MS level achieved when performing PFF with the ion trap (e.g. MS E10)." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1000480 ! mass analyzer attribute
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000025
 name: magnetic field strength
 def: "A property of space that produces a force on a charged particle equal to qv x B where q is the particle charge and v its velocity." [PSI:MS]
+synonym: "B" EXACT []
+synonym: "Magnetic Field" RELATED []
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000480 ! mass analyzer attribute
 relationship: has_units UO:0000228 ! tesla
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000026
@@ -266,21 +256,22 @@ name: detector resolution
 def: "The resolving power of the detector to detect the smallest difference between two ions so that the valley between them is a specified fraction of the peak height." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000481 ! detector attribute
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000029
 name: sampling frequency
 def: "The rate of signal sampling (measurement) with respect to time." [PSI:MS]
+synonym: "ADC Sampling Frequency" NARROW []
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000481 ! detector attribute
 relationship: has_units UO:0000106 ! hertz
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000030
 name: vendor
 def: "OBSOLETE Name of instrument vendor." [PSI:MS]
+comment: This term was made obsolete because it was replaced by instrument model (MS:1000031).
+is_obsolete: true
 
 [Term]
 id: MS:1000031
@@ -294,7 +285,6 @@ name: customization
 def: "Free text description of a single customization made to the instrument; for several modifications, use several entries." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000496 ! instrument attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000033
@@ -318,36 +308,47 @@ is_a: MS:1000543 ! data processing action
 id: MS:1000036
 name: scan mode
 def: "OBSOLETE." [PSI:MS]
+comment: This term was made obsolete because .
+is_obsolete: true
 
 [Term]
 id: MS:1000037
 name: polarity
 def: "OBSOLETE Terms to describe the polarity setting of the instrument." [PSI:MS]
+comment: This term was made obsolete because it was redundant with the Pato Ontology term polarity (UO:0002186).
+is_obsolete: true
 
 [Term]
 id: MS:1000038
 name: minute
 def: "OBSOLETE Acquisition time in minutes." [PSI:MS]
+comment: This term was made obsolete because it was redundant with Unit Ontology minute (UO:0000031).
+is_obsolete: true
 
 [Term]
 id: MS:1000039
 name: second
 def: "OBSOLETE Acquisition time in seconds." [PSI:MS]
+comment: This term was made obsolete because it was redundant with Unit Ontology second (UO:0000010).
+is_obsolete: true
 
 [Term]
 id: MS:1000040
 name: m/z
 def: "Three-character symbol m/z is used to denote the quantity formed by dividing the mass of an ion in unified atomic mass units by its charge number (regardless of sign). The symbol is written in italicized lower case letters with no spaces. Note 1: The term mass-to-charge-ratio is deprecated. Mass-to-charge ratio has been used for the abscissa of a mass spectrum, although the quantity measured is not the quotient of the ion's mass to its electric charge. The three-character symbol m/z is recommended for the quantity that is the independent variable in a mass spectrum Note 2: The proposed unit thomson (Th) is deprecated." [PSI:MS]
+synonym: "mass-to-charge ratio" EXACT []
+synonym: "Th" EXACT []
+synonym: "thomson" EXACT []
 is_a: UO:0000000 ! unit
 
 [Term]
 id: MS:1000041
 name: charge state
 def: "Number of net charges, positive or negative, on an ion." [PSI:MS]
+synonym: "z" EXACT []
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1000455 ! ion selection attribute
 is_a: MS:1000507 ! ion property
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000042
@@ -361,7 +362,6 @@ relationship: has_units MS:1000814 ! counts per second
 relationship: has_units MS:1000905 ! percent of base peak times 100
 relationship: has_units UO:0000269 ! absorbance unit
 relationship: part_of MS:1000231 ! peak
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000043
@@ -373,6 +373,7 @@ is_a: UO:0000000 ! unit
 id: MS:1000044
 name: dissociation method
 def: "Fragmentation method used for dissociation or fragmentation." [PSI:MS]
+synonym: "Activation Method" RELATED []
 relationship: part_of MS:1000456 ! precursor activation
 
 [Term]
@@ -382,13 +383,14 @@ def: "Energy for an ion experiencing collision with a stationary gas particle re
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000510 ! precursor activation attribute
 relationship: has_units UO:0000266 ! electronvolt
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000046
 name: energy unit
 def: "OBSOLETE Energy units are represented in either eV or Joules." [PSI:MS]
+comment: This term was made obsolete because it was redundant with the Unit Ontology term energy unit (UO:0000111).
 is_a: UO:0000000 ! unit
+is_obsolete: true
 
 [Term]
 id: MS:1000047
@@ -432,17 +434,19 @@ name: sample batch
 def: "Sample batch lot identifier." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000548 ! sample attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000054
 name: chromatography
 def: "OBSOLETE Chromatographic conditions used to obtain the sample." [PSI:MS]
+comment: This former purgatory term was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000055
 name: continuous flow fast atom bombardment
 def: "Fast atom bombardment ionization in which the analyte in solution is entrained in a flowing liquid matrix." [PSI:MS]
+synonym: "CF-FAB" EXACT []
 is_a: MS:1000007 ! inlet type
 
 [Term]
@@ -533,46 +537,58 @@ is_a: MS:1000007 ! inlet type
 id: MS:1000070
 name: atmospheric pressure chemical ionization
 def: "Chemical ionization that takes place at atmospheric pressure as opposed to the reduced pressure is normally used for chemical ionization." [PSI:MS]
+synonym: "APCI" EXACT []
 is_a: MS:1000240 ! atmospheric pressure ionization
 
 [Term]
 id: MS:1000071
 name: chemical ionization
 def: "The formation of a new ion by the reaction of a neutral species with an ion. The process may involve transfer of an electron, a proton or other charged species between the reactants. When a positive ion results from chemical ionization the term may be used without qualification. When a negative ion results the term negative ion chemical ionization should be used. Note that this term is not synonymous with chemi-ionization." [PSI:MS]
+synonym: "CI" EXACT []
 is_a: MS:1000008 ! ionization type
 
 [Term]
 id: MS:1000072
 name: Electronic Ionization
 def: "OBSOLETE The ionization of an atom or molecule by electrons that are typically accelerated to energies between 50 and 150 eV. Usually 70 eV electrons are used to produce positive ions. The term 'electron impact' is not recommended." [PSI:MS]
+comment: This term was made obsolete because it was replaced by electron ionization (MS:1000389).
+synonym: "EI" EXACT []
+is_obsolete: true
 
 [Term]
 id: MS:1000073
 name: electrospray ionization
 def: "A process in which ionized species in the gas phase are produced from an analyte-containing solution via highly charged fine droplets, by means of spraying the solution from a narrow-bore needle tip at atmospheric pressure in the presence of a high electric field. When a pressurized gas is used to aid in the formation of a stable spray, the term pneumatically assisted electrospray ionization is used. The term ion spray is not recommended." [PSI:MS]
+synonym: "ESI" EXACT []
 is_a: MS:1000008 ! ionization type
 
 [Term]
 id: MS:1000074
 name: fast atom bombardment ionization
 def: "The ionization of any species by the interaction of a focused beam of neutral atoms having a translational energy of several thousand eV with a sample that is typically dissolved in a solvent matrix. See also secondary ionization." [PSI:MS]
+synonym: "FAB" EXACT []
 is_a: MS:1000008 ! ionization type
 
 [Term]
 id: MS:1000075
 name: matrix-assisted laser desorption ionization
 def: "The formation of gas-phase ions from molecules that are present in a solid or solvent matrix that is irradiated with a pulsed laser. See also laser desorption/ionization." [PSI:MS]
+synonym: "MALDI" EXACT []
 is_a: MS:1000247 ! desorption ionization
 
 [Term]
 id: MS:1000076
 name: negative ion mode
 def: "OBSOLETE." [PSI:MS]
+comment: This term was made obsolete because it was replaced by negative scan (MS:1000129).
+is_obsolete: true
 
 [Term]
 id: MS:1000077
 name: positive ion mode
 def: "OBSOLETE." [PSI:MS]
+comment: This term was made obsolete because it was replaced by positive scan (MS:1000130).
+is_obsolete: true
 
 [Term]
 id: MS:1000078
@@ -584,6 +600,7 @@ is_a: MS:1000291 ! linear ion trap
 id: MS:1000079
 name: fourier transform ion cyclotron resonance mass spectrometer
 def: "A mass spectrometer based on the principle of ion cyclotron resonance in which an ion in a magnetic field moves in a circular orbit at a frequency characteristic of its m/z value. Ions are coherently excited to a larger radius orbit using a pulse of radio frequency energy and their image charge is detected on receiver plates as a time domain signal. Fourier transformation of the time domain signal results in a frequency domain signal which is converted to a mass spectrum based in the inverse relationship between frequency and m/z." [PSI:MS]
+synonym: "FT_ICR" EXACT []
 is_a: MS:1000443 ! mass analyzer type
 
 [Term]
@@ -602,6 +619,9 @@ is_a: MS:1000443 ! mass analyzer type
 id: MS:1000082
 name: quadrupole ion trap
 def: "Quadrupole Ion Trap mass analyzer captures the ions in a three dimensional ion trap and then selectively ejects them by varying the RF and DC potentials." [PSI:MS]
+synonym: "Paul Ion trap" EXACT []
+synonym: "QIT" EXACT []
+synonym: "Quistor" EXACT []
 is_a: MS:1000264 ! ion trap
 
 [Term]
@@ -614,6 +634,7 @@ is_a: MS:1000291 ! linear ion trap
 id: MS:1000084
 name: time-of-flight
 def: "Instrument that separates ions by m/z in a field-free region after acceleration to a fixed acceleration energy." [PSI:MS]
+synonym: "TOF" EXACT []
 is_a: MS:1000443 ! mass analyzer type
 
 [Term]
@@ -626,6 +647,7 @@ is_a: MS:1000012 ! resolution measurement method
 id: MS:1000086
 name: full width at half-maximum
 def: "A measure of resolution represented as width of the peak at half peak height." [PSI:MS]
+synonym: "FWHM" EXACT []
 is_a: MS:1000012 ! resolution measurement method
 
 [Term]
@@ -638,21 +660,29 @@ is_a: MS:1000012 ! resolution measurement method
 id: MS:1000088
 name: constant
 def: "OBSOLETE When resolution is constant with respect to m/z." [PSI:MS]
+comment: This child of the former purgatory term resolution type was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000089
 name: proportional
 def: "OBSOLETE When resolution is proportional with respect to m/z." [PSI:MS]
+comment: This child of the former purgatory term resolution type was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000090
 name: mass scan
 def: "OBSOLETE A variation of instrument where a selected mass is scanned." [PSI:MS]
+comment: This child of the former purgatory term Scan Function was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000091
 name: selected ion detection
 def: "OBSOLETE Please see Single Ion Monitoring." [PSI:MS]
+comment: This child of the former purgatory term Scan Function was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000092
@@ -676,7 +706,9 @@ is_a: MS:1000019 ! scan law
 id: MS:1000095
 name: linear
 def: "OBSOLETE The mass scan is done in linear mode." [PSI:MS]
+comment: This term was made obsolete because it was redundant with the Pato Ontology term linear (UO:0001199).
 is_a: MS:1000019 ! scan law
+is_obsolete: true
 
 [Term]
 id: MS:1000096
@@ -688,41 +720,58 @@ is_a: MS:1000019 ! scan law
 id: MS:1000097
 name: constant neutral mass loss
 def: "OBSOLETE A spectrum formed of all product ions that have been produced with a selected m/z decrement from any precursor ions. The spectrum shown correlates to the precursor ion spectrum. See also neutral loss spectrum." [PSI:MS]
+comment: This former purgatory term was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000098
 name: multiple ion monitoring
 def: "OBSOLETE Data acquired when monitoring the ion current of a few specific m/z values. Remap to MS:1000205 -Selected Ion Monitoring." [PSI:MS]
+comment: This former purgatory term was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000099
 name: multiple reaction monitoring
 def: "OBSOLETE This term is not recommended. See Selected Reaction Monitoring." [PSI:MS]
+comment: This term was made obsolete because it was merged with selected reaction monitoring (MS:1000206).
+synonym: "MRM" EXACT []
+is_obsolete: true
 
 [Term]
 id: MS:1000100
 name: precursor ion scan
 def: "OBSOLETE The specific scan function or process that will record a precursor ion spectrum." [PSI:MS]
+comment: This former purgatory term was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000101
 name: product ion scan
 def: "OBSOLETE The specific scan function or process that records product ion spectrum." [PSI:MS]
+comment: This former purgatory term was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000102
 name: single ion monitoring
 def: "OBSOLETE The operation of a mass spectrometer to monitor a single ion rather than scanning entire mass spectrum." [PSI:MS]
+comment: This term was made obsolete because it was replaced by single ion monitoring (MS:100205).
+is_obsolete: true
 
 [Term]
 id: MS:1000103
 name: single reaction monitoring
 def: "OBSOLETE This term is not recommended. See Selected Reaction Monitoring." [PSI:MS]
+comment: This term was made obsolete because it was replaced by selected reaction monitoring (MS:1000206).
+is_obsolete: true
 
 [Term]
 id: MS:1000104
 name: None ??
 def: "OBSOLETE None." [PSI:MS]
+comment: This term was made obsolete because .
+is_obsolete: true
 
 [Term]
 id: MS:1000105
@@ -740,6 +789,7 @@ is_a: MS:1000021 ! reflectron state
 id: MS:1000107
 name: channeltron
 def: "A horn-shaped (or cone-shaped) continuous dynode particle multiplier. The ion strikes the inner surface of the device and induces the production of secondary electrons that in turn impinge on the inner surfaces to produce more secondary electrons. This avalanche effect produces an increase in signal in the final measured current pulse." [PSI:MS]
+synonym: "Channeltron Detector" EXACT []
 is_a: MS:1000026 ! detector type
 
 [Term]
@@ -752,18 +802,21 @@ is_a: MS:1000346 ! conversion dynode
 id: MS:1000109
 name: conversion dynode photomultiplier
 def: "A detector in which ions strike a conversion dynode to produce electrons that in turn generate photons through a phosphorescent screen that are detected by a photomultiplier." [PSI:MS]
+synonym: "ion-to-photon detector" RELATED []
 is_a: MS:1000346 ! conversion dynode
 
 [Term]
 id: MS:1000110
 name: daly detector
 def: "Detector consisting of a conversion dynode, scintillator and photomultiplier. The metal knob at high potential emits secondary electrons when ions impinge on the surface. The secondary electrons are accelerated onto the scintillator that produces light that is then detected by the photomultiplier detector." [PSI:MS]
+synonym: "Daly" EXACT []
 is_a: MS:1000026 ! detector type
 
 [Term]
 id: MS:1000111
 name: electron multiplier tube
 def: "A device to amplify the current of a beam or packet of charged particles or photons by incidence upon the surface of an electrode to produce secondary electrons." [PSI:MS]
+synonym: "EMT" EXACT []
 is_a: MS:1000253 ! electron multiplier
 
 [Term]
@@ -782,6 +835,7 @@ is_a: MS:1000348 ! focal plane collector
 id: MS:1000114
 name: microchannel plate detector
 def: "A thin plate that contains a closely spaced array of channels that each act as a continuous dynode particle multiplier. A charged particle, fast neutral particle, or photon striking the plate causes a cascade of secondary electrons that ultimately exits the opposite side of the plate." [PSI:MS]
+synonym: "multichannel plate" EXACT []
 is_a: MS:1000345 ! array detector
 
 [Term]
@@ -794,12 +848,14 @@ is_a: MS:1000026 ! detector type
 id: MS:1000116
 name: photomultiplier
 def: "A detector for conversion of the ion/electron signal into photon(s) which are then amplified and detected." [PSI:MS]
+synonym: "PMT" EXACT []
 is_a: MS:1000026 ! detector type
 
 [Term]
 id: MS:1000117
 name: analog-digital converter
 def: "Analog-to-digital converter (abbreviated ADC, A/D or A to D) is an electronic integrated circuit (i/c) that converts continuous signals to discrete digital numbers." [PSI:MS]
+synonym: "ADC" EXACT []
 is_a: MS:1000027 ! detector acquisition mode
 
 [Term]
@@ -812,6 +868,7 @@ is_a: MS:1000027 ! detector acquisition mode
 id: MS:1000119
 name: time-digital converter
 def: "A device for converting a signal of sporadic pluses into a digital representation of their time indices." [PSI:MS]
+synonym: "TDC" EXACT []
 is_a: MS:1000027 ! detector acquisition mode
 
 [Term]
@@ -824,6 +881,7 @@ is_a: MS:1000027 ! detector acquisition mode
 id: MS:1000121
 name: SCIEX instrument model
 def: "The brand of instruments from the joint venture between Applied Biosystems and MDS Analytical Technologies (formerly MDS SCIEX). Previously branded as \"Applied Biosystems|MDS SCIEX\"." [PSI:MS]
+synonym: "Applied Biosystems|MDS SCIEX" RELATED []
 is_a: MS:1000031 ! instrument model
 
 [Term]
@@ -860,12 +918,15 @@ is_a: MS:1000031 ! instrument model
 id: MS:1000127
 name: centroid spectrum
 def: "Processing of profile data to produce spectra that contains discrete peaks of zero width. Often used to reduce the size of dataset." [PSI:MS]
+synonym: "Discrete Mass Spectrum" EXACT []
 is_a: MS:1000525 ! spectrum representation
 
 [Term]
 id: MS:1000128
 name: profile spectrum
 def: "A profile mass spectrum is created when data is recorded with ion current (counts per second) on one axis and mass/charge ratio on another axis." [PSI:MS]
+synonym: "continuous mass spectrum" EXACT []
+synonym: "Continuum Mass Spectrum" EXACT []
 is_a: MS:1000525 ! spectrum representation
 
 [Term]
@@ -894,36 +955,43 @@ name: percent of base peak
 def: "The magnitude of a peak or measurement element expressed in terms of the percentage of the magnitude of the base peak intensity." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000043 ! intensity unit
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000133
 name: collision-induced dissociation
 def: "The dissociation of an ion after collisional excitation. The term collisional-activated dissociation is not recommended." [PSI:MS]
+synonym: "CID" EXACT []
+synonym: "CAD" EXACT []
+synonym: "collisionally activated dissociation" EXACT []
 is_a: MS:1000044 ! dissociation method
 
 [Term]
 id: MS:1000134
 name: plasma desorption
 def: "The ionization of material in a solid sample by bombarding it with ionic or neutral atoms formed as a result of the fission of a suitable nuclide, typically 252Cf. Synonymous with fission fragment ionization." [PSI:MS]
+synonym: "PD" EXACT []
 is_a: MS:1000044 ! dissociation method
 
 [Term]
 id: MS:1000135
 name: post-source decay
 def: "A technique specific to reflectron time-of-flight mass spectrometers where product ions of metastable transitions or collision-induced dissociations generated in the drift tube prior to entering the reflectron are m/z separated to yield product ion spectra." [PSI:MS]
+synonym: "PSD" EXACT []
 is_a: MS:1000044 ! dissociation method
 
 [Term]
 id: MS:1000136
 name: surface-induced dissociation
 def: "Fragmentation that results from the collision of an ion with a surface." [PSI:MS]
+synonym: "SID" EXACT []
 is_a: MS:1000044 ! dissociation method
 
 [Term]
 id: MS:1000137
 name: electron volt
 def: "OBSOLETE A non-SI unit of energy (eV) defined as the energy acquired by a particle containing one unit of charge through a potential difference of one volt. An electron-volt is equal to 1.602 176 53(14) x 10^-19 J." [PSI:MS]
+comment: This term was made obsolete because it was redundant with the Unit Ontology term electron volt (UO:0000266).
+is_obsolete: true
 
 [Term]
 id: MS:1000138
@@ -932,7 +1000,6 @@ def: "Instrument setting, expressed in percent, for adjusting collisional energi
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000510 ! precursor activation attribute
 relationship: has_units UO:0000187 ! percent
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000139
@@ -1034,6 +1101,8 @@ is_a: MS:1000125 ! Thermo Finnigan instrument model
 id: MS:1000155
 name: ELEMENT2
 def: "OBSOLETE ThermoFinnigan ELEMENT2 MS." [PSI:MS]
+comment: This former purgatory term was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000156
@@ -1333,12 +1402,18 @@ is_a: MS:1000495 ! Applied Biosystems instrument model
 id: MS:1000205
 name: selected ion monitoring
 def: "The operation of a mass spectrometer in which the intensities of several specific m/z values are recorded rather than the entire mass spectrum." [PSI:MS]
+synonym: "MIM" RELATED []
+synonym: "Multiple Ion Monitoring" EXACT []
+synonym: "SIM" EXACT []
 is_a: MS:1000596 ! measurement method
 
 [Term]
 id: MS:1000206
 name: selected reaction monitoring
 def: "Data acquired from specific product ions corresponding to m/z selected precursor ions recorded via multiple stages of mass spectrometry. Selected reaction monitoring can be performed in time or in space." [PSI:MS]
+synonym: "MRM" RELATED []
+synonym: "Multiple Reaction Monitoring" RELATED []
+synonym: "SRM" EXACT []
 is_a: MS:1000596 ! measurement method
 
 [Term]
@@ -1346,29 +1421,34 @@ id: MS:1000207
 name: accurate mass
 def: "OBSOLETE An experimentally determined mass that is can be to determine a unique elemental formula. For ions less than 200 u, a measurement with 5 ppm accuracy is sufficient to determine the elemental composition." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
+comment: This child of the former purgatory term ion attribute was made obsolete.
 relationship: has_units UO:0000002 ! mass unit
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
+is_obsolete: true
 
 [Term]
 id: MS:1000208
 name: average mass
 def: "OBSOLETE The mass of an ion or molecule calculated using the average mass of each element weighted for its natural isotopic abundance." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
+comment: This child of the former purgatory term ion attribute was made obsolete.
 relationship: has_units UO:0000002 ! mass unit
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
+is_obsolete: true
 
 [Term]
 id: MS:1000209
 name: appearance energy
 def: "OBSOLETE The minimum energy that must be imparted to an atom or molecule to produce a specified ion. The term appearance potential is not recommended." [PSI:MS]
+synonym: "AE" EXACT []
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
+comment: This child of the former purgatory term ion attribute was made obsolete.
 relationship: has_units UO:0000266 ! electronvolt
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
+is_obsolete: true
 
 [Term]
 id: MS:1000210
 name: base peak
 def: "The peak in a mass spectrum that has the greatest intensity. This term may be applied to the spectra of pure substances or mixtures." [PSI:MS]
+synonym: "BP" EXACT []
 is_a: MS:1000231 ! peak
 
 [Term]
@@ -1376,63 +1456,79 @@ id: MS:1000211
 name: OBSOLETE charge number
 def: "OBSOLETE The total charge on an ion divided by the electron charge e. OBSOLETED 2009-10-27 since this was viewed as a duplication of 00041 charge state." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
+is_obsolete: true
 
 [Term]
 id: MS:1000212
 name: dalton
 def: "OBSOLETE A non-SI unit of mass (symbol Da) that is equal to the unified atomic mass unit: 1.660 538 86(28) x 10^-27 kg." [PSI:MS]
+comment: This term was made obsolete because it was redundant with the Unit Ontology term dalton (UO:0000221).
+is_obsolete: true
 
 [Term]
 id: MS:1000213
 name: electron affinity
 def: "OBSOLETE The electron affinity of M is the minimum energy required for the process M- ? M + e where M- and M are in their ground rotational, vibrational and electronic states and the electron has zero kinetic energy." [PSI:MS]
+comment: This child of the former purgatory term ion attribute was made obsolete.
+synonym: "EA" EXACT []
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
+is_obsolete: true
 
 [Term]
 id: MS:1000214
 name: electron energy obsolete
 def: "OBSOLETE The potential difference through which electrons are accelerated before they are used to bring about electron ionization." [PSI:MS]
+comment: This former purgatory term was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000215
 name: exact mass
 def: "OBSOLETE The calculated mass of an ion or molecule containing a single isotope of each atom." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
+comment: This child of the former purgatory term ion attribute was made obsolete.
 relationship: has_units UO:0000002 ! mass unit
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
+is_obsolete: true
 
 [Term]
 id: MS:1000216
 name: field-free region
 def: "A section of a mass spectrometer in which there are no electric or magnetic fields." [PSI:MS]
+synonym: "FFR" EXACT []
 is_a: MS:1000487 ! ion optics attribute
 
 [Term]
 id: MS:1000217
 name: ionization cross section
 def: "OBSOLETE A measure of the probability that a given ionization process will occur when an atom or molecule interacts with a photon, electron, atom or molecule." [PSI:MS]
+comment: This child of the former purgatory term ion reaction was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000218
 name: ionization efficiency
 def: "OBSOLETE The ratio of the number of ions formed to the number of electrons, molecules or photons used." [PSI:MS]
+comment: This term was made obsolete because it was replaced by ionization efficiency (MS:1000392).
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
+is_obsolete: true
 
 [Term]
 id: MS:1000219
 name: ionization energy
 def: "OBSOLETE The minimum energy required to remove an electron from an atom or molecule to produce a positive ion." [PSI:MS]
+synonym: "IE" EXACT []
+comment: This child of the former purgatory term ion attribute was made obsolete.
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 relationship: has_units UO:0000266 ! electronvolt
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
+is_obsolete: true
 
 [Term]
 id: MS:1000220
 name: isotope dilution mass spectrometry
 def: "OBSOLETE A quantitative mass spectrometry technique in which an isotopically enriched compound is used as an internal standard." [PSI:MS]
+comment: This child of the former purgatory term mass spectrometry was made obsolete.
+synonym: "IDMS" EXACT []
+is_obsolete: true
 
 [Term]
 id: MS:1000221
@@ -1445,15 +1541,17 @@ id: MS:1000222
 name: mass defect
 def: "OBSOLETE The difference between the monoisotopic and nominal mass of a molecule or atom." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
+comment: This child of the former purgatory term ion attribute was made obsolete.
 relationship: has_units UO:0000002 ! mass unit
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
+is_obsolete: true
 
 [Term]
 id: MS:1000223
 name: mass number
 def: "OBSOLETE The sum of the protons and neutrons in an atom, molecule or ion." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
+comment: This child of the former purgatory term ion attribute was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000224
@@ -1462,44 +1560,53 @@ def: "Mass of a molecule measured in unified atomic mass units (u or Da)." [http
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000861 ! molecular entity property
 relationship: has_units UO:0000002 ! mass unit
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000225
 name: monoisotopic mass
 def: "OBSOLETE The mass of an ion or molecule calculated using the mass of the most abundant isotope of each element." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
+comment: This child of the former purgatory term ion attribute was made obsolete.
 relationship: has_units UO:0000002 ! mass unit
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
+is_obsolete: true
 
 [Term]
 id: MS:1000226
 name: molecular beam mass spectrometry
 def: "OBSOLETE A mass spectrometry technique in which the sample is introduced into the mass spectrometer as a molecular beam." [PSI:MS]
+comment: This child of the former purgatory term mass spectrometer was made obsolete.
+synonym: "MBMS" EXACT []
+is_obsolete: true
 
 [Term]
 id: MS:1000227
 name: multiphoton ionization
 def: "Photoionization of an atom or molecule in which in two or more photons are absorbed." [PSI:MS]
+synonym: "MPI" EXACT []
 is_a: MS:1000008 ! ionization type
 
 [Term]
 id: MS:1000228
 name: nitrogen rule
 def: "OBSOLETE An organic molecule containing the elements C, H, O, S, P, or halogen has an odd nominal mass if it contains an odd number of nitrogen atoms." [PSI:MS]
+comment: This child of the former purgatory term ion reaction was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000229
 name: nominal mass
 def: "OBSOLETE The mass of an ion or molecule calculated using the mass of the most abundant isotope of each element rounded to the nearest integer value." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
+comment: This child of the former purgatory term ion attribute was made obsolete.
 relationship: has_units UO:0000002 ! mass unit
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
+is_obsolete: true
 
 [Term]
 id: MS:1000230
 name: odd-electron rule
 def: "OBSOLETE Odd-electron ions may dissociate to form either odd or even-electron ions, whereas even-electron ions generally form even-electron fragment ions." [PSI:MS]
+comment: This child of the former purgatory term ion reaction was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000231
@@ -1511,25 +1618,31 @@ relationship: part_of MS:1000442 ! spectrum
 id: MS:1000232
 name: peak intensity
 def: "OBSOLETE The height or area of a peak in a mass spectrum." [PSI:MS]
+comment: This term was made obsolete because it was replaced by base peak intensity (MS:1000505).
+is_obsolete: true
 
 [Term]
 id: MS:1000233
 name: proton affinity
 def: "OBSOLETE The proton affinity of a species M is defined as the negative of the enthalpy change for the reaction M + H+ ->[M+H]+, where all species are in their ground rotational, vibrational and electronic states." [PSI:MS]
+synonym: "PA" EXACT [PSI:MS]
+comment: This child of the former purgatory term ion attribute was made obsolete.
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
+is_obsolete: true
 
 [Term]
 id: MS:1000234
 name: mass resolving power
 def: "OBSOLETE In a mass spectrum, the observed mass divided by the difference between two masses that can be separated. The method by which delta m was obtained and the mass at which the measurement was made should be reported." [PSI:MS]
+comment: This term was made obsolete because it was replaced by mass resolving power (MS:1000800).
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
+is_obsolete: true
 
 [Term]
 id: MS:1000235
 name: total ion current chromatogram
 def: "Representation of the total ion current detected in each of a series of mass spectra versus time." [PSI:MS]
+synonym: "TIC chromatogram" EXACT []
 is_a: MS:1000810 ! ion current chromatogram
 
 [Term]
@@ -1538,294 +1651,387 @@ name: transmission
 def: "The ratio of the number of ions leaving a region of a mass spectrometer to the number entering that region." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000496 ! instrument attribute
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000237
 name: unified atomic mass unit
 def: "OBSOLETE A non-SI unit of mass (u) defined as one twelfth of ^12 C in its ground state and equal to 1.660 538 86(28) x 10^-27 kg." [PSI:MS]
+comment: This term was made obsolete because it was redundant with Unit Ontology dalton (UO:0000221).
+synonym: "u" EXACT []
+is_obsolete: true
 
 [Term]
 id: MS:1000238
 name: accelerator mass spectrometry
 def: "OBSOLETE A mass spectrometry technique in which atoms extracted from a sample are ionized, accelerated to MeV energies and separated according to their momentum, charge and energy." [PSI:MS]
+comment: This child of the former purgatory term mass spectrometer was made obsolete.
+synonym: "AMS" EXACT []
+is_obsolete: true
 
 [Term]
 id: MS:1000239
 name: atmospheric pressure matrix-assisted laser desorption ionization
 def: "Matrix-assisted laser desorption ionization in which the sample target is at atmospheric pressure and the ions formed by the pulsed laser are sampled through a small aperture into the mass spectrometer." [PSI:MS]
+synonym: "AP MALDI" EXACT []
 is_a: MS:1000240 ! atmospheric pressure ionization
 
 [Term]
 id: MS:1000240
 name: atmospheric pressure ionization
 def: "Any ionization process in which ions are formed in the gas phase at atmospheric pressure." [PSI:MS]
+synonym: "API" EXACT []
 is_a: MS:1000008 ! ionization type
 
 [Term]
 id: MS:1000241
 name: Atmostpheric Pressure Photoionization
 def: "OBSOLETE Atmospheric pressure chemical ionization in which the reactant ions are generated by photo-ionization." [PSI:MS]
+comment: This term was made obsolete because it was replaced by atmospheric pressure photoionization (MS:1000382).
+synonym: "APPI" EXACT []
+is_obsolete: true
 
 [Term]
 id: MS:1000242
 name: blackbody infrared radiative dissociation
 def: "A special case of infrared multiphoton dissociation wherein excitation of the reactant ion is caused by absorption of infrared photons radiating from heated blackbody surroundings, which are usually the walls of a vacuum chamber. See also infrared multiphoton dissociation." [PSI:MS]
+synonym: "BIRD" EXACT []
 is_a: MS:1000044 ! dissociation method
 
 [Term]
 id: MS:1000243
 name: charge-remote fragmentation
 def: "OBSOLETE A fragmentation of an even-electron ion in which the cleaved bond is not adjacent to the apparent charge site." [PSI:MS]
+comment: This child of the former purgatory term ion reaction was made obsolete.
+synonym: "CRF" EXACT []
+is_obsolete: true
 
 [Term]
 id: MS:1000244
 name: consecutive reaction monitoring
 def: "OBSOLETE MSn experiment with three or more stages of m/z separation and in which a particular multi-step reaction path is monitored." [PSI:MS]
+comment: This former purgatory term was made obsolete.
+synonym: "CRM" EXACT []
+is_obsolete: true
 
 [Term]
 id: MS:1000245
 name: charge stripping
 def: "The reaction of a positive ion with an atom or molecule that results in the removal of one or more electrons from the ion." [PSI:MS]
+synonym: "CS" EXACT []
 is_a: MS:1000510 ! precursor activation attribute
 
 [Term]
 id: MS:1000246
 name: delayed extraction
 def: "The application of the accelerating voltage pulse after a time delay in desorption ionization from a surface. The extraction delay can produce energy focusing in a time-of-flight mass spectrometer." [PSI:MS]
+synonym: "DE" EXACT []
 is_a: MS:1000597 ! ion optics type
 
 [Term]
 id: MS:1000247
 name: desorption ionization
 def: "The formation of ions from a solid or liquid material after the rapid vaporization of that sample." [PSI:MS]
+synonym: "DI" EXACT []
 is_a: MS:1000008 ! ionization type
 
 [Term]
 id: MS:1000248
 name: direct insertion probe
 def: "A device for introducing a solid or liquid sample into a mass spectrometer ion source for desorption ionization." [PSI:MS]
+synonym: "DIP" EXACT []
 is_a: MS:1000007 ! inlet type
 
 [Term]
 id: MS:1000249
 name: direct liquid introduction
 def: "The delivery of a liquid sample into a mass spectrometer for spray or desorption ionization." [PSI:MS]
+synonym: "DLI" EXACT []
 is_a: MS:1000007 ! inlet type
 
 [Term]
 id: MS:1000250
 name: electron capture dissociation
 def: "A process in which a multiply protonated molecules interacts with a low energy electrons. Capture of the electron leads the liberation of energy and a reduction in charge state of the ion with the production of the (M + nH) (n-1)+ odd electron ion, which readily fragments." [PSI:MS]
+synonym: "ECD" EXACT []
 is_a: MS:1000044 ! dissociation method
 
 [Term]
 id: MS:1000251
 name: even-electron ion
 def: "OBSOLETE An ion containing no unpaired electrons in its ground electronic state, e.g. CH3+ in its ground state." [PSI:MS]
+comment: This child of the former purgatory term ion chemical type was made obsolete.
+synonym: "EE" EXACT []
+is_obsolete: true
 
 [Term]
 id: MS:1000252
 name: electron-induced excitation in organics
 def: "OBSOLETE The reaction of an ion with an electron in which the translational energy of the collision is converted into internal energy of the ion." [PSI:MS]
+comment: This child of the former purgatory term ion reaction was made obsolete.
+synonym: "EIEIO" EXACT []
+is_obsolete: true
 
 [Term]
 id: MS:1000253
 name: electron multiplier
 def: "A device to amplify the current of a beam or packet of charged particles or photons by incidence upon the surface of an electrode to produce secondary electrons. The secondary electrons are then accelerated to other electrodes or parts of a continuous electrode to produce further secondary electrons." [PSI:MS]
+synonym: "EM" EXACT []
 is_a: MS:1000026 ! detector type
 
 [Term]
 id: MS:1000254
 name: electrostatic energy analyzer
 def: "A device consisting of conducting parallel plates, concentric cylinders or concentric spheres that separates charged particles according to their kinetic energy by means of an electric field that is constant in time." [PSI:MS]
+synonym: "ESA" EXACT []
 is_a: MS:1000443 ! mass analyzer type
 
 [Term]
 id: MS:1000255
 name: flowing afterglow
 def: "An ion source immersed in a flow of helium or other inert buffer gas that carries the ions through a meter-long reactor at pressures around 100 Pa." [PSI:MS]
+synonym: "FA" EXACT []
 is_a: MS:1000008 ! ionization type
 
 [Term]
 id: MS:1000256
 name: high-field asymmetric waveform ion mobility spectrometry
 def: "OBSOLETE The separation of ions between two concentric cylindrical electrodes due to application of a high voltage asymmetric waveform whereby ions migrate towards one of the two electrodes depending on the ratio of the high- to low-field mobility of the ion." [PSI:MS]
+comment: This child of the former purgatory term mass spectrometer was made obsolete.
+synonym: "FAIMS" EXACT []
+is_obsolete: true
 
 [Term]
 id: MS:1000257
 name: field desorption
 def: "The formation of gas-phase ions from a material deposited on a solid surface in the presence of a high electric field. Because this process may encompass ionization by field ionization or other mechanisms, it is not recommended as a synonym for field desorption ionization." [PSI:MS]
+synonym: "FD" EXACT []
 is_a: MS:1000247 ! desorption ionization
 
 [Term]
 id: MS:1000258
 name: field ionization
 def: "The removal of electrons from any species by interaction with a high electric field." [PSI:MS]
+synonym: "FI" EXACT []
 is_a: MS:1000008 ! ionization type
 
 [Term]
 id: MS:1000259
 name: glow discharge ionization
 def: "The formation of ions in the gas phase and from solid samples at the cathode by application of a voltage to a low pressure gas." [PSI:MS]
+synonym: "GD-MS" EXACT []
 is_a: MS:1000008 ! ionization type
 
 [Term]
 id: MS:1000260
 name: ion kinetic energy spectrometry
 def: "OBSOLETE A method of analysis in which a beam of ions is separated according to the ratio of its translational energy to charge." [PSI:MS]
+comment: This child of the former purgatory term mass spectrometer was made obsolete.
+synonym: "IKES" EXACT []
+is_obsolete: true
 
 [Term]
 id: MS:1000261
 name: ion mobility spectrometry
 def: "OBSOLETE The separation of ions according to their velocity through a buffer gas under the influence of an electric field." [PSI:MS]
+comment: This child of the former purgatory term mass spectrometer was made obsolete.
+synonym: "IMS" EXACT []
+is_obsolete: true
 
 [Term]
 id: MS:1000262
 name: infrared multiphoton dissociation
 def: "Multiphoton ionization where the reactant ion dissociates as a result of the absorption of multiple infrared photons." [PSI:MS]
+synonym: "IRMPD" EXACT []
 is_a: MS:1000044 ! dissociation method
 
 [Term]
 id: MS:1000263
 name: isotope ratio mass spectrometry
 def: "OBSOLETE The measurement of the relative quantity of the different isotopes of an element in a material with a mass spectrometer." [PSI:MS]
+comment: This child of the former purgatory term mass spectrometry was made obsolete.
+synonym: "IRMS" EXACT []
+is_obsolete: true
 
 [Term]
 id: MS:1000264
 name: ion trap
 def: "A device for spatially confining ions using electric and magnetic fields alone or in combination." [PSI:MS]
+synonym: "IT" EXACT []
 is_a: MS:1000443 ! mass analyzer type
 
 [Term]
 id: MS:1000265
 name: kinetic energy release distribution
 def: "OBSOLETE Distribution of values of translational kinetic energy release for an ensemble of metastable ions undergoing a specific dissociation reaction." [PSI:MS]
+comment: This child of the former purgatory term ion reaction was made obsolete.
+synonym: "KERD" EXACT []
+is_obsolete: true
 
 [Term]
 id: MS:1000266
 name: Laser Desorption
 def: "OBSOLETE The formation of ions through the interaction of a laser with a material or with gas-phase ions or molecules." [PSI:MS]
+comment: This term was made obsolete because it was replaced by laser desorption ionization (MS:1000393).
+synonym: "Laser Ionization MERGE" EXACT []
+synonym: "LD" EXACT []
+is_obsolete: true
+replaced_by: MS:1000393
 
 [Term]
 id: MS:1000267
 name: mass analyzed ion kinetic energy spectrometry
 def: "OBSOLETE Spectra that are obtained from a sector mass spectrometer that incorporates at least one magnetic sector plus one electric sector in reverse geometry. The accelerating voltage, V, and the magnetic sector field, B, are set at fixed values to select the precursor ions, which are then allowed to dissociate or to react in a field free region between the two sectors. The kinetic energy product ions of m/z selected precursor ions is analyzed by scanning the electric sector field, E. The width of the product ion spectrum peaks is related to the kinetic energy release distribution (KERD) for the dissociation process." [PSI:MS]
+comment: This child of the former purgatory term mass spectrometer was made obsolete.
+synonym: "MIKES" EXACT []
+is_obsolete: true
 
 [Term]
 id: MS:1000268
 name: mass spectrometry
 def: "OBSOLETE The branch of science that deals with all aspects of mass spectrometers and the results obtained with these instruments." [PSI:MS]
+comment: This former purgatory term was made obsolete.
+synonym: "MS" EXACT []
+is_obsolete: true
 
 [Term]
 id: MS:1000269
 name: mass spectrometry/mass spectrometry
 def: "OBSOLETE The acquisition, study and spectra of the electrically charged products or precursors of a m/z selected ion or ions." [PSI:MS]
+comment: This child of the former purgatory term mass spectrometer was made obsolete.
+synonym: "MS/MS" EXACT []
+is_obsolete: true
 
 [Term]
 id: MS:1000270
 name: multiple stage mass spectrometry
 def: "OBSOLETE Multiple stages of precursor ion m/z selection followed by product ion detection for successive progeny ions." [PSI:MS]
+comment: This child of the former purgatory term m/z Separation Method was made obsolete.
+synonym: "MSn" EXACT []
+is_obsolete: true
 
 [Term]
 id: MS:1000271
 name: Negative Ion chemical ionization
 def: "Chemical ionization that results in the formation of negative ions." [PSI:MS]
+synonym: "NICI" EXACT []
 is_a: MS:1000008 ! ionization type
 
 [Term]
 id: MS:1000272
 name: neutralization reionization mass spectrometry
 def: "With this technique, m/z selected ions form neutrals by charge transfer to a collision gas or by dissociation. The neutrals are separated from the remaining ions and ionized in collisions with a second gas. This method is used to investigate reaction intermediates and other unstable species." [PSI:MS]
+synonym: "NRMS" EXACT []
 is_a: MS:1000008 ! ionization type
 
 [Term]
 id: MS:1000273
 name: photoionization
 def: "The ionization of an atom or molecule by a photon, written M + h? ? M^+ + e. The term photon impact is not recommended." [PSI:MS]
+synonym: "PI" EXACT []
 is_a: MS:1000008 ! ionization type
 
 [Term]
 id: MS:1000274
 name: pyrolysis mass spectrometry
 def: "A mass spectrometry technique in which the sample is heated to the point of decomposition and the gaseous decomposition products are introduced into the ion source." [PSI:MS]
+synonym: "PyMS" EXACT []
 is_a: MS:1000008 ! ionization type
 
 [Term]
 id: MS:1000275
 name: collision quadrupole
 def: "A transmission quadrupole to which an oscillating potential is applied so as to focus a beam of ions through a collision gas with no m/z separation." [PSI:MS]
+synonym: "q" EXACT []
 is_a: MS:1000597 ! ion optics type
 
 [Term]
 id: MS:1000276
 name: resonance enhanced multiphoton ionization
 def: "Multiphoton ionization in which the ionization cross section is significantly enhanced because the energy of the incident photons is resonant with an intermediate excited state of the neutral species." [PSI:MS]
+synonym: "REMPI" EXACT []
 is_a: MS:1000008 ! ionization type
 
 [Term]
 id: MS:1000277
 name: residual gas analyzer
 def: "OBSOLETE A mass spectrometer used to measure the composition and pressure of gasses in an evacuated chamber." [PSI:MS]
+comment: This child of the former purgatory term mass spectrometer was made obsolete.
+synonym: "RGA" EXACT []
+is_obsolete: true
 
 [Term]
 id: MS:1000278
 name: surface enhanced laser desorption ionization
 def: "The formation of ionized species in the gas phase from analytes deposited on a particular surface substrate which is irradiated with a laser beam of which wavelength is absorbed by the surface. See also desorption/ionization on silicon and laser desorption/ionization." [PSI:MS]
+synonym: "SELDI" EXACT []
 is_a: MS:1000406 ! surface ionization
 
 [Term]
 id: MS:1000279
 name: surface enhanced neat desorption
 def: "Matrix-assisted laser desorption ionization in which the matrix is covalently linked to the target surface." [PSI:MS]
+synonym: "SEND" EXACT []
 is_a: MS:1000406 ! surface ionization
 
 [Term]
 id: MS:1000280
 name: suface ionization
 def: "OBSOLETE The ionization of a neutral species when it interacts with a solid surface with an appropriate work function and temperature." [PSI:MS]
+comment: This term was made obsolete because it was replaced by surface ionization (MS:1000406).
+synonym: "SI" EXACT []
+is_obsolete: true
 
 [Term]
 id: MS:1000281
 name: selected ion flow tube
 def: "A device in which m/z selected ions are entrained in an inert carrier gas and undergo ion-molecule reactions." [PSI:MS]
+synonym: "SIFT" EXACT []
 is_a: MS:1000597 ! ion optics type
 
 [Term]
 id: MS:1000282
 name: sustained off-resonance irradiation
 def: "A technique associated with Fourier transform ion cyclotron resonance (FT-ICR) mass spectrometry to carry out ion/neutral reactions such as low-energy collision-induced dissociation. A radio-frequency electric field of slightly off-resonance to the cyclotron frequency of the reactant ion cyclically accelerates and decelerates the reactant ion that is confined in the Penning ion trap. The ion's orbit does not exceed the dimensions of ion trap while the ion undergoes an ion/neutral species process that produces a high average translational energy for an extended time." [PSI:MS]
+synonym: "SORI" EXACT []
 is_a: MS:1000044 ! dissociation method
 
 [Term]
 id: MS:1000283
 name: Spark Source Mass Spectrometry
 def: "OBSOLETE Mass spectrometry using spark ionization." [PSI:MS]
+comment: This term was made obsolete because it was replaced by spark ionization (MS:1000404).
+synonym: "SSMS" EXACT []
+is_obsolete: true
 
 [Term]
 id: MS:1000284
 name: stored waveform inverse fourier transform
 def: "A technique to create excitation waveforms for ions in FT-ICR mass spectrometer or Paul ion trap. An excitation waveform in the time-domain is generated by taking the inverse Fourier transform of an appropriate frequency-domain programmed excitation spectrum, in which the resonance frequencies of ions to be excited are included. This technique may be used for selection of precursor ions in MS2 experiments." [PSI:MS]
+synonym: "SWIFT" EXACT []
 is_a: MS:1000443 ! mass analyzer type
 
 [Term]
 id: MS:1000285
 name: total ion current
 def: "The sum of all the separate ion currents carried by the ions of different m/z contributing to a complete mass spectrum or in a specified m/z range of a mass spectrum." [PSI:MS]
+synonym: "TIC" EXACT []
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1003058 ! spectrum property
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000286
 name: time lag focusing
 def: "Energy focusing in a time-of-flight mass spectrometer that is accomplished by introducing a time delay between the formation of the ions and the application of the accelerating voltage pulse." [PSI:MS]
+synonym: "TLF" EXACT []
 is_a: MS:1000597 ! ion optics type
 
 [Term]
 id: MS:1000287
 name: time-of-flight mass spectrometer
 def: "OBSOLETE An instrument that separates ions by m/z in a field-free region after acceleration to a fixed kinetic energy." [PSI:MS]
+comment: This child of the former purgatory term mass spectrometer was made obsolete.
+synonym: "TOF-MS" EXACT []
+is_obsolete: true
 
 [Term]
 id: MS:1000288
@@ -1837,11 +2043,15 @@ is_a: MS:1000443 ! mass analyzer type
 id: MS:1000289
 name: double-focusing mass spectrometer
 def: "OBSOLETE A mass spectrometer that uses a magnetic sector for m/z focusing and an electric sector for energy focusing of an ion beam." [PSI:MS]
+comment: This child of the former purgatory term mass spectrometer was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000290
 name: hybrid mass spectrometer
 def: "OBSOLETE A mass spectrometer that combines m/z analyzers of different types to perform tandem mass spectrometry." [PSI:MS]
+comment: This child of the former purgatory term mass spectrometer was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000291
@@ -1853,11 +2063,15 @@ is_a: MS:1000264 ! ion trap
 id: MS:1000292
 name: mass spectrograph obsolete
 def: "OBSOLETE An instrument that separates a beam of ions according to their mass-to-charge ratio in which the ions are directed onto a focal plane detector such as a photographic plate." [PSI:MS]
+comment: This former purgatory term was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000293
 name: mass spectrometer
 def: "OBSOLETE An instrument that measures the mass-to-charge ratio and relative abundances of ions." [PSI:MS]
+comment: This former purgatory term was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000294
@@ -1870,26 +2084,37 @@ is_a: MS:1000559 ! spectrum type
 id: MS:1000295
 name: mattauch-herzog geometry
 def: "OBSOLETE An arrangement for a double-focusing mass spectrometer in which a deflection of ?/(4 ?(2)) radians in a radial electric field is followed by a magnetic deflection of ?/2 radians." [PSI:MS]
+comment: This former purgatory term was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000296
 name: nier-johnson geometry
 def: "OBSOLETE An arrangement for a double-focusing mass spectrometer in which a deflection of ?/2 radians in a radial electric field analyzer is followed by a magnetic deflection of ?/3 radians." [PSI:MS]
+comment: This former purgatory term was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000297
 name: paul ion trap
 def: "OBSOLETE A device that permits the trapping of ions by means of an alternating current voltage. The ejection of ions with a m/z less than a prescribed value and retention of those with higher mass depends on the application of radio frequency voltages between a ring electrode and two end-cap electrodes to confine the ions in a circular path. The choice of these voltages determines the m/z below which ions are ejected." [PSI:MS]
+comment: This term was made obsolete because it is redundant to quadrupole ion trap.
+synonym: "quadrupole ion trap" RELATED []
+is_obsolete: true
 
 [Term]
 id: MS:1000298
 name: prolate traochoidal mass spectrometer
 def: "OBSOLETE A mass spectrometer in which the ions of different m/z are separated by means of crossed electric and magnetic fields in such a way that the selected ions follow a prolate trochoidal path." [PSI:MS]
+comment: This child of the former purgatory term mass spectrometer was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000299
 name: quistor
 def: "OBSOLETE An abbreviation of quadrupole ion storage trap. This term is synonymous with Paul Ion Trap. If so then add a synonym to paul and obsolete this term." [PSI:MS]
+comment: This former purgatory term was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000300
@@ -1901,16 +2126,22 @@ is_a: MS:1000597 ! ion optics type
 id: MS:1000301
 name: sector mass spectrometer
 def: "OBSOLETE A mass spectrometer consisting of one or more magnetic sectors for m/z selection in a beam of ions. Such instruments may also have one or more electric sectors for energy selection." [PSI:MS]
+comment: This child of the former purgatory term mass spectrometer was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000302
 name: tandem mass spectrometer
 def: "OBSOLETE A mass spectrometer designed for mass spectrometry/mass spectrometry." [PSI:MS]
+comment: This child of the former purgatory term mass spectrometer was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000303
 name: transmission quadrupole mass spectrometer
 def: "OBSOLETE A mass spectrometer that consists of four parallel rods whose centers form the corners of a square and whose opposing poles are connected. The voltage applied to the rods is a superposition of a static potential and a sinusoidal radio frequency potential. The motion of an ion in the x and y dimensions is described by the Matthieu equation whose solutions show that ions in a particular m/z range can be transmitted along the z axis." [PSI:MS]
+comment: This child of the former purgatory term mass spectrometer was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000304
@@ -1919,17 +2150,20 @@ def: "The electrical potential used to impart kinetic energy to ions in a mass s
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000487 ! ion optics attribute
 relationship: has_units UO:0000218 ! volt
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000305
 name: cyclotron motion
 def: "OBSOLETE The circular motion of a charged particle moving at velocity v in a magnetic field B that results from the force qvB." [PSI:MS]
+comment: This child of the former purgatory term m/z Separation Method was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000306
 name: dynamic mass spectrometry
 def: "OBSOLETE A mass spectrometer in which m/z separation using one or more electric fields that vary with time." [PSI:MS]
+comment: This child of the former purgatory term mass spectrometer was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000307
@@ -1944,7 +2178,6 @@ def: "The magnitude of the force per unit charge at a given point in space." [PS
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000487 ! ion optics attribute
 relationship: has_units UO:0000268 ! volt per meter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000309
@@ -1968,36 +2201,50 @@ is_a: MS:1000597 ! ion optics type
 id: MS:1000312
 name: mass limit
 def: "OBSOLETE The m/z value above which ions cannot be detected in a mass spectrometer." [PSI:MS]
+comment: This former purgatory term was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000313
 name: scan m/z range?
 def: "OBSOLETE The limit of m/z over which a mass spectrometer can detect ions." [PSI:MS]
+comment: This former purgatory term was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000314
 name: mass selective axial ejection
 def: "OBSOLETE The use of mass selective instability to eject ions of selected m/z values from an ion trap." [PSI:MS]
+comment: This child of the former purgatory term m/z Separation Method was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000315
 name: mass selective instability
 def: "OBSOLETE A method for selective ejection of ions according to their m/z value in an ion trap." [PSI:MS]
+comment: This child of the former purgatory term m/z Separation Method was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000316
 name: mathieu stability diagram
 def: "OBSOLETE A graphical representation expressed in terms of reduced coordinates that describes charged particle motion in a quadrupole mass filter or quadrupole ion trap mass spectrometer." [PSI:MS]
+comment: This child of the former purgatory term m/z Separation Method was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000317
 name: orthogonal extraction
 def: "OBSOLETE The pulsed acceleration of ions perpendicular to their direction of travel into a time-of-flight mass spectrometer. Ions may be extracted from a directional ion source, drift tube or m/z separation stage." [PSI:MS]
+comment: This child of the former purgatory term m/z Separation Method was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000318
 name: resonance ion ejection
 def: "OBSOLETE A mode of ion ejection in a quadrupole ion trap that relies on a auxiliary radio frequency voltage that is applied to the end-cap electrodes. The voltage is tuned to the secular frequency of a particular ion to eject it." [PSI:MS]
+comment: This child of the former purgatory term m/z Separation Method was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000319
@@ -2015,6 +2262,8 @@ is_a: MS:1000597 ! ion optics type
 id: MS:1000321
 name: 2E Mass Spectrum
 def: "OBSOLETE A mass spectrum obtained by setting the electric sector field E to twice the value required to transmit the main ion-beam thereby allowing ions with a kinetic energy-to-charge ratio twice that of the main ion-beam to be transmitted. Product ions resulting from partial charge transfer reactions such as m^2+ + N ? m^+ + N^+ that occur in a collision cell (containing a gas, N) located in a field-free region preceding a magnetic and electric sector combination are detected. When the magnetic sector field B is scanned, a mass spectrum of singly charged product ions of doubly charged precursor ions is obtained." [PSI:MS]
+comment: This child of the former purgatory term m/z Separation Method was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000322
@@ -2026,28 +2275,39 @@ is_a: MS:1000294 ! mass spectrum
 id: MS:1000323
 name: constant neutral loss scan
 def: "OBSOLETE Spectrum of all precursor ions that undergo a selected m/z decrement." [PSI:MS]
+comment: This former purgatory term was made obsolete.
+synonym: "constant neutral mass loss scan" RELATED []
+synonym: "fixed neutral fragment scan" RELATED []
+is_obsolete: true
 
 [Term]
 id: MS:1000324
 name: constant neutral gain scan
 def: "OBSOLETE Spectrum of all precursor ions that undergo a selected m/z increment." [PSI:MS]
+comment: This former purgatory term was made obsolete.
+synonym: "Constant Neutral Mass Gain Scan" EXACT []
+is_obsolete: true
 
 [Term]
 id: MS:1000325
 name: constant neutral gain spectrum
 def: "A spectrum formed of all product ions that have been produced by gain of a pre-selected neutral mass following the reaction with and addition of the gas in a collision cell." [PSI:MS]
+synonym: "constant neutral mass gain spectrum" EXACT []
 is_a: MS:1000294 ! mass spectrum
 
 [Term]
 id: MS:1000326
 name: constant neutral loss spectrum
 def: "A spectrum formed of all product ions that have been produced with a selected m/z decrement from any precursor ions. The spectrum shown correlates to the precursor ion spectrum. See also neutral loss spectrum." [PSI:MS]
+synonym: "constant neutral mass loss spectrum" EXACT []
 is_a: MS:1000294 ! mass spectrum
 
 [Term]
 id: MS:1000327
 name: consecutive reaction monitoring
 def: "OBSOLETE A type of MS2 experiments with three or more stages of m/z separation and in which a particular multi-step reaction path is monitored." [PSI:MS]
+comment: This term was made obsolete because it was replaced by consecutive reaction monitoring (MS:1000244).
+is_obsolete: true
 
 [Term]
 id: MS:1000328
@@ -2059,36 +2319,50 @@ is_a: MS:1000294 ! mass spectrum
 id: MS:1000329
 name: linked scan
 def: "OBSOLETE A scan in an instrument with two or more m/z analysers or in a sector mass spectrometer that incorporates at least one magnetic sector and one electric sector. Two or more of the analyzers are scanned simultaneously so as to preserve a predetermined relationship between scan parameters to produce a product ion, precursor ion or constant neutral loss spectrum." [PSI:MS]
+comment: This former purgatory term was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000330
 name: linked scan at constant b/e
 def: "OBSOLETE A linked scan at constant B/E may be performed on a sector mass spectrometer that incorporates at least one magnetic sector plus one electric sector. The magnetic field B and the electric field E are scanned simultaneously while the accelerating voltage V is held constant, so as to maintain the ratio of the two fields constant. This linked scan may record a product ion spectrum of dissociation or other reactions occurring in a field free region preceding the two sectors." [PSI:MS]
+comment: This child of the former purgatory term linked scan was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000331
 name: Linked Scan at Constant E2/V
 def: "OBSOLETE A linked scan performed on a sector instrument that incorporates at least one electric sector plus one magnetic sector. The electric sector field, E, and the accelerating voltage, V, are scanned simultaneously, so as to maintain the ratio E2/V at a constant value. This linked scan recordss a product ion spectrum of dissociation or other reactions occurring in a field free region (FFR) preceding the two sectors." [PSI:MS]
+comment: This child of the former purgatory term linked scan was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000332
 name: Linked Scan at Constant B2/E
 def: "OBSOLETE A linked scan performed on a sector mass spectrometer that incorporates at least one electric sector plus one magnetic sector in either order. The accelerating voltage is fixed and the magnetic field, B, and the electric field, E, are scanned simultaneously so as to maintain the ratio B2/E at a constant value. This linked scan records a precursor ion spectrum of dissociation or other reactions occurring in the field free region preceding the two sectors. The term B2/E linked scan is not recommended." [PSI:MS]
+comment: This child of the former purgatory term linked scan was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000333
 name: Linked Scan at Constant B[1-(E/E0)]^1/2 / E
 def: "OBSOLETE A linked scan performed on a sector instrument that incorporates at least one electric sector plus one magnetic sector placed in either order. The accelerating voltage is fixed while scanning the magnetic field, B, and electric field, E, simultaneously, so as to maintain the quantity B[1-(E/E0)]1/2/E at a constant value. This linked scan records a constant neutral mass loss (or gain) spectrum of dissociation or other reactions occurring in a field free region preceding the two sectors. E0 is the electric field required to transmit the singly charged analog of the desired neutral fragment. The term B[1-(E/E0)]1/2/E linked scan." [PSI:MS]
+comment: This child of the former purgatory term linked scan was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000334
 name: MS/MS in Time
 def: "OBSOLETE A tandem mass spectrometry method in which product ion spectra are recorded in a single m/z analyzer (such as a Paul Ion Trap or FTMS) in discreet steps over time. Ions in a specific m/z range are selected, dissociated, and the product ions analyzed sequentially in time." [PSI:MS]
+comment: This child of the former purgatory term m/z Separation Method was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000335
 name: MS/MS in Space
 def: "OBSOLETE A tandem mass spectrometry method in which product ion spectra are recorded in m/z analyzers separated in space. Specific m/z separation functions are designed such that in one section of the instrument ions are selected, dissociated in an intermediate region, and the product ions are then transmitted to another analyser for m/z separation and data acquisition." [PSI:MS]
+comment: This child of the former purgatory term m/z Separation Method was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000336
@@ -2096,27 +2370,36 @@ name: neutral loss
 def: "The loss of an uncharged species during a rearrangement process. The value slot holds the molecular formula in Hill notation of the neutral loss molecule, see PMID: 21182243. This term must be used in conjunction with a child of the term MS:1002307 (fragmentation ion type)." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001055 ! modification parameters
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000337
 name: nth generation product ion
 def: "OBSOLETE Serial product ions from dissociation of selected precursor ions where n refers to the number of stages of dissociation. The term granddaughter ion is deprecated." [PSI:MS]
+comment: This child of the former purgatory term product ion was made obsolete.
+synonym: "granddaughter ion" RELATED []
+is_obsolete: true
 
 [Term]
 id: MS:1000338
 name: nth generation product ion scan
 def: "OBSOLETE The specific scan functions or processes that record the appropriate generation of product ion or ions of any m/z selected precursor ions." [PSI:MS]
+comment: This former purgatory term was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000339
 name: nth generation product ion spectrum
 def: "OBSOLETE The mass spectrum recorded from any mass spectrometer in which the appropriate scan function can be set to record the appropriate generation product ion or ions of m/z selected precursor ions." [PSI:MS]
+comment: This term was made obsolete because it was merged with MSn spectrum (MS:1000580).
+is_obsolete: true
 
 [Term]
 id: MS:1000340
 name: precursor ion
 def: "OBSOLETE An ion that reacts to form particular product ions. The reaction can be unimolecular dissociation, ion/molecule reaction, isomerization, or change in charge state. The term parent ion is deprecated." [PSI:MS]
+comment: This child of the former purgatory term ion role was made obsolete.
+synonym: "parent ion" RELATED []
+is_obsolete: true
 
 [Term]
 id: MS:1000341
@@ -2128,17 +2411,25 @@ is_a: MS:1000294 ! mass spectrum
 id: MS:1000342
 name: product ion
 def: "OBSOLETE An ion formed as the product of a reaction involving a particular precursor ion. The reaction can be unimolecular dissociation to form fragment ions, an ion/molecule reaction, or simply involve a change in the number of charges. The term fragment ion is deprecated. The term daughter ion is deprecated." [PSI:MS]
+comment: This child of the former purgatory term ion role was made obsolete.
+synonym: "daughter ion" RELATED []
+is_obsolete: true
 
 [Term]
 id: MS:1000343
 name: product ion spectrum
 def: "OBSOLETE A mass spectrum recorded from any spectrometer in which the appropriate m/z separation scan function is set to record the product ion or ions of selected precursor ions." [PSI:MS]
+comment: This term was made obsolete because it was merged with MSn spectrum (MS:1000580).
 is_a: MS:1000294 ! mass spectrum
+is_obsolete: true
 
 [Term]
 id: MS:1000344
 name: progeny ion
 def: "OBSOLETE A charged product of a series of consecutive reactions that includes product ions, 1st generation product ions, 2nd generation product ions, etc. Given the sequential fragmentation scheme: M1+ -> M2+ -> M3+ -> M4+ -> M5+. M4+ is the precursor ion of M5+, a 1st generation product ion of M3+, a 2nd generation product ion of M2+ and a 3rd generation product ion of M1+." [PSI:MS]
+comment: This child of the former purgatory term ion chemical type was made obsolete.
+synonym: "Progeny Fragment Ion" EXACT []
+is_obsolete: true
 
 [Term]
 id: MS:1000345
@@ -2186,6 +2477,8 @@ is_a: MS:1000026 ! detector type
 id: MS:1000352
 name: secondary electron
 def: "OBSOLETE Electrons that are ejected from a sample surface as a result of bombardment by a primary beam of atoms, ions or photons. WAS IN DETECTOR TYPE. Where should it go." [PSI:MS]
+comment: This former purgatory term was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000353
@@ -2197,131 +2490,183 @@ is_a: MS:1003055 ! adduct
 id: MS:1000354
 name: aromatic ion
 def: "OBSOLETE A planar cyclic ion that obeys the Hueckel (4n + 2) rule where n is a positive integer representing the number of conjugated Pi electrons. Charge delocalization leads to greater stability compared to a hypothetical localized structure." [PSI:MS]
+comment: This child of the former purgatory term ion chemical type was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000355
 name: analog ion
 def: "OBSOLETE Ions that have similar chemical valence, for example the acetyl cation CH3-CO+ and the thioacetyl cation CH3-CS+." [PSI:MS]
+comment: This child of the former purgatory term ion chemical type was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000356
 name: anti-aromatic ion
 def: "OBSOLETE A planar cyclic ion with 4n ? electrons and is therefore not aromatic." [PSI:MS]
+comment: This child of the former purgatory term ion chemical type was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000357
 name: cationized molecule
 def: "OBSOLETE An ion formed by the association of a cation with a neutral molecule, M, for example [M+ Na]+ and [M + K]+. The terms quasi-molecular ion and pseudo-molecular ion should not be used." [PSI:MS]
+comment: This child of the former purgatory term ion chemical type was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000358
 name: cluster ion
 def: "OBSOLETE An ion formed by a multi-component atomic or molecular assembly of one or more ions with atoms or molecules, such as [(H20)nH]+, [(NaCl)nNa]+ and [(H3PO3)nHPO3]-." [PSI:MS]
+comment: This child of the former purgatory term ion chemical type was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000359
 name: Conventional ion
 def: "OBSOLETE A radical cation or anion in which the charge site and the unpaired electron spin are both formally located in the same atom or group of atoms, as opposed to the spatially separate electronic configuration of distonic ions. The radical cation of methanol, CH3OH+, in which the charge and spin sites are formally located at the O atom is an example of a conventional ion, whereas .CH2-OH2+ is a distonic ion." [PSI:MS]
+comment: This child of the former purgatory term ion chemical type was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000360
 name: diagnostic ion
 def: "OBSOLETE A product ion whose formation reveals structural or compositional information of its precursor. For instance, the phenyl cation in an electron ionization mass spectrum is a diagnostic ion for benzene and derivatives." [PSI:MS]
+comment: This child of the former purgatory term ion chemical type was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000361
 name: dimeric ion
 def: "OBSOLETE An ion formed by ionization of a dimer or by the association of an ion with its neutral counterpart such as [M2]+ or [M-H-M]+." [PSI:MS]
+comment: This child of the former purgatory term ion chemical type was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000362
 name: distonic ion
 def: "OBSOLETE A radical cation or anion in which the charge site and the unpaired electron spin cannot be both formally located in the same atom or group of atoms as it can be with a conventional ion. For example, CH2-OH2+ is a distonic ion whereas the radical cation of methanol, CH3OH+ is a conventional ion." [PSI:MS]
+comment: This child of the former purgatory term ion chemical type was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000363
 name: enium ion
 def: "OBSOLETE A positively charged lower-valency ion of the nonmetallic elements. The methenium ion is CH3+. Other examples are the oxenium, sulfenium, nitrenium, phosphenium, and halenium ions." [PSI:MS]
+comment: This child of the former purgatory term ion chemical type was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000364
 name: fragment ion
 def: "OBSOLETE A product ion that results from the dissociation of a precursor ion." [PSI:MS]
+comment: This term was made obsolete because it was replaced by product ion (MS:1000342).
+is_obsolete: true
 
 [Term]
 id: MS:1000365
 name: ion?
 def: "OBSOLETE An atomic or molecular species having a net positive or negative electric charge." [PSI:MS]
+comment: This former purgatory term was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000366
 name: Isotopologue ion
 def: "OBSOLETE An ion that differs only in the isotopic composition of one or more of its constituent atoms. For example CH4+ and CH3D+ or 10BF3 and 11BF3. The term isotopologue is a contraction of isotopic homologue." [PSI:MS]
+comment: This child of the former purgatory term ion chemical type was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000367
 name: Isotopomeric ion
 def: "OBSOLETE Isomeric ion having the same numbers of each isotopic atom but differing in their positions. Isotopomeric ions can be either configurational isomers in which two atomic isotopes exchange positions or isotopic stereoisomers. The term isotopomer is a shortening of isotopic isomer." [PSI:MS]
+comment: This child of the former purgatory term ion chemical type was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000368
 name: metastable ion
 def: "OBSOLETE An ion that is formed with internal energy higher than the threshold for dissociation but with a lifetime great enough to allow it to exit the ion source and enter the mass spectrometer where it dissociates before detection." [PSI:MS]
+comment: This child of the former purgatory term ion stability type was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000369
 name: molecular ion
 def: "OBSOLETE An ion formed by the removal of one or more electrons to form a positive ion or the addition off one or more electrons to form a negative ion." [PSI:MS]
+comment: This child of the former purgatory term ion chemical type was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000370
 name: negative ion
 def: "OBSOLETE An atomic or molecular species having a net negative electric charge." [PSI:MS]
+comment: This child of the former purgatory term ion chemical type was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000371
 name: non-classical ion
 def: "OBSOLETE Hyper-coordinated carbonium ion such as the penta-coordinated norbornyl cation. Note: Tri-coordinated carbenium ions are termed classical ions." [PSI:MS]
+comment: This child of the former purgatory term ion chemical type was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000372
 name: onium ion
 def: "OBSOLETE A positively charged hypervalent ion of the nonmetallic elements. Examples are the methonium ion CH5+, the hydrogenonium ion H3+ and the hydronium ion H3O+. Other examples are the carbonium, oxonium, sulfonium, nitronium, diazonium, phosphonium, and halonium ions. Onium ions are not limited to monopositive ions; multiply-charged onium ions exist such as the gitonic (proximal) oxonium dication H4O2+ and the distonic oxonium dication H2O+-CH2-CH2-OH2+." [PSI:MS]
+comment: This child of the former purgatory term ion chemical type was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000373
 name: principal ion
 def: "OBSOLETE Most abundant ion of an isotope cluster, such as the 11B79Br2 81Br+ ion of m/z 250 of the cluster of isotopologue molecular ions of BBr3. The term principal ion has also been used to describe ions that have been artificially isotopically enriched in one or more positions such as CH3 13CH3+ or CH2D2 +, but those are best defined as isotopologue ions." [PSI:MS]
+comment: This child of the former purgatory term ion chemical type was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000374
 name: positive ion
 def: "OBSOLETE An atomic or molecular species having a net positive electric charge." [PSI:MS]
+comment: This child of the former purgatory term ion chemical type was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000375
 name: protonated molecule
 def: "OBSOLETE An ion formed by interaction of a neutral molecule with a proton and represented by the symbol [M + H]+, where M is the neutral molecule. The term 'protonated molecular ion,' 'quasi-molecular ion' and 'pseudo-molecular ion' are not recommended." [PSI:MS]
+comment: This child of the former purgatory term ion chemical type was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000376
 name: radical ion
 def: "OBSOLETE An ion, either a cation or anion, containing unpaired electrons in its ground state. The unpaired electron is denoted by a superscript dot alongside the superscript symbol for charge, such as for the molecular ion of a molecule M, that is, M+. Radical ions with more than one charge and/or more than one unpaired electron are denoted such as M(2+)(2). Unless the positions of the unpaired electron and charge can be associated with specific atoms, superscript charge designation should be placed before the superscript dot designation." [PSI:MS]
+comment: This child of the former purgatory term ion chemical type was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000377
 name: reference ion
 def: "OBSOLETE A stable ion whose structure is known with certainty. These ions are usually formed by direct ionization of a neutral molecule of known structure and are used to verify by comparison the structure of an unknown ion." [PSI:MS]
+comment: This child of the former purgatory term ion chemical type was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000378
 name: stable ion
 def: "OBSOLETE An ion with internal energy sufficiently low that it does not rearrange or dissociate prior to detection in a mass spectrometer." [PSI:MS]
+comment: This child of the former purgatory term ion stability type was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000379
 name: unstable ion
 def: "OBSOLETE An ion with sufficient energy to dissociate within the ion source." [PSI:MS]
+comment: This child of the former purgatory term ion stability type was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000380
@@ -2387,11 +2732,15 @@ is_a: MS:1000008 ! ionization type
 id: MS:1000390
 name: ion desolvation
 def: "OBSOLETE The removal of solvent molecules clustered around a gas-phase ion by means of heating and/or collisions with gas molecules." [PSI:MS]
+comment: This child of the former purgatory term ion reaction was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000391
 name: ion-pair formation
 def: "OBSOLETE The reaction of a molecule to form both a positive ion and negative ion fragment among the products." [PSI:MS]
+comment: This child of the former purgatory term ion reaction was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000392
@@ -2399,7 +2748,6 @@ name: ionization efficiency
 def: "The ratio of the number of ions formed to the number of electrons, molecules or photons used." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000482 ! source attribute
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000393
@@ -2429,6 +2777,7 @@ is_a: MS:1000073 ! electrospray ionization
 id: MS:1000398
 name: nanoelectrospray
 def: "Electrospray ionization at a flow rate less than ~25 nL/min. Nanoelectrospray is synonymous with nanospray. The flow is dependent on the potenial on the tip of the electrospray needle and/or a gas presure to push the sample through the needle. See also electrospray ionization and microelectrospray." [PSI:MS]
+synonym: "nanospray" EXACT []
 is_a: MS:1000073 ! electrospray ionization
 
 [Term]
@@ -2447,6 +2796,8 @@ is_a: MS:1000008 ! ionization type
 id: MS:1000401
 name: pre-ionization state
 def: "OBSOLETE An electronic state capable of undergoing auto-Ionization." [PSI:MS]
+comment: This child of the former purgatory term ion reaction was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000402
@@ -2494,16 +2845,22 @@ is_a: MS:1000008 ! ionization type
 id: MS:1000409
 name: association reaction
 def: "OBSOLETE The reaction of an ion with a neutral species in which the reactants combine to form a single ion." [PSI:MS]
+comment: This child of the former purgatory term ion reaction was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000410
 name: alpha-cleavage
 def: "OBSOLETE A homolytic cleavage where the bond fission occurs between at the atom adjacent to the atom at the apparent charge site and an atom removed from the aparent charge site by two bonds." [PSI:MS]
+comment: This child of the former purgatory term ion reaction was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000411
 name: beta-cleavage
 def: "OBSOLETE A homolytic cleavage where the bond fission occurs between at an atom removed from the apparent charge site atom by two bonds and an atom adjacent to that atom and removed from the aparent charge site by three bonds." [PSI:MS]
+comment: This child of the former purgatory term ion reaction was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000412
@@ -2511,37 +2868,48 @@ name: buffer gas
 def: "An inert gas used for collisional deactivation of internally excited ions." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000510 ! precursor activation attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000413
 name: charge-induced fragmentation
 def: "OBSOLETE Fragmentation of an odd electron ion in which the cleaved bond is adjacent to the apparent charge site. Synonymous with charge mediated fragmentation." [PSI:MS]
+comment: This child of the former purgatory term ion reaction was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000414
 name: charge inversion reaction
 def: "OBSOLETE Reaction of an ion with a neutral species in which the charge on the product ion is reversed in sign with respect to the reactant ion." [PSI:MS]
+comment: This child of the former purgatory term ion reaction was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000415
 name: charge permutation reaction
 def: "OBSOLETE The reaction of an ion with a neutral species with a resulting change in the magnitude or sign of the charge on the reactant ion." [PSI:MS]
+comment: This child of the former purgatory term ion reaction was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000416
 name: charge stripping reaction
 def: "OBSOLETE Reaction of a positive ion with a neutral species in which the positive charge on the product ion is greater than that on the reactant ion." [PSI:MS]
+comment: This child of the former purgatory term ion reaction was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000417
 name: charge transfer reaction
 def: "OBSOLETE The reaction of an ion with a neutral species in which some or all of the charge of the reactant ion is transferred to the neutral species." [PSI:MS]
+comment: This child of the former purgatory term ion reaction was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000418
 name: collisional excitation
 def: "OBSOLETE The reaction of an ion with a neutral species in which the translational energy of the collision is converted into internal energy of the ion." [PSI:MS]
+comment: This child of the former purgatory term ion reaction was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000419
@@ -2549,73 +2917,99 @@ name: collision gas
 def: "An inert gas used for collisional excitation. The term target gas is not recommended." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000510 ! precursor activation attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000420
 name: heterolytic cleavage
 def: "OBSOLETE Fragmentation of a molecule or ion in which both electrons forming the single bond that is broken remain on one of the atoms that were originally bonded. This term is synonymous with heterolysis." [PSI:MS]
+comment: This child of the former purgatory term ion reaction was made obsolete.
+synonym: "heterolysis" RELATED []
+is_obsolete: true
 
 [Term]
 id: MS:1000421
 name: high energy collision
 def: "OBSOLETE Collision-induced dissociation process wherein the projectile ion has laboratory-frame translational energy higher than 1 keV." [PSI:MS]
+comment: This child of the former purgatory term ion reaction was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000422
 name: beam-type collision-induced dissociation
 def: "A collision-induced dissociation process that occurs in a beam-type collision cell." [PSI:MS]
+synonym: "HCD" EXACT []
 is_a: MS:1000133 ! collision-induced dissociation
 
 [Term]
 id: MS:1000423
 name: homolytic cleavage
 def: "OBSOLETE Fragmentation of an odd electron ion that results from one of a pair of electrons that form a bond between two atoms moving to form a pair with the odd electron on the atom at the apparent charge site. Fragmentation results in the formation of an even electron ion and a radical. This reaction involves the movement of a single electron and is symbolized by a single-barbed arrow. Synonymous with Homolysis." [PSI:MS]
+comment: This child of the former purgatory term ion reaction was made obsolete.
+synonym: "homolysis" RELATED []
+is_obsolete: true
 
 [Term]
 id: MS:1000424
 name: hydrogen/deuterium exchange
 def: "OBSOLETE Exchange of hydrogen atoms with deuterium atoms in a molecule or pre-formed ion in solution prior to introduction into a mass spectrometer, or by reaction of an ion with a deuterated collision gas inside a mass spectrometer." [PSI:MS]
+comment: This child of the former purgatory term ion reaction was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000425
 name: ion energy loss spectrum
 def: "OBSOLETE A plot of the relative abundance of a beam or other collection of ions as a function their loss of translational energy in reactions with neutral species." [PSI:MS]
+comment: This former purgatory term was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000426
 name: ionizing collision
 def: "OBSOLETE The reaction of an ion with a neutral species in which one or more electrons are removed from either the ion or neutral." [PSI:MS]
+comment: This child of the former purgatory term ion reaction was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000427
 name: ion/molecule reaction
 def: "OBSOLETE The reaction of an ion with a neutral molecule. The term ion-molecule reaction is not recommended because the hyphen suggests a single species that is that is both an ion and a molecule." [PSI:MS]
+comment: This child of the former purgatory term ion reaction was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000428
 name: ion/neutral complex
 def: "OBSOLETE A particular type of transition state that lies between precursor and product ions on the reaction coordinate of some ion reactions." [PSI:MS]
+comment: This child of the former purgatory term ion reaction was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000429
 name: ion/neutral species reaction
 def: "OBSOLETE A process wherein a charged species interacts with a neutral reactant to produce either chemically different species or changes in the internal energy of one or both of the reactants." [PSI:MS]
+comment: This child of the former purgatory term ion reaction was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000430
 name: ion/neutral species exchange reaction
 def: "OBSOLETE In this reaction an association reaction is accompanied by the subsequent or simultaneous liberation of a different neutral species as a product." [PSI:MS]
+comment: This child of the former purgatory term ion reaction was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000431
 name: kinetic method
 def: "OBSOLETE An approach to determination of ion thermodynamic quantities by a bracketing procedure in which the relative probabilities of competing ion fragmentations are measured via the relative abundances of the reaction products. The extended kinetic method takes the associated entropy changes into account." [PSI:MS]
+comment: This child of the former purgatory term ion reaction was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000432
 name: low energy collisions
 def: "OBSOLETE A collision between an ion and neutral species with translational energy approximately 1000 eV or lower." [PSI:MS]
+comment: This child of the former purgatory term ion reaction was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000433
@@ -2627,37 +3021,51 @@ is_a: MS:1000044 ! dissociation method
 id: MS:1000434
 name: McLafferty Rearrangement
 def: "OBSOLETE A dissociation reaction triggered by transfer of a hydrogen atom via a 6-member transition state to the formal radical/charge site from a carbon atom four atoms removed from the charge/radical site (the gamma-carbon); subsequent rearrangement of electron density leads to expulsion of an olefin molecule. This term was originally applied to ketone ions where the charge/radical site is the carbonyl oxygen, but it is now more widely applied." [PSI:MS]
+comment: This child of the former purgatory term ion reaction was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000435
 name: photodissociation
 def: "A process wherein the reactant ion is dissociated as a result of absorption of one or more photons." [PSI:MS]
+synonym: "multiphoton dissociation" EXACT []
+synonym: "MPD" EXACT []
 is_a: MS:1000044 ! dissociation method
 
 [Term]
 id: MS:1000436
 name: partial charge transfer reaction
 def: "OBSOLETE Reaction of an ion with a neutral species in which some but not all of the ion charge is transferred to the neutral." [PSI:MS]
+comment: This child of the former purgatory term ion reaction was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000437
 name: ion reaction
 def: "OBSOLETE Chemical transformation involving an ion." [PSI:MS]
+comment: This child of the former purgatory term ion was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000438
 name: superelastic collision
 def: "OBSOLETE Collision in which the translational energy of the fast-moving collision partner is increased at the expense of internal energy of one or both collision partners." [PSI:MS]
+comment: This child of the former purgatory term ion reaction was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000439
 name: surface-induced reaction
 def: "OBSOLETE A process wherein a reactant ion interacts with a surface to produce either chemically different species or a change in the internal energy of the reactant ion." [PSI:MS]
+comment: This child of the former purgatory term ion reaction was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000440
 name: unimolecular dissociation
 def: "OBSOLETE Fragmentation reaction in which the molecularity is treated as one, irrespective of whether the dissociative state is that of a metastable ion produced in the ion source or results from collisional excitation of a stable ion." [PSI:MS]
+comment: This child of the former purgatory term ion reaction was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000441
@@ -2681,16 +3089,21 @@ relationship: part_of MS:1000451 ! mass analyzer
 id: MS:1000444
 name: m/z Separation Method
 def: "OBSOLETE Mass/charge separation Method." [PSI:MS]
+comment: This former purgatory term was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000445
 name: sequential m/z separation method
 def: "OBSOLETE Sequential m/z separation method." [PSI:MS]
+comment: This former purgatory term was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000446
 name: fast ion bombardment
 def: "The ionization of any species by the interaction of a focused beam of ions having a translational energy of several thousand eV with a solid sample." [PSI:MS]
+synonym: "FIB" EXACT []
 is_a: MS:1000008 ! ionization type
 
 [Term]
@@ -2721,12 +3134,14 @@ is_a: MS:1000494 ! Thermo Scientific instrument model
 id: MS:1000451
 name: mass analyzer
 def: "Terms used to describe the Analyzer." [PSI:MS]
+synonym: "analyzer" EXACT []
 relationship: part_of MS:1000463 ! instrument
 
 [Term]
 id: MS:1000452
 name: data transformation
 def: "Terms used to describe types of data processing." [PSI:MS]
+synonym: "data processing" EXACT []
 relationship: part_of MS:1001458 ! spectrum generation information
 
 [Term]
@@ -2739,6 +3154,8 @@ relationship: part_of MS:1000463 ! instrument
 id: MS:1000454
 name: instrument additional description
 def: "OBSOLETE Additional terms to describe the instrument as outlined in the mass spec doc, Appendix 1, section 1.5." [PSI:MS]
+comment: This former purgatory term was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000455
@@ -2751,6 +3168,7 @@ relationship: part_of MS:1000442 ! spectrum
 id: MS:1000456
 name: precursor activation
 def: "Terms to describe the precursor activation." [PSI:MS]
+synonym: "activation" EXACT []
 relationship: part_of MS:1000442 ! spectrum
 
 [Term]
@@ -2769,17 +3187,23 @@ relationship: part_of MS:1000463 ! instrument
 id: MS:1000459
 name: spectrum instrument description
 def: "OBSOLETE Terms used to describe the spectrum." [PSI:MS]
+comment: This former purgatory term was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000460
 name: unit
 def: "OBSOLETE Terms to describe units." [PSI:MS]
+comment: This term was made obsolete because it was redundant with the Unit Ontology term unit (UO:0000000).
 relationship: part_of MS:1001458 ! spectrum generation information
+is_obsolete: true
 
 [Term]
 id: MS:1000461
 name: additional description
 def: "OBSOLETE Terms to describe Additional." [PSI:MS]
+comment: This former purgatory term was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000462
@@ -2791,12 +3215,15 @@ relationship: part_of MS:1000463 ! instrument
 id: MS:1000463
 name: instrument
 def: "Description of the instrument or the mass spectrometer." [PSI:MS]
+synonym: "instrument configuration" EXACT []
 relationship: part_of MS:1001458 ! spectrum generation information
 
 [Term]
 id: MS:1000464
 name: mass unit
 def: "OBSOLETE A unit of measurement for mass." [PSI:MS]
+comment: This term was made obsolete because it was redundant with Unit Ontology mass unit (UO:0000002).
+is_obsolete: true
 
 [Term]
 id: MS:1000465
@@ -2808,6 +3235,8 @@ relationship: part_of MS:1000441 ! scan
 id: MS:1000466
 name: alternating
 def: "OBSOLETE Alternating." [PSI:MS]
+comment: This term was made obsolete because .
+is_obsolete: true
 
 [Term]
 id: MS:1000467
@@ -2873,6 +3302,7 @@ is_a: MS:1000490 ! Agilent instrument model
 id: MS:1000477
 name: 6410 Triple Quadrupole LC/MS
 def: "The 6410 Quadrupole LC/MS system is a Agilent liquid chromatography instrument combined with a Agilent triple quadrupole mass spectrometer. Mass range of the mass spectrometer is 15-1650 m/z, resolution is at three settings of 0.7 u (unit), 1.2 u (wide) and 2.5 u (widest). The mass accuracy for 6410 mass spectrometer is 0.1 across the mass range. The collision cell is a hexapole with linear acceleration." [PSI:MS]
+synonym: "6410 Triple Quad LC/MS" EXACT []
 is_a: MS:1000490 ! Agilent instrument model
 
 [Term]
@@ -2885,6 +3315,8 @@ is_a: MS:1000490 ! Agilent instrument model
 id: MS:1000479
 name: purgatory
 def: "OBSOLETE Terms that will likely become obsolete unless there are wails of dissent." [PSI:MS]
+comment: The whole branch purgatory term was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000480
@@ -2908,6 +3340,7 @@ relationship: part_of MS:1000458 ! source
 id: MS:1000483
 name: Thermo Fisher Scientific instrument model
 def: "Thermo Fisher Scientific instrument model. The company has gone through several names including Thermo Finnigan, Thermo Scientific." [PSI:MS]
+synonym: "Thermo Scientific" RELATED []
 is_a: MS:1000031 ! instrument model
 
 [Term]
@@ -2929,7 +3362,6 @@ def: "Potential difference at the MS source in volts." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000482 ! source attribute
 relationship: has_units UO:0000218 ! volt
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000487
@@ -2983,6 +3415,7 @@ is_a: MS:1000483 ! Thermo Fisher Scientific instrument model
 id: MS:1000495
 name: Applied Biosystems instrument model
 def: "Applied Biosystems instrument model." [PSI:MS]
+synonym: "ABI" EXACT []
 is_a: MS:1000031 ! instrument model
 
 [Term]
@@ -2996,12 +3429,15 @@ relationship: part_of MS:1000463 ! instrument
 id: MS:1000497
 name: zoom scan
 def: "Special scan mode where data with improved resolution is acquired. This is typically achieved by scanning a more narrow m/z window or scanning with a lower scan rate." [PSI:MS]
+synonym: "enhanced resolution scan" EXACT []
 is_a: MS:1000503 ! scan attribute
 
 [Term]
 id: MS:1000498
 name: full scan
 def: "OBSOLETE Feature of the ion trap mass spectrometer where MS data is acquired over a mass range." [PSI:MS]
+comment: This former purgatory term was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000499
@@ -3013,29 +3449,29 @@ relationship: part_of MS:1000442 ! spectrum
 id: MS:1000500
 name: scan window upper limit
 def: "The lower m/z bound of a mass spectrometer scan window." [PSI:MS]
+synonym: "mzRangeStop" RELATED []
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000549 ! selection window attribute
 relationship: has_units MS:1000040 ! m/z
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000501
 name: scan window lower limit
 def: "The upper m/z bound of a mass spectrometer scan window." [PSI:MS]
+synonym: "mzRangeStart" RELATED []
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000549 ! selection window attribute
 relationship: has_units MS:1000040 ! m/z
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000502
 name: dwell time
 def: "The time spent gathering data across a peak." [PSI:MS]
+synonym: "Scan Duration" RELATED []
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000503 ! scan attribute
 relationship: has_units UO:0000010 ! second
 relationship: has_units UO:0000031 ! minute
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000503
@@ -3051,7 +3487,6 @@ def: "M/z value of the signal of highest intensity in the mass spectrum." [PSI:M
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1003058 ! spectrum property
 relationship: has_units MS:1000040 ! m/z
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000505
@@ -3064,12 +3499,13 @@ relationship: has_units MS:1000132 ! percent of base peak
 relationship: has_units MS:1000814 ! counts per second
 relationship: has_units MS:1000905 ! percent of base peak times 100
 relationship: has_units UO:0000269 ! absorbance unit
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000506
 name: ion role
 def: "OBSOLETE Ion Role." [PSI:MS]
+comment: This child of the former purgatory term ion was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000507
@@ -3081,6 +3517,8 @@ relationship: part_of MS:1002806 ! ion
 id: MS:1000508
 name: ion chemical type
 def: "OBSOLETE Ion Type." [PSI:MS]
+comment: This child of the former purgatory term ion was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000509
@@ -3089,7 +3527,6 @@ def: "Activation Energy." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000510 ! precursor activation attribute
 relationship: has_units UO:0000266 ! electronvolt
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000510
@@ -3103,7 +3540,6 @@ name: ms level
 def: "Stage number achieved in a multi stage mass spectrometry acquisition." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1000499 ! spectrum attribute
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000512
@@ -3111,7 +3547,6 @@ name: filter string
 def: "A string unique to Thermo instrument describing instrument settings for the scan." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000503 ! scan attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000513
@@ -3175,6 +3610,7 @@ id: MS:1000520
 name: 16-bit float
 def: "OBSOLETE Signed 16-bit float." [PSI:MS]
 is_a: MS:1000518 ! binary data type
+is_obsolete: true
 
 [Term]
 id: MS:1000521
@@ -3220,7 +3656,6 @@ xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000808 ! chromatogram attribute
 is_a: MS:1003058 ! spectrum property
 relationship: has_units MS:1000040 ! m/z
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000528
@@ -3230,7 +3665,6 @@ xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000808 ! chromatogram attribute
 is_a: MS:1003058 ! spectrum property
 relationship: has_units MS:1000040 ! m/z
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000529
@@ -3238,7 +3672,6 @@ name: instrument serial number
 def: "Serial Number of the instrument." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000496 ! instrument attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000530
@@ -3265,6 +3698,7 @@ is_a: MS:1001457 ! data processing software
 id: MS:1000533
 name: Bioworks
 def: "Thermo Finnigan software for data analysis of peptides and proteins." [PSI:MS]
+synonym: "Bioworks Browser" RELATED []
 is_a: MS:1000693 ! Thermo Finnigan software
 is_a: MS:1001456 ! analysis software
 is_a: MS:1001457 ! data processing software
@@ -3308,6 +3742,7 @@ is_a: MS:1001457 ! data processing software
 id: MS:1000538
 name: massWolf
 def: "A software for converting Waters raw directory format to mzXML or mzML. MassWolf was originally developed at the Institute for Systems Biology." [PSI:MS]
+synonym: "wolf" EXACT []
 is_a: MS:1001457 ! data processing software
 
 [Term]
@@ -3386,6 +3821,8 @@ relationship: part_of MS:1000441 ! scan
 id: MS:1000550
 name: time unit
 def: "OBSOLETE Time Unit." [PSI:MS]
+comment: This term was made obsolete because it was redundant with the Unit Ontology term time unit (UO:0000003).
+is_obsolete: true
 
 [Term]
 id: MS:1000551
@@ -3400,6 +3837,8 @@ is_a: MS:1001457 ! data processing software
 id: MS:1000552
 name: maldi spot identifier
 def: "OBSOLETE Maldi Spot Identifier." [PSI:MS]
+comment: This former purgatory term was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1000553
@@ -3497,7 +3936,6 @@ name: MD5
 def: "MD5 (Message-Digest algorithm 5) is a (now deprecated) cryptographic hash function with a 128-bit hash value used to check the integrity of files." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000561 ! data file checksum type
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000569
@@ -3505,7 +3943,6 @@ name: SHA-1
 def: "SHA-1 (Secure Hash Algorithm-1) is a cryptographic hash function designed by the National Security Agency (NSA). It is also used to verify file integrity. Since 2011 it has been deprecated by the NIST as a U. S. government standard." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000561 ! data file checksum type
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000570
@@ -3554,8 +3991,9 @@ is_a: MS:1000572 ! binary data compression type
 id: MS:1000577
 name: source data file
 def: "Data file from which an entity is sourced." [PSI:MS]
-is_a: MS:1000499 ! spectrum attribute
+synonym: "source file" EXACT []
 relationship: part_of MS:1001458 ! spectrum generation information
+is_a: MS:1000499 ! spectrum attribute
 
 [Term]
 id: MS:1000578
@@ -3567,12 +4005,19 @@ is_a: MS:1000125 ! Thermo Finnigan instrument model
 id: MS:1000579
 name: MS1 spectrum
 def: "Mass spectrum created by a single-stage MS experiment or the first stage of a multi-stage experiment." [PSI:MS]
+synonym: "full spectrum" EXACT []
+synonym: "Q1 spectrum" EXACT []
+synonym: "Q3 spectrum" EXACT []
+synonym: "Single-Stage Mass Spectrometry" EXACT []
 is_a: MS:1000294 ! mass spectrum
 
 [Term]
 id: MS:1000580
 name: MSn spectrum
 def: "MSn refers to multi-stage MS2 experiments designed to record product ion spectra where n is the number of product ion stages (progeny ions). For ion traps, sequential MS/MS experiments can be undertaken where n > 2 whereas for a simple triple quadrupole system n=2. Use the term ms level (MS:1000511) for specifying n." [PSI:MS]
+synonym: "multiple-stage mass spectrometry spectrum" EXACT []
+synonym: "nth generation product ion spectrum" EXACT []
+synonym: "product ion spectrum" EXACT []
 is_a: MS:1000294 ! mass spectrum
 
 [Term]
@@ -3585,12 +4030,18 @@ is_a: MS:1000294 ! mass spectrum
 id: MS:1000582
 name: SIM spectrum
 def: "Spectrum obtained with the operation of a mass spectrometer in which the abundances of one ion or several ions of specific m/z values are recorded rather than the entire mass spectrum (Selected Ion Monitoring)." [PSI:MS]
+synonym: "MIM spectrum" EXACT []
+synonym: "multiple ion monitoring spectrum" EXACT []
+synonym: "selected ion monitoring spectrum" EXACT []
 is_a: MS:1000294 ! mass spectrum
 
 [Term]
 id: MS:1000583
 name: SRM spectrum
 def: "Spectrum obtained when data are acquired from specific product ions corresponding to m/z values of selected precursor ions a recorded via two or more stages of mass spectrometry. The precursor/product ion pair is called a transition pair. Data can be obtained for a single transition pair or multiple transition pairs. Multiple time segments of different transition pairs can exist in a single file. Single precursor ions can have multiple product ions consitituting multiple transition pairs. Selected reaction monitoring can be performed as tandem mass spectrometry in time or tandem mass spectrometry in space." [PSI:MS]
+synonym: "MRM spectrum" EXACT []
+synonym: "multiple reaction monitoring spectrum" EXACT []
+synonym: "selected reaction monitoring spectrum" EXACT []
 is_a: MS:1000294 ! mass spectrum
 
 [Term]
@@ -3612,7 +4063,6 @@ name: contact name
 def: "Name of the contact person or organization." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000585 ! contact attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000587
@@ -3620,7 +4070,6 @@ name: contact address
 def: "Postal address of the contact person or organization." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000585 ! contact attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000588
@@ -3628,7 +4077,6 @@ name: contact URL
 def: "Uniform Resource Locator related to the contact person or organization." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000585 ! contact attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000589
@@ -3636,7 +4084,6 @@ name: contact email
 def: "Email address of the contact person or organization." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000585 ! contact attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000590
@@ -3644,7 +4091,6 @@ name: contact affiliation
 def: "Home institution of the contact person." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000585 ! contact attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000591
@@ -3668,6 +4114,7 @@ is_a: MS:1000543 ! data processing action
 id: MS:1000594
 name: low intensity data point removal
 def: "The removal of very low intensity data points that are likely to be spurious noise rather than real signal." [PSI:MS]
+synonym: "thresholding" EXACT []
 is_a: MS:1001486 ! data filtering
 
 [Term]
@@ -3696,12 +4143,14 @@ is_a: MS:1000462 ! ion optics
 id: MS:1000598
 name: electron transfer dissociation
 def: "A process to fragment ions in a mass spectrometer by inducing fragmentation of cations (e.g. peptides or proteins) by transferring electrons to them." [PSI:MS]
+synonym: "ETD" EXACT []
 is_a: MS:1000044 ! dissociation method
 
 [Term]
 id: MS:1000599
 name: pulsed q dissociation
 def: "A process that involves precursor ion activation at high Q, a time delay to allow the precursor to fragment, then a rapid pulse to low Q where all fragment ions are trapped. The product ions can then be scanned out of the ion trap and detected." [PSI:MS]
+synonym: "PQD" EXACT []
 is_a: MS:1000044 ! dissociation method
 
 [Term]
@@ -3801,6 +4250,7 @@ is_a: MS:1000560 ! mass spectrometer file format
 id: MS:1000615
 name: ProteoWizard software
 def: "ProteoWizard software for data processing and analysis. Primarily developed by the labs of P. Malick and D. Tabb." [PSI:MS]
+synonym: "pwiz" EXACT []
 is_a: MS:1001456 ! analysis software
 is_a: MS:1001457 ! data processing software
 
@@ -3810,7 +4260,6 @@ name: preset scan configuration
 def: "A user-defined scan configuration that specifies the instrumental settings in which a spectrum is acquired. An instrument may cycle through a list of preset scan configurations to acquire data. This is a more generic term for the Thermo \"scan event\", which is defined in the Thermo Xcalibur glossary as: a mass spectrometer scan that is defined by choosing the necessary scan parameter settings. Multiple scan events can be defined for each segment of time." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000503 ! scan attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000617
@@ -3829,7 +4278,6 @@ xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1003058 ! spectrum property
 is_a: MS:1000808 ! chromatogram attribute
 relationship: has_units UO:0000018 ! nanometer
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000619
@@ -3839,19 +4287,21 @@ xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1003058 ! spectrum property
 is_a: MS:1000808 ! chromatogram attribute
 relationship: has_units UO:0000018 ! nanometer
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000620
 name: PDA spectrum
 def: "OBSOLETE Spectrum generated from a photodiode array detector (ultraviolet/visible spectrum)." [PSI:MS]
+comment: This term was made obsolete because it was replaced by absorption spectrum (MS:1000806).
 is_a: MS:1000524 ! data file content
 is_a: MS:1000559 ! spectrum type
+is_obsolete: true
 
 [Term]
 id: MS:1000621
 name: photodiode array detector
 def: "An array detector used to record spectra in the ultraviolet and visible region of light." [PSI:MS]
+synonym: "PDA" EXACT []
 is_a: MS:1000345 ! array detector
 
 [Term]
@@ -3870,6 +4320,7 @@ is_a: MS:1000494 ! Thermo Scientific instrument model
 id: MS:1000624
 name: inductive detector
 def: "Inductive detector." [PSI:MS]
+synonym: "image current detector" EXACT []
 is_a: MS:1000026 ! detector type
 
 [Term]
@@ -3888,6 +4339,7 @@ relationship: part_of MS:1000625 ! chromatogram
 id: MS:1000627
 name: selected ion current chromatogram
 def: "Representation of an array of the measurements of a specific single ion current versus time." [PSI:MS]
+synonym: "SIC chromatogram" EXACT []
 is_a: MS:1000810 ! ion current chromatogram
 
 [Term]
@@ -3907,7 +4359,6 @@ relationship: has_units MS:1000132 ! percent of base peak
 relationship: has_units MS:1000814 ! counts per second
 relationship: has_units MS:1000905 ! percent of base peak times 100
 relationship: has_units UO:0000269 ! absorbance unit
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000630
@@ -3926,7 +4377,6 @@ relationship: has_units MS:1000132 ! percent of base peak
 relationship: has_units MS:1000814 ! counts per second
 relationship: has_units MS:1000905 ! percent of base peak times 100
 relationship: has_units UO:0000269 ! absorbance unit
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000632
@@ -3940,7 +4390,6 @@ name: possible charge state
 def: "A possible charge state of the ion in a situation where the charge of an ion is known to be one of several possible values rather than a completely unknown value or determined to be a specific charge with reasonable certainty." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1000455 ! ion selection attribute
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000634
@@ -4345,6 +4794,7 @@ is_a: MS:1000531 ! software
 id: MS:1000693
 name: Thermo Finnigan software
 def: "Thermo Finnigan software for data acquisition and analysis." [PSI:MS]
+synonym: "Bioworks Browser" RELATED []
 is_a: MS:1000531 ! software
 
 [Term]
@@ -4687,7 +5137,6 @@ def: "Mass-to-charge ratio of an selected ion." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000455 ! ion selection attribute
 relationship: has_units MS:1000040 ! m/z
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000745
@@ -4707,7 +5156,6 @@ name: completion time
 def: "The time that a data processing action was finished." [PSI:MS]
 xref: value-type:xsd\:dateTime "The allowed value-type for this CV term."
 is_a: MS:1000630 ! data processing parameter
-relationship: has_value_type xsd\:dateTime ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000748
@@ -4786,7 +5234,9 @@ is_a: MS:1000752 ! TOPP software
 id: MS:1000760
 name: MapAligner
 def: "OBSOLETE Corrects retention time distortions between maps." [PSI:MS]
+comment: This term was made obsolete, because it is replaced by the terms under the 'TOPP map aligner' (MS:1002147) branch.
 is_a: MS:1000752 ! TOPP software
+is_obsolete: true
 
 [Term]
 id: MS:1000761
@@ -4798,13 +5248,17 @@ is_a: MS:1000752 ! TOPP software
 id: MS:1000762
 name: NoiseFilter
 def: "OBSOLETE Removes noise from profile spectra by using different smoothing techniques." [PSI:MS]
+comment: This term was made obsolete, because it is replaced by the terms under the 'TOPP noise filter' (MS:1002131) branch.
 is_a: MS:1000752 ! TOPP software
+is_obsolete: true
 
 [Term]
 id: MS:1000763
 name: PeakPicker
 def: "OBSOLETE Finds mass spectrometric peaks in profile mass spectra." [PSI:MS]
+comment: This term was made obsolete, because it is replaced by the terms under the 'TOPP peak picker' (MS:1002134) branch.
 is_a: MS:1000752 ! TOPP software
+is_obsolete: true
 
 [Term]
 id: MS:1000764
@@ -4816,7 +5270,9 @@ is_a: MS:1000752 ! TOPP software
 id: MS:1000765
 name: SpectraFilter
 def: "OBSOLETE Applies a filter to peak spectra." [PSI:MS]
+comment: This term was made obsolete, because it is replaced by the terms under the 'TOPP spectra filter' (MS:1002137) branch.
 is_a: MS:1000752 ! TOPP software
+is_obsolete: true
 
 [Term]
 id: MS:1000766
@@ -4828,6 +5284,7 @@ is_a: MS:1000752 ! TOPP software
 id: MS:1000767
 name: native spectrum identifier format
 def: "Describes how the native spectrum identifiers are formated." [PSI:MS]
+synonym: "nativeID format" EXACT []
 relationship: part_of MS:1000577 ! source data file
 
 [Term]
@@ -4864,30 +5321,35 @@ is_a: MS:1000767 ! native spectrum identifier format
 id: MS:1000773
 name: Bruker FID nativeID format
 def: "Native format defined by file=xsd:IDREF." [PSI:MS]
+comment: The nativeID must be the same as the source file ID.
 is_a: MS:1000767 ! native spectrum identifier format
 
 [Term]
 id: MS:1000774
 name: multiple peak list nativeID format
 def: "Native format defined by index=xsd:nonNegativeInteger." [PSI:MS]
+comment: Used for conversion of peak list files with multiple spectra, i.e. MGF, PKL, merged DTA files. Index is the spectrum number in the file, starting from 0.
 is_a: MS:1000767 ! native spectrum identifier format
 
 [Term]
 id: MS:1000775
 name: single peak list nativeID format
 def: "Native format defined by file=xsd:IDREF." [PSI:MS]
+comment: The nativeID must be the same as the source file ID. Used for conversion of peak list files with one spectrum per file, typically folder of PKL or DTAs, each sourceFileRef is different.
 is_a: MS:1000767 ! native spectrum identifier format
 
 [Term]
 id: MS:1000776
 name: scan number only nativeID format
 def: "Native format defined by scan=xsd:nonNegativeInteger." [PSI:MS]
+comment: Used for conversion from mzXML, or DTA folder where native scan numbers can be derived.
 is_a: MS:1000767 ! native spectrum identifier format
 
 [Term]
 id: MS:1000777
 name: spectrum identifier nativeID format
 def: "Native format defined by spectrum=xsd:nonNegativeInteger." [PSI:MS]
+comment: Used for conversion from mzData. The spectrum id attribute is referenced.
 is_a: MS:1000767 ! native spectrum identifier format
 
 [Term]
@@ -4930,12 +5392,17 @@ is_a: MS:1000592 ! smoothing
 id: MS:1000784
 name: Gaussian smoothing
 def: "Reduces intensity spikes by convolving the data with a one-dimensional Gaussian function." [PSI:MS]
+synonym: "binomial smoothing" EXACT []
+synonym: "Weierstrass transform" EXACT []
 is_a: MS:1000592 ! smoothing
 
 [Term]
 id: MS:1000785
 name: moving average smoothing
 def: "Reduces intensity spikes by averaging each point with two or more adjacent points. The more adjacent points that used, the stronger the smoothing effect." [PSI:MS]
+synonym: "box smoothing" EXACT []
+synonym: "boxcar smoothing" EXACT []
+synonym: "sliding average smoothing" EXACT []
 is_a: MS:1000592 ! smoothing
 
 [Term]
@@ -4949,7 +5416,6 @@ xref: binary-data-type:MS\:1000523 "64-bit float"
 xref: binary-data-type:MS\:1001479 "null-terminated ASCII string"
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000513 ! binary data array
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000787
@@ -4962,7 +5428,6 @@ relationship: has_units MS:1000132 ! percent of base peak
 relationship: has_units MS:1000814 ! counts per second
 relationship: has_units MS:1000905 ! percent of base peak times 100
 relationship: has_units UO:0000269 ! absorbance unit
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000788
@@ -4975,7 +5440,6 @@ relationship: has_units MS:1000132 ! percent of base peak
 relationship: has_units MS:1000814 ! counts per second
 relationship: has_units MS:1000905 ! percent of base peak times 100
 relationship: has_units UO:0000269 ! absorbance unit
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000789
@@ -4993,6 +5457,8 @@ is_a: MS:1000580 ! MSn spectrum
 id: MS:1000791
 name: enhanced resolution scan
 def: "OBSOLETE Scan with enhanced resolution." [PSI:MS]
+comment: This term was made obsolete because it was merged with zoom scan (MS:1000497).
+is_obsolete: true
 
 [Term]
 id: MS:1000792
@@ -5005,19 +5471,21 @@ relationship: part_of MS:1000441 ! scan
 id: MS:1000793
 name: isolation window upper limit
 def: "OBSOLETE The highest m/z being isolated in an isolation window." [PSI:MS]
+comment: This term was obsoleted in favour of using a target, lower, upper offset scheme. See terms 1000827-1000829.
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000792 ! isolation window attribute
 relationship: has_units MS:1000040 ! m/z
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
+is_obsolete: true
 
 [Term]
 id: MS:1000794
 name: isolation window lower limit
 def: "OBSOLETE The lowest m/z being isolated in an isolation window." [PSI:MS]
+comment: This term was obsoleted in favour of using a target, lower, upper offset scheme. See terms 1000827-1000829.
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000792 ! isolation window attribute
 relationship: has_units MS:1000040 ! m/z
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
+is_obsolete: true
 
 [Term]
 id: MS:1000795
@@ -5029,28 +5497,28 @@ is_a: MS:1000570 ! spectra combination
 id: MS:1000796
 name: spectrum title
 def: "Free-form text title describing a spectrum, usually a series of key value pairs as used in an MGF file." [PSI:MS]
+comment: This is the preferred storage place for the spectrum TITLE from an MGF peak list.
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001405 ! spectrum identification result details
 is_a: MS:1000499 ! spectrum attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000797
 name: peak list scans
 def: "A list of scan numbers and or scan ranges associated with a peak list. If possible the list of scans should be converted to native spectrum identifiers instead of using this term." [PSI:MS]
+comment: This is the preferred storage place for the spectrum SCANS attribute from an MGF peak list.
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001405 ! spectrum identification result details
 is_a: MS:1003058 ! spectrum property
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000798
 name: peak list raw scans
 def: "A list of raw scans and or scan ranges used to generate a peak list. If possible the list of scans should be converted to native spectrum identifiers instead of using this term." [PSI:MS]
+comment: This is the preferred storage place for the spectrum RAWSCANS attribute from an MGF peak list.
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001405 ! spectrum identification result details
 is_a: MS:1003058 ! spectrum property
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000799
@@ -5058,7 +5526,6 @@ name: custom unreleased software tool
 def: "A software tool that has not yet been released. The value should describe the software. Please do not use this term for publicly available software - contact the PSI-MS working group in order to have another CV term added." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000531 ! software
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000800
@@ -5066,18 +5533,19 @@ name: mass resolving power
 def: "The observed mass divided by the difference between two masses that can be separated: m/dm. The procedure by which dm was obtained and the mass at which the measurement was made should be reported." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000503 ! scan attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000801
 name: area peak picking
 def: "Spectral peak processing conducted on the acquired data to convert profile data to centroided data. The area defined by all raw data points that belong to the peak is reported." [PSI:MS]
+synonym: "sum peak picking" EXACT []
 is_a: MS:1000035 ! peak picking
 
 [Term]
 id: MS:1000802
 name: height peak picking
 def: "Spectral peak processing conducted on the acquired data to convert profile data to centroided data. The maximum intensity of all raw data points that belong to the peak is reported." [PSI:MS]
+synonym: "max peak picking" EXACT []
 is_a: MS:1000035 ! peak picking
 
 [Term]
@@ -5087,12 +5555,12 @@ def: "Offset between two analyzers in a constant neutral loss or neutral gain sc
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000503 ! scan attribute
 relationship: has_units MS:1000040 ! m/z
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000804
 name: electromagnetic radiation spectrum
 def: "A plot of the relative intensity of electromagnetic radiation as a function of the wavelength." [PSI:MS]
+synonym: "EMR spectrum" EXACT []
 is_a: MS:1000524 ! data file content
 is_a: MS:1000559 ! spectrum type
 
@@ -5127,9 +5595,9 @@ relationship: part_of MS:1000625 ! chromatogram
 id: MS:1000809
 name: chromatogram title
 def: "A free-form text title describing a chromatogram." [PSI:MS]
+comment: This is the preferred storage place for the spectrum title.
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000808 ! chromatogram attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000810
@@ -5142,6 +5610,7 @@ is_a: MS:1000626 ! chromatogram type
 id: MS:1000811
 name: electromagnetic radiation chromatogram
 def: "Representation of electromagnetic properties versus time." [PSI:MS]
+synonym: "EMR radiation chromatogram" EXACT []
 is_a: MS:1000524 ! data file content
 is_a: MS:1000626 ! chromatogram type
 
@@ -5248,7 +5717,6 @@ xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000503 ! scan attribute
 relationship: has_units UO:0000010 ! second
 relationship: has_units UO:0000031 ! minute
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000827
@@ -5257,7 +5725,6 @@ def: "The primary or reference m/z about which the isolation window is defined."
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000792 ! isolation window attribute
 relationship: has_units MS:1000040 ! m/z
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000828
@@ -5266,7 +5733,6 @@ def: "The extent of the isolation window in m/z below the isolation window targe
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000792 ! isolation window attribute
 relationship: has_units MS:1000040 ! m/z
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000829
@@ -5275,7 +5741,6 @@ def: "The extent of the isolation window in m/z above the isolation window targe
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000792 ! isolation window attribute
 relationship: has_units MS:1000040 ! m/z
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000831
@@ -5302,7 +5767,6 @@ name: matrix solution
 def: "Describes the chemical solution used as matrix." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000832 ! MALDI matrix application
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000835
@@ -5311,7 +5775,6 @@ def: "Concentration of the chemical solution used as matrix." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000832 ! MALDI matrix application
 relationship: has_units UO:0000175 ! gram per liter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000836
@@ -5360,10 +5823,11 @@ relationship: part_of MS:1000840 ! laser
 id: MS:1000843
 name: wavelength
 def: "OBSOLETE The distance between two peaks of the emitted laser beam." [PSI:MS]
+comment: This term was made obsolete because it was redundant with the Pato Ontology term wavelength (UO:0001242).
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000841 ! laser attribute
 relationship: has_units UO:0000018 ! nanometer
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
+is_obsolete: true
 
 [Term]
 id: MS:1000844
@@ -5372,7 +5836,6 @@ def: "Describes the diameter of the laser beam in x direction." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000841 ! laser attribute
 relationship: has_units UO:0000017 ! micrometer
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000845
@@ -5381,7 +5844,6 @@ def: "Describes the diameter of the laser beam in y direction." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000841 ! laser attribute
 relationship: has_units UO:0000017 ! micrometer
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000846
@@ -5390,7 +5852,6 @@ def: "Describes output energy of the laser system. May be attenuated by filters 
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000841 ! laser attribute
 relationship: has_units UO:0000112 ! joule
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000847
@@ -5399,7 +5860,6 @@ def: "Describes how long the laser beam was emitted from the laser device." [PSI
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000841 ! laser attribute
 relationship: has_units UO:0000150 ! nanosecond
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000848
@@ -5408,7 +5868,6 @@ def: "Describes the reduction of the intensity of the laser beam energy." [PSI:M
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000841 ! laser attribute
 relationship: has_units UO:0000187 ! percent
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000849
@@ -5417,7 +5876,6 @@ def: "Describes the angle between the laser beam and the sample target." [PSI:MS
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000841 ! laser attribute
 relationship: has_units UO:0000185 ! degree
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000850
@@ -5473,7 +5931,6 @@ name: fraction identifier
 def: "Identier string that describes the sample fraction. This identifier should contain the fraction number(s) or similar information." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000857 ! run attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000859
@@ -5497,17 +5954,17 @@ relationship: part_of MS:1000881 ! molecular entity
 id: MS:1000862
 name: isoelectric point
 def: "The pH of a solution at which a charged molecule does not migrate in an electric field." [PSI:MS]
+synonym: "pI" EXACT []
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000861 ! molecular entity property
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000863
 name: predicted isoelectric point
 def: "The pH of a solution at which a charged molecule would not migrate in an electric field, as predicted by a software algorithm." [PSI:MS]
+synonym: "predicted pI" EXACT []
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000862 ! isoelectric point
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000864
@@ -5521,7 +5978,6 @@ name: empirical formula
 def: "A chemical formula which expresses the proportions of the elements present in a substance." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000864 ! chemical formula
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000866
@@ -5529,7 +5985,6 @@ name: molecular formula
 def: "A chemical compound formula expressing the number of atoms of each element present in a compound, without indicating how they are linked." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000864 ! chemical formula
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000867
@@ -5537,7 +5992,6 @@ name: structural formula
 def: "A chemical formula showing the number of atoms of each element in a molecule, their spatial arrangement, and their linkage to each other." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000864 ! chemical formula
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000868
@@ -5545,7 +5999,6 @@ name: SMILES formula
 def: "The simplified molecular input line entry specification or SMILES is a specification for unambiguously describing the structure of a chemical compound using a short ASCII string." [EDAM:2301]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000864 ! chemical formula
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000869
@@ -5554,13 +6007,14 @@ def: "The gas pressure of the collision gas used for collisional excitation." [P
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000510 ! precursor activation attribute
 relationship: has_units UO:0000110 ! pascal
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000870
 name: 4000 QTRAP
 def: "OBSOLETE SCIEX or Applied Biosystems|MDS SCIEX QTRAP 4000." [PSI:MS]
+comment: This term was obsoleted because was redundant to MS:1000139.
 is_a: MS:1000121 ! SCIEX instrument model
+is_obsolete: true
 
 [Term]
 id: MS:1000871
@@ -5593,7 +6047,6 @@ def: "Potential difference between the orifice and the skimmer in volts." [PSI:M
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000482 ! source attribute
 relationship: has_units UO:0000218 ! volt
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000876
@@ -5602,7 +6055,6 @@ def: "Potential difference between the sampling cone/orifice in volts." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000482 ! source attribute
 relationship: has_units UO:0000218 ! volt
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000877
@@ -5611,7 +6063,6 @@ def: "Potential difference setting of the tube lens in volts." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000482 ! source attribute
 relationship: has_units UO:0000218 ! volt
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000878
@@ -5625,7 +6076,6 @@ name: PubMed identifier
 def: "A unique identifier for a publication in the PubMed database (MIR:00000015)." [PSI:MS]
 xref: value-type:xsd\:integer "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
-relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000880
@@ -5634,7 +6084,6 @@ def: "The duration of intervals between scanning, during which the instrument co
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000503 ! scan attribute
 relationship: has_units UO:0000010 ! second
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000881
@@ -5654,14 +6103,13 @@ name: protein short name
 def: "A short name or symbol of a protein (e.g., HSF 1 or HSF1_HUMAN)." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000884 ! protein attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000884
 name: protein attribute
 def: "An nonphysical characterstic attributed to a specific protein." [PSI:MS]
-is_a: MS:1001806 ! quantification object attribute
 relationship: part_of MS:1000882 ! protein
+is_a: MS:1001806 ! quantification object attribute
 
 [Term]
 id: MS:1000885
@@ -5670,7 +6118,6 @@ def: "Identifier for a specific protein in a database." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000884 ! protein attribute
 is_a: MS:1003046 ! peptide-to-protein mapping attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000886
@@ -5678,7 +6125,6 @@ name: protein name
 def: "A long name describing the function of the protein." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000884 ! protein attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000887
@@ -5692,15 +6138,14 @@ name: stripped peptide sequence
 def: "Sequence of letter symbols denoting the order of amino acids that compose the peptide, with any amino acid mass modifications that might be present having been stripped away." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1003050 ! peptidoform attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000889
 name: peptidoform sequence
 def: "Sequence of letter symbols denoting the order of amino acid residues that compose the peptidoform including the encoding of any residue modifications that are present." [PSI:MS]
+comment: Make it more general as there are actually many other ways to display a modified peptide sequence.
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1003050 ! peptidoform attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000890
@@ -5718,6 +6163,7 @@ is_a: MS:1000890 ! peptidoform labeling state
 id: MS:1000892
 name: unlabeled peptidoform
 def: "A peptide that has not been labelled with heavier-than-usual isotopes. This is often referred to as \"light\" to distinguish from \"heavy\"." [PSI:MS]
+synonym: "light labeled peptide" EXACT []
 is_a: MS:1000890 ! peptidoform labeling state
 
 [Term]
@@ -5726,7 +6172,6 @@ name: peptidoform group label
 def: "An arbitrary string label used to mark a set of peptides that belong together in a set, whereby the members are differentiated by different isotopic labels. For example, the heavy and light forms of the same peptide will both be assigned the same peptide group label." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1003050 ! peptidoform attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000894
@@ -5736,7 +6181,6 @@ xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1003050 ! peptidoform attribute
 relationship: has_units UO:0000010 ! second
 relationship: has_units UO:0000031 ! minute
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000895
@@ -5746,7 +6190,6 @@ xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000894 ! retention time
 relationship: has_units UO:0000010 ! second
 relationship: has_units UO:0000031 ! minute
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000896
@@ -5756,7 +6199,6 @@ xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000894 ! retention time
 relationship: has_units UO:0000010 ! second
 relationship: has_units UO:0000031 ! minute
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000897
@@ -5766,7 +6208,6 @@ xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000894 ! retention time
 relationship: has_units UO:0000010 ! second
 relationship: has_units UO:0000031 ! minute
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000898
@@ -5804,7 +6245,6 @@ name: product ion series ordinal
 def: "The ordinal of the fragment within a specified ion series. (e.g. 8 for a y8 ion)." [PSI:PI]
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1001221 ! product ion attribute
-relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000904
@@ -5819,7 +6259,6 @@ name: percent of base peak times 100
 def: "The magnitude of a peak expressed in terms of the percentage of the magnitude of the base peak intensity multiplied by 100. The base peak is therefore 10000. This unit is common in normalized spectrum libraries." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000043 ! intensity unit
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000906
@@ -5828,7 +6267,6 @@ def: "Ordinal specifying the rank in intensity of a peak in a spectrum. Base pea
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1000455 ! ion selection attribute
 relationship: part_of MS:1000231 ! peak
-relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000907
@@ -5837,12 +6275,12 @@ def: "Ordinal specifying the rank of a peak in a spectrum in terms of suitabilit
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1000455 ! ion selection attribute
 relationship: part_of MS:1000231 ! peak
-relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000908
 name: transition
 def: "A set of two m/z values corresponding to the precursor m/z and a fragment m/z that in combination can be used to identify or quantify a specific ion, although not necessarily uniquely." [PSI:MS]
+synonym: "reaction" EXACT []
 relationship: part_of MS:1001458 ! spectrum generation information
 
 [Term]
@@ -5896,7 +6334,6 @@ xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000915 ! retention time window attribute
 relationship: has_units UO:0000010 ! second
 relationship: has_units UO:0000031 ! minute
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000917
@@ -5906,7 +6343,6 @@ xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000915 ! retention time window attribute
 relationship: has_units UO:0000010 ! second
 relationship: has_units UO:0000031 ! minute
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000918
@@ -5949,6 +6385,9 @@ is_a: MS:1000871 ! SRM software
 id: MS:1000924
 name: MaRiMba
 def: "OBSOLETE Software used to predict transitions for selected reaction monitoring experiments based on observed spectrum libraries developed and distributed by the Institute for Systems Biology." [http://tools.proteomecenter.org/wiki/index.php?title=Software:TPP-MaRiMba]
+comment: This term was made obsolete because it was redundant with an existing term (MS:1000872).
+is_obsolete: true
+replaced_by: MS:1000872
 
 [Term]
 id: MS:1000925
@@ -5962,7 +6401,6 @@ name: product interpretation rank
 def: "The integer rank given an interpretation of an observed product ion. For example, if y8 is selected as the most likely interpretation of a peak, then it is assigned a rank of 1." [PSI:MS]
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1001221 ! product ion attribute
-relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000927
@@ -5971,7 +6409,6 @@ def: "The length of time spent filling an ion trapping device." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000503 ! scan attribute
 relationship: has_units UO:0000028 ! millisecond
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000928
@@ -6009,7 +6446,6 @@ name: protein modifications
 def: "Encoding of modifications of the protein sequence from the specified accession, written in PEFF notation." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000884 ! protein attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000934
@@ -6017,7 +6453,6 @@ name: gene name
 def: "Name of the gene from which the protein is translated." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000884 ! protein attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001000
@@ -6030,7 +6465,6 @@ id: MS:1001005
 name: SEQUEST:CleavesAt
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002096 ! SEQUEST input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001006
@@ -6044,7 +6478,6 @@ name: SEQUEST:OutputLines
 def: "Number of peptide results to show." [PSI:MS]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1002096 ! SEQUEST input parameter
-relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001009
@@ -6052,7 +6485,6 @@ name: SEQUEST:DescriptionLines
 def: "Number of full protein descriptions to show for top N peptides." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002096 ! SEQUEST input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001010
@@ -6072,7 +6504,6 @@ name: database source
 def: "The organisation, project or laboratory from where the database is obtained (UniProt, NCBI, EBI, other)." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001011 ! search database details
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001013
@@ -6085,6 +6516,7 @@ id: MS:1001014
 name: database local file path
 def: "OBSOLETE: Use attribute in mzIdentML instead. Local file path of the search database from the search engine's point of view." [PSI:PI]
 is_a: MS:1001011 ! search database details
+is_obsolete: true
 
 [Term]
 id: MS:1001015
@@ -6092,7 +6524,6 @@ name: database original uri
 def: "URI, from where the search database was originally downloaded." [PSI:PI]
 xref: value-type:xsd\:anyURI "The allowed value-type for this CV term."
 is_a: MS:1001011 ! search database details
-relationship: has_value_type xsd\:anyURI ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001016
@@ -6100,13 +6531,13 @@ name: database version
 def: "Version of the search database. In mzIdentML use the attribute instead." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001011 ! search database details
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001017
 name: database release date
 def: "OBSOLETE: Use attribute in mzIdentML instead. Release date of the search database." [PSI:PI]
 is_a: MS:1001011 ! search database details
+is_obsolete: true
 
 [Term]
 id: MS:1001018
@@ -6156,14 +6587,12 @@ name: translation table
 def: "The translation table used to translate the nucleotides to amino acids." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001011 ! search database details
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001026
 name: SEQUEST:NormalizeXCorrValues
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002096 ! SEQUEST input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001027
@@ -6177,7 +6606,6 @@ name: SEQUEST:SequenceHeaderFilter
 def: "String in the header of a sequence entry for that entry to be searched." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002096 ! SEQUEST input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001029
@@ -6185,7 +6613,6 @@ name: number of sequences searched
 def: "The number of sequences (proteins / nucleotides) from the database search after filtering." [PSI:PI]
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1001011 ! search database details
-relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001030
@@ -6194,7 +6621,6 @@ def: "Number of peptide seqs compared to each spectrum." [PSI:PI]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1001011 ! search database details
 is_a: MS:1001405 ! spectrum identification result details
-relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001031
@@ -6207,13 +6633,13 @@ id: MS:1001032
 name: SEQUEST:SequencePartialFilter
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002096 ! SEQUEST input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001035
 name: date / time search performed
 def: "OBSOLETE: use attribute in mzIdentML instead. Date and time of the actual search run." [PSI:PI]
 is_a: MS:1001184 ! search statistics
+is_obsolete: true
 
 [Term]
 id: MS:1001036
@@ -6221,7 +6647,6 @@ name: search time taken
 def: "The time taken to complete the search in seconds." [PSI:PI]
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1001184 ! search statistics
-relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001037
@@ -6229,7 +6654,6 @@ name: SEQUEST:ShowFragmentIons
 def: "Flag indicating that fragment ions should be shown." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002096 ! SEQUEST input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001038
@@ -6237,7 +6661,6 @@ name: SEQUEST:Consensus
 def: "Specify depth as value of the CVParam." [PSI:PI]
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1001006 ! SEQUEST:ViewCV
-relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001040
@@ -6257,7 +6680,6 @@ name: SEQUEST:LimitTo
 def: "Specify \"number of dtas shown\" as value of the CVParam." [PSI:PI]
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1002096 ! SEQUEST input parameter
-relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001044
@@ -6277,7 +6699,6 @@ name: SEQUEST:sort by dCn
 def: "Sort order of SEQUEST search results by the delta of the normalized correlation score." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001041 ! SEQUEST:sortCV
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001047
@@ -6285,7 +6706,6 @@ name: SEQUEST:sort by dM
 def: "Sort order of SEQUEST search results by the difference between a theoretically calculated and the corresponding experimentally measured molecular mass M." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001041 ! SEQUEST:sortCV
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001048
@@ -6293,7 +6713,6 @@ name: SEQUEST:sort by Ions
 def: "Sort order of SEQUEST search results given by the ions." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001041 ! SEQUEST:sortCV
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001049
@@ -6301,7 +6720,6 @@ name: SEQUEST:sort by MH+
 def: "Sort order of SEQUEST search results given by the mass of the protonated ion." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001041 ! SEQUEST:sortCV
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001050
@@ -6309,14 +6727,13 @@ name: SEQUEST:sort by P
 def: "Sort order of SEQUEST search results given by the probability." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001041 ! SEQUEST:sortCV
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001051
 name: multiple enzyme combination rules
 def: "OBSOLETE: use attribute independent in mzIdentML instead. Description of multiple enzyme digestion protocol, if any." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
+is_obsolete: true
 
 [Term]
 id: MS:1001052
@@ -6324,7 +6741,6 @@ name: SEQUEST:sort by PreviousAminoAcid
 def: "Sort order of SEQUEST search results given by the previous amino acid." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001041 ! SEQUEST:sortCV
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001053
@@ -6332,7 +6748,6 @@ name: SEQUEST:sort by Ref
 def: "Sort order of SEQUEST search results given by the reference." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001041 ! SEQUEST:sortCV
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001055
@@ -6351,6 +6766,7 @@ id: MS:1001057
 name: tolerance on types
 def: "OBSOLETE: Tolerance on types." [PSI:PI]
 is_a: MS:1001055 ! modification parameters
+is_obsolete: true
 
 [Term]
 id: MS:1001058
@@ -6364,7 +6780,6 @@ name: SEQUEST:sort by RSp
 def: "Sort order of SEQUEST search results given by the result 'Sp' of 'Rank/Sp' in the out file (peptide)." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001041 ! SEQUEST:sortCV
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001060
@@ -6377,6 +6792,8 @@ id: MS:1001061
 name: neutral loss
 def: "OBSOLETE: replaced by MS:1000336 (neutral loss): Leave this to PSI-MOD." [PSI:PI]
 is_a: MS:1001055 ! modification parameters
+is_obsolete: true
+replaced_by: MS:1000336
 
 [Term]
 id: MS:1001062
@@ -6388,7 +6805,10 @@ is_a: MS:1000560 ! mass spectrometer file format
 id: MS:1001065
 name: TODOscoring model
 def: "OBSOLETE: There is Phenyx:ScoringModel for Phenyx! Scoring model (more detailed granularity). TODO: add some child terms." [PSI:PI]
+comment: This term was made obsolete and is replaced by the term (MS:1001961).
 is_a: MS:1001249 ! search input details
+is_obsolete: true
+replaced_by: MS:1001961
 
 [Term]
 id: MS:1001066
@@ -6402,7 +6822,6 @@ name: SEQUEST:sort by Sp
 def: "Sort order of SEQUEST search results by the Sp score." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001041 ! SEQUEST:sortCV
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001069
@@ -6410,7 +6829,6 @@ name: SEQUEST:sort by TIC
 def: "Sort order of SEQUEST search results given by the total ion current." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001041 ! SEQUEST:sortCV
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001070
@@ -6418,7 +6836,6 @@ name: SEQUEST:sort by Scan
 def: "Sort order of SEQUEST search results given by the scan number." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001041 ! SEQUEST:sortCV
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001071
@@ -6426,7 +6843,6 @@ name: SEQUEST:sort by Sequence
 def: "Sort order of SEQUEST search results given by the sequence." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001041 ! SEQUEST:sortCV
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001072
@@ -6434,7 +6850,6 @@ name: SEQUEST:sort by Sf
 def: "Sort order of SEQUEST search results given by the SEQUEST result 'Sf'." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001041 ! SEQUEST:sortCV
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001073
@@ -6490,7 +6905,6 @@ name: SEQUEST:sort by XCorr
 def: "Sort order of SEQUEST search results by the correlation score." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001041 ! SEQUEST:sortCV
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001087
@@ -6505,7 +6919,6 @@ def: "The protein description line from the sequence entry in the source databas
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001085 ! protein-level identification attribute
 is_a: MS:1001342 ! database sequence details
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001089
@@ -6515,18 +6928,24 @@ xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001085 ! protein-level identification attribute
 is_a: MS:1001342 ! database sequence details
 is_a: MS:1001512 ! Sequence database filters
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001090
 name: taxonomy nomenclature
 def: "OBSOLETE: The system used to indicate taxonomy. There should be an enumerated list of options: latin name, NCBI TaxID, common name, Swiss-Prot species ID (ex. RABIT from the full protein ID ALBU_RABIT)." [PSI:PI]
 is_a: MS:1001089 ! molecule taxonomy
+is_obsolete: true
+replaced_by: MS:1001467
+replaced_by: MS:1001468
+replaced_by: MS:1001469
+replaced_by: MS:1001470
 
 [Term]
 id: MS:1001091
 name: NoEnzyme
 is_a: MS:1001045 ! cleavage agent name
+comment: This term was made obsolete because it is ambiguous and is replaced by NoCleavage (MS:1001955) and unspecific cleavage (MS:1001956).
+is_obsolete: true
 
 [Term]
 id: MS:1001092
@@ -6540,7 +6959,6 @@ name: sequence coverage
 def: "The percent coverage for the protein based upon the matched peptide sequences (can be calculated)." [PSI:PI]
 xref: value-type:xsd\:decimal "The allowed value-type for this CV term."
 is_a: MS:1001085 ! protein-level identification attribute
-relationship: has_value_type xsd\:decimal ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001094
@@ -6548,14 +6966,12 @@ name: SEQUEST:sort by z
 def: "Sort order of SEQUEST search results given by the charge." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001041 ! SEQUEST:sortCV
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001095
 name: SEQUEST:ProcessAll
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001087 ! SEQUEST:ProcessCV
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001096
@@ -6563,7 +6979,6 @@ name: SEQUEST:TopPercentMostIntense
 def: "Specify \"percentage\" as value of the CVParam." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001087 ! SEQUEST:ProcessCV
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001097
@@ -6571,7 +6986,6 @@ name: distinct peptide sequences
 def: "This counts distinct sequences hitting the protein without regard to a minimal confidence threshold." [PSI:PI]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1001085 ! protein-level identification attribute
-relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001098
@@ -6579,7 +6993,6 @@ name: confident distinct peptide sequences
 def: "This counts the number of distinct peptide sequences. Multiple charge states and multiple modification states do NOT count as multiple sequences. The definition of 'confident' must be qualified elsewhere." [PSI:PI]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1001085 ! protein-level identification attribute
-relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001099
@@ -6587,7 +7000,6 @@ name: confident peptide qualification
 def: "The point of this entry is to define what is meant by confident for the term Confident distinct peptide sequence and/or Confident peptides. Example 1 - metric=Paragon:Confidence value=95 sense=greater than Example 2 - metric=Mascot:Eval value=0.05 sense=less than." [PSI:PI]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1001085 ! protein-level identification attribute
-relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001100
@@ -6595,7 +7007,6 @@ name: confident peptide sequence number
 def: "This counts the number of peptide sequences without regard to whether they are distinct. Multiple charges states and multiple modification states DO count as multiple peptides. The definition of 'confident' must be qualified elsewhere." [PSI:PI]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1001085 ! protein-level identification attribute
-relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001101
@@ -6608,14 +7019,12 @@ id: MS:1001102
 name: SEQUEST:Chromatogram
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001006 ! SEQUEST:ViewCV
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001103
 name: SEQUEST:InfoAndLog
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001006 ! SEQUEST:ViewCV
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001104
@@ -6635,7 +7044,6 @@ name: SEQUEST:TopNumber
 def: "Specify \"number\" as value of the CVParam." [PSI:PI]
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1001087 ! SEQUEST:ProcessCV
-relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001107
@@ -6655,7 +7063,6 @@ name: SEQUEST:CullTo
 def: "Specify cull string as value of the CVParam." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001087 ! SEQUEST:ProcessCV
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001110
@@ -6668,7 +7075,6 @@ id: MS:1001111
 name: SEQUEST:Full
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001110 ! SEQUEST:modeCV
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001112
@@ -6677,7 +7083,6 @@ def: "Residue preceding the first amino acid in the peptide sequence as it occur
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1003046 ! peptide-to-protein mapping attribute
 is_a: MS:1001105 ! peptide sequence-level identification attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001113
@@ -6686,22 +7091,24 @@ def: "Residue following the last amino acid in the peptide sequence as it occurs
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1003046 ! peptide-to-protein mapping attribute
 is_a: MS:1001105 ! peptide sequence-level identification attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001114
 name: retention time(s)
 def: "OBSOLETE Retention time of the spectrum from the source file." [PSI:PI]
+comment: This term was made obsolete because scan start time (MS:1000016) should be used instead.
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001105 ! peptide sequence-level identification attribute
 relationship: has_units UO:0000010 ! second
 relationship: has_units UO:0000031 ! minute
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
+is_obsolete: true
 
 [Term]
 id: MS:1001115
 name: scan number(s)
 def: "OBSOLETE: use spectrumID attribute of SpectrumIdentificationResult. Take from mzData." [PSI:PI]
+comment: This former purgatory term was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1001116
@@ -6716,7 +7123,6 @@ def: "The theoretical mass of the molecule (e.g. the peptide sequence and its mo
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001105 ! peptide sequence-level identification attribute
 relationship: has_units UO:0000221 ! dalton
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001118
@@ -6735,7 +7141,6 @@ id: MS:1001120
 name: SEQUEST:FormatAndLinks
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001110 ! SEQUEST:modeCV
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001121
@@ -6743,7 +7148,6 @@ name: number of matched peaks
 def: "The number of peaks that were matched as qualified by the ion series considered field. If a peak matches multiple ions then only 1 would be added the count." [PSI:PI]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1001105 ! peptide sequence-level identification attribute
-relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001122
@@ -6757,7 +7161,6 @@ name: number of peaks used
 def: "The number of peaks from the original peak list that are used to calculate the scores for a particular search engine. All ions that have the opportunity to match or be counted even if they don't." [PSI:PI]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1001105 ! peptide sequence-level identification attribute
-relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001124
@@ -6765,7 +7168,6 @@ name: number of peaks submitted
 def: "The number of peaks from the original peaks listed that were submitted to the search engine." [PSI:PI]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1001105 ! peptide sequence-level identification attribute
-relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001125
@@ -6774,14 +7176,12 @@ def: "Result of quality estimation: decision of a manual validation." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001092 ! peptide sequence-level identification statistic
 is_a: MS:1001116 ! single protein identification statistic
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001126
 name: SEQUEST:Fast
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001110 ! SEQUEST:modeCV
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001127
@@ -6805,9 +7205,10 @@ relationship: part_of MS:1001000 ! spectrum interpretation
 id: MS:1001130
 name: peptide raw area
 def: "OBSOLETE Peptide raw area." [PSI:PI]
+comment: This term was made obsolete because it is replaced by 'MS1 feature area' (MS:1001844).
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002737 ! peptide-level quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
+is_obsolete: true
 
 [Term]
 id: MS:1001131
@@ -6815,7 +7216,6 @@ name: error on peptide area
 def: "Error on peptide area." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002737 ! peptide-level quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001132
@@ -6823,7 +7223,6 @@ name: peptide ratio
 def: "Peptide ratio." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002737 ! peptide-level quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001133
@@ -6831,7 +7230,6 @@ name: error on peptide ratio
 def: "Error on peptide ratio." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002737 ! peptide-level quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001134
@@ -6839,7 +7237,6 @@ name: protein ratio
 def: "Protein ratio." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002738 ! protein-level quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001135
@@ -6847,15 +7244,15 @@ name: error on protein ratio
 def: "Error on protein ratio." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002738 ! protein-level quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001136
 name: p-value (protein diff from 1 randomly)
 def: "OBSOLETE P-value (protein diff from 1 randomly)." [PSI:PI]
+comment: This term was made obsolete because it is replaced by 't-test p-value' (MS:1001855).
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002738 ! protein-level quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
+is_obsolete: true
 
 [Term]
 id: MS:1001137
@@ -6863,7 +7260,6 @@ name: absolute quantity
 def: "Absolute quantity in terms of real concentration or molecule copy number in sample." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001138
@@ -6871,7 +7267,6 @@ name: error on absolute quantity
 def: "Error on absolute quantity." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001139
@@ -6884,7 +7279,9 @@ is_a: MS:1001129 ! quantification information
 id: MS:1001140
 name: quantitation software version
 def: "OBSOLETE Quantitation software version." [PSI:PI]
+comment: This term was made obsolete because part of mzQuantML schema.
 is_a: MS:1001129 ! quantification information
+is_obsolete: true
 
 [Term]
 id: MS:1001141
@@ -6892,7 +7289,6 @@ name: intensity of precursor ion
 def: "The intensity of the precursor ion." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001142
@@ -6956,6 +7352,7 @@ is_a: MS:1001066 ! ions series considered in search
 [Term]
 id: MS:1001152
 name: param: y ion-H2O DEPRECATED
+comment: This term was made obsolete - use MS:1001262 and MS:1002455 instead.
 is_a: MS:1001066 ! ions series considered in search
 
 [Term]
@@ -6970,7 +7367,6 @@ name: SEQUEST:probability
 def: "The SEQUEST result 'Probability'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001155
@@ -6979,7 +7375,6 @@ def: "The SEQUEST result 'XCorr'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002108 ! higher score better
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001156
@@ -6987,7 +7382,6 @@ name: SEQUEST:deltacn
 def: "The SEQUEST result 'DeltaCn'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001157
@@ -6995,14 +7389,12 @@ name: SEQUEST:sp
 def: "The SEQUEST result 'Sp' (protein)." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001158
 name: SEQUEST:Uniq
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001159
@@ -7010,7 +7402,6 @@ name: SEQUEST:expectation value
 def: "The SEQUEST result 'Expectation value'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001153 ! search engine specific score
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001160
@@ -7018,7 +7409,6 @@ name: SEQUEST:sf
 def: "The SEQUEST result 'Sf'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001161
@@ -7026,7 +7416,6 @@ name: SEQUEST:matched ions
 def: "The SEQUEST result 'Matched Ions'." [PSI:PI]
 xref: value-type:xsd\:integer "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001162
@@ -7034,7 +7423,6 @@ name: SEQUEST:total ions
 def: "The SEQUEST result 'Total Ions'." [PSI:PI]
 xref: value-type:xsd\:integer "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001163
@@ -7042,7 +7430,6 @@ name: SEQUEST:consensus score
 def: "The SEQUEST result 'Consensus Score'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001153 ! search engine specific score
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001164
@@ -7051,7 +7438,6 @@ def: "The Paragon result 'Unused ProtScore'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
 is_a: MS:1002368 ! search engine specific score for protein groups
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001165
@@ -7060,7 +7446,6 @@ def: "The Paragon result 'Total ProtScore'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
 is_a: MS:1002368 ! search engine specific score for protein groups
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001166
@@ -7068,7 +7453,6 @@ name: Paragon:score
 def: "The Paragon result 'Score'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001167
@@ -7076,7 +7460,6 @@ name: Paragon:confidence
 def: "The Paragon result 'Confidence'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001168
@@ -7084,7 +7467,6 @@ name: Paragon:expression error factor
 def: "The Paragon result 'Expression Error Factor'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001169
@@ -7092,7 +7474,6 @@ name: Paragon:expression change p-value
 def: "The Paragon result 'Expression change P-value'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001170
@@ -7100,7 +7481,6 @@ name: Paragon:contrib
 def: "The Paragon result 'Contrib'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001171
@@ -7108,7 +7488,6 @@ name: Mascot:score
 def: "The Mascot result 'Score'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001172
@@ -7116,7 +7495,6 @@ name: Mascot:expectation value
 def: "The Mascot result 'expectation value'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001173
@@ -7124,7 +7502,6 @@ name: Mascot:matched ions
 def: "The Mascot result 'Matched ions'." [PSI:PI]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001174
@@ -7132,7 +7509,6 @@ name: Mascot:total ions
 def: "The Mascot result 'Total ions'." [PSI:PI]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001175
@@ -7152,7 +7528,6 @@ name: number of molecular hypothesis considered
 def: "Number of Molecular Hypothesis Considered - This is the number of molecules (e.g. peptides for proteomics) considered for a particular search." [PSI:PI]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1001184 ! search statistics
-relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001178
@@ -7164,8 +7539,8 @@ is_a: MS:1001079 ! database type nucleotide
 id: MS:1001180
 name: Cleavage agent regular expression
 def: "Regular expressions for cleavage enzymes." [PSI:PI]
-is_a: MS:1002479 ! regular expression
 relationship: part_of MS:1001044 ! cleavage agent details
+is_a: MS:1002479 ! regular expression
 
 [Term]
 id: MS:1001184
@@ -7189,10 +7564,11 @@ is_a: MS:1001056 ! modification specificity rule
 id: MS:1001191
 name: p-value
 def: "OBSOLETE Quality estimation by p-value." [PSI:PI]
+comment: This term was made obsolete because now is split into peptide and protein terms.
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001092 ! peptide sequence-level identification statistic
 is_a: MS:1001198 ! protein identification confidence metric
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
+is_obsolete: true
 
 [Term]
 id: MS:1001192
@@ -7201,7 +7577,6 @@ def: "Result of quality estimation: Expect value." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001092 ! peptide sequence-level identification statistic
 is_a: MS:1001116 ! single protein identification statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001193
@@ -7210,7 +7585,6 @@ def: "Result of quality estimation: confidence score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001092 ! peptide sequence-level identification statistic
 is_a: MS:1001116 ! single protein identification statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001194
@@ -7218,7 +7592,6 @@ name: quality estimation with decoy database
 def: "Quality estimation by decoy database." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001060 ! quality estimation method details
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001195
@@ -7264,7 +7637,6 @@ xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001512 ! Sequence database filters
 relationship: has_units UO:0000221 ! dalton
 relationship: has_units UO:0000222 ! kilodalton
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001202
@@ -7274,7 +7646,6 @@ xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001512 ! Sequence database filters
 relationship: has_units UO:0000221 ! dalton
 relationship: has_units UO:0000222 ! kilodalton
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001203
@@ -7282,7 +7653,6 @@ name: DB PI filter maximum
 def: "Maximum value of isoelectric point filter." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001512 ! Sequence database filters
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001204
@@ -7290,7 +7660,6 @@ name: DB PI filter minimum
 def: "Minimum value of isoelectric point filter." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001512 ! Sequence database filters
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001207
@@ -7332,6 +7701,8 @@ is_a: MS:1001210 ! mass type settings
 id: MS:1001213
 name: search result details
 def: "OBSOLETE: Scores and global result characteristics." [PSI:PI]
+comment: This former purgatory term was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1001214
@@ -7340,7 +7711,6 @@ def: "Estimation of the global false discovery rate of proteins." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002705 ! protein-level result list statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001215
@@ -7348,7 +7718,6 @@ name: SEQUEST:PeptideSp
 def: "The SEQUEST result 'Sp' in out file (peptide)." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001217
@@ -7356,7 +7725,6 @@ name: SEQUEST:PeptideRankSp
 def: "The SEQUEST result 'Sp' of 'Rank/Sp' in out file (peptide). Also called 'rsp'." [PSI:PI]
 xref: value-type:xsd\:integer "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001218
@@ -7364,7 +7732,6 @@ name: SEQUEST:PeptideNumber
 def: "The SEQUEST result '#' in out file (peptide)." [PSI:PI]
 xref: value-type:xsd\:integer "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001219
@@ -7372,7 +7739,6 @@ name: SEQUEST:PeptideIdnumber
 def: "The SEQUEST result 'Id#' in out file (peptide)." [PSI:PI]
 xref: value-type:xsd\:integer "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001220
@@ -7408,6 +7774,7 @@ is_a: MS:1002307 ! fragmentation ion type
 id: MS:1001225
 name: product ion m/z
 def: "The m/z of the product ion." [PSI:PI]
+synonym: "fragment ion m/z" EXACT []
 is_a: MS:1001221 ! product ion attribute
 relationship: has_units MS:1000040 ! m/z
 
@@ -7415,6 +7782,7 @@ relationship: has_units MS:1000040 ! m/z
 id: MS:1001226
 name: product ion intensity
 def: "The intensity of a single product ion." [PSI:PI]
+synonym: "fragment ion intensity" EXACT []
 is_a: MS:1001221 ! product ion attribute
 relationship: has_units MS:1000131 ! number of detector counts
 relationship: has_units MS:1000132 ! percent of base peak
@@ -7556,7 +7924,6 @@ def: "Result of quality estimation: the local FDR at the current position of a s
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001092 ! peptide sequence-level identification statistic
 is_a: MS:1001116 ! single protein identification statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001251
@@ -7655,7 +8022,6 @@ name: programmer
 def: "Programmer role." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001266 ! role type
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001269
@@ -7663,7 +8029,6 @@ name: instrument vendor
 def: "Instrument vendor role." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001266 ! role type
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001270
@@ -7671,7 +8036,6 @@ name: lab personnel
 def: "Lab personnel role." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001266 ! role type
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001271
@@ -7715,13 +8079,14 @@ name: decoy DB accession regexp
 def: "Specify the regular expression for decoy accession numbers." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001450 ! decoy DB details
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001284
 name: decoy DB derived from
 def: "OBSOLETE The name of the database, the search database was derived from." [PSI:PI]
+comment: This term was made obsolete, because a combination of database name, DB composition , decoy DB type , decoy DB generation algorithm, decoy DB accession regexp and decoy DB details suffices.
 is_a: MS:1001450 ! decoy DB details
+is_obsolete: true
 
 [Term]
 id: MS:1001285
@@ -7763,51 +8128,71 @@ is_a: MS:1001013 ! database name
 id: MS:1001291
 name: decoy DB from nr
 def: "OBSOLETE Decoy database from a non-redundant GenBank sequence database." [PSI:PI]
+comment: This term was made obsolete, because a combination of database name, DB composition , decoy DB type , decoy DB generation algorithm, decoy DB accession regexp and decoy DB details suffices.
+is_obsolete: true
 
 [Term]
 id: MS:1001292
 name: decoy DB from IPI_rat
 def: "OBSOLETE Decoy database from a International Protein Index database for Rattus norvegicus." [PSI:PI]
+comment: This term was made obsolete, because a combination of database name, DB composition , decoy DB type , decoy DB generation algorithm, decoy DB accession regexp and decoy DB details suffices.
+is_obsolete: true
 
 [Term]
 id: MS:1001293
 name: decoy DB from IPI_mouse
 def: "OBSOLETE Decoy database from a International Protein Index database for Mus musculus." [PSI:PI]
+comment: This term was made obsolete, because a combination of database name, DB composition , decoy DB type , decoy DB generation algorithm, decoy DB accession regexp and decoy DB details suffices.
+is_obsolete: true
 
 [Term]
 id: MS:1001294
 name: decoy DB from IPI_arabidopsis
 def: "OBSOLETE Decoy database from a International Protein Index database for Arabidopsis thaliana." [PSI:PI]
+comment: This term was made obsolete, because a combination of database name, DB composition , decoy DB type , decoy DB generation algorithm, decoy DB accession regexp and decoy DB details suffices.
+is_obsolete: true
 
 [Term]
 id: MS:1001295
 name: decoy DB from EST
 def: "OBSOLETE Decoy database from an expressed sequence tag nucleotide sequence database." [PSI:PI]
+comment: This term was made obsolete, because a combination of database name, DB composition , decoy DB type , decoy DB generation algorithm, decoy DB accession regexp and decoy DB details suffices.
+is_obsolete: true
 
 [Term]
 id: MS:1001296
 name: decoy DB from IPI_zebrafish
 def: "OBSOLETE Decoy database from a International Protein Index database for Danio rerio." [PSI:PI]
+comment: This term was made obsolete, because a combination of database name, DB composition , decoy DB type , decoy DB generation algorithm, decoy DB accession regexp and decoy DB details suffices.
+is_obsolete: true
 
 [Term]
 id: MS:1001297
 name: decoy DB from UniProtKB/Swiss-Prot
 def: "OBSOLETE Decoy database from a Swiss-Prot protein sequence database." [PSI:PI]
+comment: This term was made obsolete, because a combination of database name, DB composition , decoy DB type , decoy DB generation algorithm, decoy DB accession regexp and decoy DB details suffices.
+is_obsolete: true
 
 [Term]
 id: MS:1001298
 name: decoy DB from IPI_chicken
 def: "OBSOLETE Decoy database from a International Protein Index database for Gallus gallus." [PSI:PI]
+comment: This term was made obsolete, because a combination of database name, DB composition , decoy DB type , decoy DB generation algorithm, decoy DB accession regexp and decoy DB details suffices.
+is_obsolete: true
 
 [Term]
 id: MS:1001299
 name: decoy DB from IPI_cow
 def: "OBSOLETE Decoy database from a International Protein Index database for Bos taurus." [PSI:PI]
+comment: This term was made obsolete, because a combination of database name, DB composition , decoy DB type , decoy DB generation algorithm, decoy DB accession regexp and decoy DB details suffices.
+is_obsolete: true
 
 [Term]
 id: MS:1001300
 name: decoy DB from IPI_human
 def: "OBSOLETE Decoy database from a International Protein Index database for Homo sapiens." [PSI:PI]
+comment: This term was made obsolete, because a combination of database name, DB composition , decoy DB type , decoy DB generation algorithm, decoy DB accession regexp and decoy DB details suffices.
+is_obsolete: true
 
 [Term]
 id: MS:1001301
@@ -7815,7 +8200,6 @@ name: protein rank
 def: "The rank of the protein in a list sorted by the search engine." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1001085 ! protein-level identification attribute
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001302
@@ -7827,6 +8211,8 @@ is_a: MS:1002093 ! search engine input parameter
 id: MS:1001303
 name: Arg-C
 def: "Endoproteinase Arg-C." [PSI:PI]
+synonym: "Trypsin/R" EXACT []
+synonym: "Clostripain" EXACT []
 is_a: MS:1001045 ! cleavage agent name
 relationship: has_regexp MS:1001272 ! (?<=R)(?!P)
 
@@ -7869,6 +8255,7 @@ relationship: has_regexp MS:1001334 ! ((?<=D))|((?=D))
 id: MS:1001309
 name: Lys-C
 def: "Endoproteinase Lys-C." [PSI:PI]
+synonym: "Trypsin/K" EXACT []
 is_a: MS:1001045 ! cleavage agent name
 relationship: has_regexp MS:1001335 ! (?<=K)(?!P)
 
@@ -7920,7 +8307,6 @@ name: Mascot:SigThreshold
 def: "Significance threshold below which the p-value of a peptide match must lie to be considered statistically significant (default 0.05)." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002095 ! Mascot input parameter
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001317
@@ -7928,7 +8314,6 @@ name: Mascot:MaxProteinHits
 def: "The number of protein hits to display in the report. If 'Auto', all protein hits that have a protein score exceeding the average peptide identity threshold are reported. Otherwise an integer at least 1." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002095 ! Mascot input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001318
@@ -7936,7 +8321,6 @@ name: Mascot:ProteinScoringMethod
 def: "Mascot protein scoring method; either 'Standard' or 'MudPIT'." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002095 ! Mascot input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001319
@@ -7944,7 +8328,6 @@ name: Mascot:MinMSMSThreshold
 def: "Mascot peptide match ion score threshold. If between 0 and 1, then peptide matches whose expect value exceeds the thresholds are suppressed; if at least 1, then peptide matches whose ion score is below the threshold are suppressed." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002095 ! Mascot input parameter
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001320
@@ -7952,7 +8335,6 @@ name: Mascot:ShowHomologousProteinsWithSamePeptides
 def: "If true, show (sequence or spectrum) same-set proteins. Otherwise they are suppressed." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002095 ! Mascot input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001321
@@ -7960,7 +8342,6 @@ name: Mascot:ShowHomologousProteinsWithSubsetOfPeptides
 def: "If true, show (sequence or spectrum) sub-set and subsumable proteins. Otherwise they are suppressed." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002095 ! Mascot input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001322
@@ -7968,7 +8349,6 @@ name: Mascot:RequireBoldRed
 def: "Only used in Peptide Summary and Select Summary reports. If true, a peptide match must be 'bold red' to be included in the report; bold red means the peptide is a top ranking match in a query and appears for the first time (in linear order) in the list of protein hits." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002095 ! Mascot input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001323
@@ -7976,7 +8356,6 @@ name: Mascot:UseUnigeneClustering
 def: "If true, then the search results are against a nucleic acid database and Unigene clustering is enabled. Otherwise UniGene clustering is not in use." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002095 ! Mascot input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001324
@@ -7984,7 +8363,6 @@ name: Mascot:IncludeErrorTolerantMatches
 def: "If true, then the search results are error tolerant and peptide matches from the second pass are included in search results. Otherwise no error tolerant peptide matches are included." [http://www.matrixscience.com/help/error_tolerant_help.html]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002095 ! Mascot input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001325
@@ -7992,12 +8370,13 @@ name: Mascot:ShowDecoyMatches
 def: "If true, then the search results are against an automatically generated decoy database and the reported peptide matches and protein hits come from the decoy database. Otherwise peptide matches and protein hits come from the original database." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002095 ! Mascot input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001326
 name: add_others
 def: "OBSOLETE." [PSI:PI]
+comment: This former purgatory term was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1001328
@@ -8005,7 +8384,6 @@ name: OMSSA:evalue
 def: "OMSSA E-value." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001329
@@ -8013,7 +8391,6 @@ name: OMSSA:pvalue
 def: "OMSSA p-value." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001330
@@ -8021,7 +8398,6 @@ name: X\!Tandem:expect
 def: "The X!Tandem expectation value." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001331
@@ -8029,7 +8405,6 @@ name: X\!Tandem:hyperscore
 def: "The X!Tandem hyperscore." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001332
@@ -8193,7 +8568,6 @@ name: msmsEval quality
 def: "This term reports the quality of the spectrum assigned by msmsEval." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001357 ! spectrum quality descriptions
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001359
@@ -8207,7 +8581,6 @@ name: alternate single letter codes
 def: "List of standard residue one letter codes which are used to replace a non-standard." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001359 ! ambiguous residues
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001361
@@ -8216,7 +8589,6 @@ def: "List of masses a non-standard letter code is replaced with." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001359 ! ambiguous residues
 relationship: has_units UO:0000221 ! dalton
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001362
@@ -8224,7 +8596,6 @@ name: number of unmatched peaks
 def: "The number of unmatched peaks." [PSI:PI]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1002345 ! PSM-level attribute
-relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001363
@@ -8239,7 +8610,6 @@ def: "Estimation of the global false discovery rate for distinct peptides once r
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002703 ! peptide sequence-level result list statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001365
@@ -8277,7 +8647,6 @@ name: Mascot:homology threshold
 def: "The Mascot result 'homology threshold'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001371
@@ -8285,14 +8654,12 @@ name: Mascot:identity threshold
 def: "The Mascot result 'identity threshold'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001372
 name: SEQUEST:Sequences
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001373
@@ -8300,14 +8667,12 @@ name: SEQUEST:TIC
 def: "SEQUEST total ion current." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001374
 name: SEQUEST:Sum
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001375
@@ -8315,7 +8680,6 @@ name: Phenyx:Instrument Type
 def: "The instrument type parameter value in Phenyx." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002097 ! Phenyx input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001376
@@ -8323,7 +8687,6 @@ name: Phenyx:Scoring Model
 def: "The selected scoring model in Phenyx." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002097 ! Phenyx input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001377
@@ -8331,7 +8694,6 @@ name: Phenyx:Default Parent Charge
 def: "The default parent charge value in Phenyx." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002097 ! Phenyx input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001378
@@ -8339,7 +8701,6 @@ name: Phenyx:Trust Parent Charge
 def: "The parameter in Phenyx that specifies if the experimental charge state is to be considered as correct." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002097 ! Phenyx input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001379
@@ -8347,7 +8708,6 @@ name: Phenyx:Turbo
 def: "The turbo mode parameter in Phenyx." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002097 ! Phenyx input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001380
@@ -8355,7 +8715,6 @@ name: Phenyx:Turbo:ErrorTol
 def: "The maximal allowed fragment m/z error filter considered in the turbo mode of Phenyx." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002097 ! Phenyx input parameter
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001381
@@ -8363,7 +8722,6 @@ name: Phenyx:Turbo:Coverage
 def: "The minimal peptide sequence coverage value, expressed in percent, considered in the turbo mode of Phenyx." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002097 ! Phenyx input parameter
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001382
@@ -8371,7 +8729,6 @@ name: Phenyx:Turbo:Series
 def: "The list of ion series considered in the turbo mode of Phenyx." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002097 ! Phenyx input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001383
@@ -8379,7 +8736,6 @@ name: Phenyx:MinPepLength
 def: "The minimal number of residues for a peptide to be considered for a valid identification in Phenyx." [PSI:PI]
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1002097 ! Phenyx input parameter
-relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001384
@@ -8387,7 +8743,6 @@ name: Phenyx:MinPepzscore
 def: "The minimal peptide z-score for a peptide to be considered for a valid identification in Phenyx." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002097 ! Phenyx input parameter
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001385
@@ -8395,7 +8750,6 @@ name: Phenyx:MaxPepPvalue
 def: "The maximal peptide p-value for a peptide to be considered for a valid identification in Phenyx." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002097 ! Phenyx input parameter
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001386
@@ -8403,7 +8757,6 @@ name: Phenyx:AC Score
 def: "The minimal protein score required for a protein database entry to be displayed in the list of identified proteins in Phenyx." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002097 ! Phenyx input parameter
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001387
@@ -8411,7 +8764,6 @@ name: Phenyx:Conflict Resolution
 def: "The parameter in Phenyx that specifies if the conflict resolution algorithm is to be used." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002097 ! Phenyx input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001388
@@ -8419,15 +8771,13 @@ name: Phenyx:AC
 def: "The primary sequence database identifier of a protein in Phenyx." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001389
 name: Phenyx:ID
-def: "A secondary sequence database identifier of a protein in Phenyx." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
+def: "A secondary sequence database identifier of a protein in Phenyx." [PSI:PI]
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001390
@@ -8435,7 +8785,6 @@ name: Phenyx:Score
 def: "The protein score of a protein match in Phenyx." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001391
@@ -8443,7 +8792,6 @@ name: Phenyx:Peptides1
 def: "First number of phenyx result \"#Peptides\"." [PSI:PI]
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001392
@@ -8451,7 +8799,6 @@ name: Phenyx:Peptides2
 def: "Second number of phenyx result \"#Peptides\"." [PSI:PI]
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001393
@@ -8459,7 +8806,6 @@ name: Phenyx:Auto
 def: "The value of the automatic peptide acceptance filter in Phenyx." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001394
@@ -8468,7 +8814,6 @@ def: "The value of the user-defined peptide acceptance filter in Phenyx." [PSI:P
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001395
@@ -8476,7 +8821,6 @@ name: Phenyx:Pepzscore
 def: "The z-score value of a peptide sequence match in Phenyx." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001396
@@ -8485,7 +8829,6 @@ def: "The p-value of a peptide sequence match in Phenyx." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1002358 ! search engine specific peptide sequence-level identification statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001397
@@ -8493,7 +8836,6 @@ name: Phenyx:NumberOfMC
 def: "The number of missed cleavages of a peptide sequence in Phenyx." [PSI:PI]
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001398
@@ -8502,7 +8844,6 @@ def: "The expression of the nature and position(s) of modified residue(s) on a m
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001399
@@ -8558,7 +8899,6 @@ name: translation start codons
 def: "The translation start codons used to translate the nucleotides to amino acids." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001011 ! search database details
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001411
@@ -8575,7 +8915,6 @@ relationship: has_units UO:0000166 ! parts per notation unit
 relationship: has_units UO:0000169 ! parts per million
 relationship: has_units UO:0000187 ! percent
 relationship: has_units UO:0000221 ! dalton
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001413
@@ -8586,7 +8925,6 @@ relationship: has_units UO:0000166 ! parts per notation unit
 relationship: has_units UO:0000169 ! parts per million
 relationship: has_units UO:0000187 ! percent
 relationship: has_units UO:0000221 ! dalton
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001414
@@ -8594,7 +8932,8 @@ name: MGF scans
 def: "OBSOLETE: replaced by MS:1000797 (peak list scans): This term can hold the scans attribute from an MGF input file." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001405 ! spectrum identification result details
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
+is_obsolete: true
+replaced_by: MS:1000797
 
 [Term]
 id: MS:1001415
@@ -8602,7 +8941,8 @@ name: MGF raw scans
 def: "OBSOLETE: replaced by MS:1000798 (peak list raw scans): This term can hold the raw scans attribute from an MGF input file." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001405 ! spectrum identification result details
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
+is_obsolete: true
+replaced_by: MS:1000798
 
 [Term]
 id: MS:1001416
@@ -8610,7 +8950,8 @@ name: spectrum title
 def: "OBSOLETE: replaced by MS:1000796 (spectrum title): Holds the spectrum title from different input file formats, e.g. MGF TITLE." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001405 ! spectrum identification result details
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
+is_obsolete: true
+replaced_by: MS:1000796
 
 [Term]
 id: MS:1001417
@@ -8618,7 +8959,6 @@ name: SpectraST:dot
 def: "SpectraST dot product of two spectra, measuring spectral similarity." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001418
@@ -8626,7 +8966,6 @@ name: SpectraST:dot_bias
 def: "SpectraST measure of how much of the dot product is dominated by a few peaks." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001419
@@ -8634,7 +8973,6 @@ name: SpectraST:discriminant score F
 def: "SpectraST spectrum score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001420
@@ -8642,7 +8980,6 @@ name: SpectraST:delta
 def: "SpectraST normalised difference between dot product of top hit and runner-up." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001421
@@ -8662,7 +8999,6 @@ name: translation table description
 def: "A URL that describes the translation table used to translate the nucleotides to amino acids." [PSI:PI]
 xref: value-type:xsd\:anyURI "The allowed value-type for this CV term."
 is_a: MS:1001011 ! search database details
-relationship: has_value_type xsd\:anyURI ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001424
@@ -8670,7 +9006,6 @@ name: ProteinExtractor:Methodname
 def: "Name of the used method in the ProteinExtractor algorithm." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001425
@@ -8678,7 +9013,6 @@ name: ProteinExtractor:GenerateNonRedundant
 def: "Flag indicating if a non redundant scoring should be generated." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001426
@@ -8686,7 +9020,6 @@ name: ProteinExtractor:IncludeIdentified
 def: "Flag indicating if identified proteins should be included." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001427
@@ -8694,7 +9027,6 @@ name: ProteinExtractor:MaxNumberOfProteins
 def: "The maximum number of proteins to consider." [PSI:PI]
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
-relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001428
@@ -8702,7 +9034,6 @@ name: ProteinExtractor:MaxProteinMass
 def: "The maximum considered mass for a protein." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001429
@@ -8710,7 +9041,6 @@ name: ProteinExtractor:MinNumberOfPeptides
 def: "The minimum number of proteins to consider." [PSI:PI]
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
-relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001430
@@ -8718,7 +9048,6 @@ name: ProteinExtractor:UseMascot
 def: "Flag indicating to include Mascot scoring for calculation of the ProteinExtractor meta score." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001431
@@ -8726,7 +9055,6 @@ name: ProteinExtractor:MascotPeptideScoreThreshold
 def: "Only peptides with scores higher than that threshold are taken into account in Mascot scoring for calculation of the ProteinExtractor meta score." [DOI:10.4172/jpb.1000056]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001432
@@ -8734,14 +9062,12 @@ name: ProteinExtractor:MascotUniqueScore
 def: "In the final result each protein must have at least one peptide above this Mascot score threshold in ProteinExtractor meta score calculation." [DOI:10.4172/jpb.1000056]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001433
 name: ProteinExtractor:MascotUseIdentityScore
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001434
@@ -8749,7 +9075,6 @@ name: ProteinExtractor:MascotWeighting
 def: "Influence of Mascot search engine in the process of merging the search engine specific protein lists into the global protein list of ProteinExtractor." [DOI:10.4172/jpb.1000056]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001435
@@ -8757,7 +9082,6 @@ name: ProteinExtractor:UseSequest
 def: "Flag indicating to include SEQUEST scoring for calculation of the ProteinExtractor meta score." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001436
@@ -8765,7 +9089,6 @@ name: ProteinExtractor:SequestPeptideScoreThreshold
 def: "Only peptides with scores higher than that threshold are taken into account in SEQUEST scoring for calculation of the ProteinExtractor meta score." [DOI:10.4172/jpb.1000056]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001437
@@ -8773,7 +9096,6 @@ name: ProteinExtractor:SequestUniqueScore
 def: "In the final result each protein must have at least one peptide above this SEQUEST score threshold in ProteinExtractor meta score calculation." [DOI:10.4172/jpb.1000056]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001438
@@ -8781,7 +9103,6 @@ name: ProteinExtractor:SequestWeighting
 def: "Influence of SEQUEST search engine in the process of merging the search engine specific protein lists into the global protein list of ProteinExtractor." [DOI:10.4172/jpb.1000056]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001439
@@ -8789,7 +9110,6 @@ name: ProteinExtractor:UseProteinSolver
 def: "Flag indicating to include ProteinSolver scoring for calculation of the ProteinExtractor meta score." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001440
@@ -8797,7 +9117,6 @@ name: ProteinExtractor:ProteinSolverPeptideScoreThreshold
 def: "Only peptides with scores higher than that threshold are taken into account in ProteinSolver scoring for calculation of the ProteinExtractor meta score." [DOI:10.4172/jpb.1000056]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001441
@@ -8805,7 +9124,6 @@ name: ProteinExtractor:ProteinSolverUniqueScore
 def: "In the final result each protein must have at least one peptide above this ProteinSolver score threshold in ProteinExtractor meta score calculation." [DOI:10.4172/jpb.1000056]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001442
@@ -8813,7 +9131,6 @@ name: ProteinExtractor:ProteinSolverWeighting
 def: "Influence of ProteinSolver search engine in the process of merging the search engine specific protein lists into the global protein list of ProteinExtractor." [DOI:10.4172/jpb.1000056]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001443
@@ -8821,7 +9138,6 @@ name: ProteinExtractor:UsePhenyx
 def: "Flag indicating to include Phenyx scoring for calculation of the ProteinExtractor meta score." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001444
@@ -8829,7 +9145,6 @@ name: ProteinExtractor:PhenyxPeptideScoreThreshold
 def: "Only peptides with scores higher than that threshold are taken into account in Phenyx scoring for calculation of the ProteinExtractor meta score." [DOI:10.4172/jpb.1000056]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001445
@@ -8837,7 +9152,6 @@ name: ProteinExtractor:PhenyxUniqueScore
 def: "In the final result each protein must have at least one peptide above this Phenyx score threshold in ProteinExtractor meta score calculation." [DOI:10.4172/jpb.1000056]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001446
@@ -8845,7 +9159,6 @@ name: ProteinExtractor:PhenyxWeighting
 def: "Influence of Phenyx search engine in the process of merging the search engine specific protein lists into the global protein list of ProteinExtractor." [DOI:10.4172/jpb.1000056]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001447
@@ -8853,7 +9166,6 @@ name: prot:FDR threshold
 def: "False-discovery rate threshold for proteins." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002485 ! protein-level statistical threshold
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001448
@@ -8861,7 +9173,6 @@ name: pep:FDR threshold
 def: "False-discovery rate threshold for peptides." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002484 ! peptide-level statistical threshold
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001449
@@ -8869,7 +9180,6 @@ name: OMSSA e-value threshold
 def: "Threshold for OMSSA e-value for quality estimation." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002099 ! OMSSA input parameter
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001450
@@ -8883,7 +9193,6 @@ name: decoy DB generation algorithm
 def: "Name of algorithm used for decoy generation." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001450 ! decoy DB details
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001452
@@ -8976,7 +9285,6 @@ name: taxonomy: NCBI TaxID
 def: "This term is used if a NCBI TaxID is specified, e.g. 9606 for Homo sapiens." [PSI:PI]
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1001089 ! molecule taxonomy
-relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001468
@@ -8984,7 +9292,6 @@ name: taxonomy: common name
 def: "This term is used if a common name is specified, e.g. human. Recommend using MS:1001467 (taxonomy: NCBI TaxID) where possible." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001089 ! molecule taxonomy
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001469
@@ -8992,7 +9299,6 @@ name: taxonomy: scientific name
 def: "This term is used if a scientific name is specified, e.g. Homo sapiens. Recommend using MS:1001467 (taxonomy: NCBI TaxID) where possible." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001089 ! molecule taxonomy
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001470
@@ -9000,7 +9306,6 @@ name: taxonomy: Swiss-Prot ID
 def: "This term is used if a swiss prot taxonomy id is specified, e.g. Human. Recommend using MS:1001467 (taxonomy: NCBI TaxID) where possible." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001089 ! molecule taxonomy
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001471
@@ -9012,19 +9317,24 @@ relationship: part_of MS:1001000 ! spectrum interpretation
 id: MS:1001472
 name: selected ion monitoring chromatogram
 def: "Representation of an array of the measurements of a selectively monitored ion versus time." [PSI:MS]
+synonym: "SIM chromatogram" EXACT []
 is_a: MS:1000810 ! ion current chromatogram
 
 [Term]
 id: MS:1001473
 name: selected reaction monitoring chromatogram
 def: "Representation of an array of the measurements of a selectively monitored reaction versus time." [PSI:MS]
+synonym: "SRM chromatogram" EXACT []
 is_a: MS:1000810 ! ion current chromatogram
 
 [Term]
 id: MS:1001474
 name: consecutive reaction monitoring chromatogram
 def: "OBSOLETE Representation of an array of the measurements of a series of monitored reactions versus time." [PSI:MS]
+comment: This term was made obsolete because, by design, it can't be properly represented in mzML 1.1. CRM experiments must be represented in a spectrum-centric way.
+synonym: "CRM chromatogram" EXACT []
 is_a: MS:1000810 ! ion current chromatogram
+is_obsolete: true
 
 [Term]
 id: MS:1001475
@@ -9133,7 +9443,6 @@ name: percolator:Q value
 def: "Percolator:Q value." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001492
@@ -9141,7 +9450,6 @@ name: percolator:score
 def: "Percolator:score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001493
@@ -9149,7 +9457,6 @@ name: percolator:PEP
 def: "Posterior error probability." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001494
@@ -9163,7 +9470,6 @@ name: ProteinScape:SearchResultId
 def: "The SearchResultId of this peptide as SearchResult in the ProteinScape database." [PSI:PI]
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001496
@@ -9171,7 +9477,6 @@ name: ProteinScape:SearchEventId
 def: "The SearchEventId of the SearchEvent in the ProteinScape database." [PSI:PI]
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001497
@@ -9179,7 +9484,6 @@ name: ProteinScape:ProfoundProbability
 def: "The Profound probability score stored by ProteinScape." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001498
@@ -9187,7 +9491,6 @@ name: Profound:z value
 def: "The Profound z value." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001499
@@ -9195,7 +9498,6 @@ name: Profound:Cluster
 def: "The Profound cluster score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001500
@@ -9203,7 +9505,6 @@ name: Profound:ClusterRank
 def: "The Profound cluster rank." [PSI:PI]
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001501
@@ -9211,7 +9512,6 @@ name: MSFit:Mowse score
 def: "The MSFit Mowse score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001502
@@ -9219,7 +9519,6 @@ name: Sonar:Score
 def: "The Sonar score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001503
@@ -9227,7 +9526,6 @@ name: ProteinScape:PFFSolverExp
 def: "The ProteinSolver exp value stored by ProteinScape." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001504
@@ -9235,7 +9533,6 @@ name: ProteinScape:PFFSolverScore
 def: "The ProteinSolver score stored by ProteinScape." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001505
@@ -9243,7 +9540,6 @@ name: ProteinScape:IntensityCoverage
 def: "The intensity coverage of the identified peaks in the spectrum calculated by ProteinScape." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001506
@@ -9251,7 +9547,6 @@ name: ProteinScape:SequestMetaScore
 def: "The SEQUEST meta score calculated by ProteinScape from the original SEQUEST scores." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001507
@@ -9259,7 +9554,6 @@ name: ProteinExtractor:Score
 def: "The score calculated by ProteinExtractor." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001508
@@ -9297,7 +9591,6 @@ name: DB sequence filter pattern
 def: "DB sequence filter pattern." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001512 ! Sequence database filters
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001514
@@ -9305,7 +9598,6 @@ name: DB accession filter string
 def: "DB accession filter string." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001512 ! Sequence database filters
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001515
@@ -9368,7 +9660,6 @@ def: "This term can describe a neutral loss m/z value that is lost from an ion."
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001471 ! peptide modification details
 relationship: has_units UO:0000221 ! dalton
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001525
@@ -9377,12 +9668,12 @@ def: "This term can describe a neutral loss m/z value that is lost from an ion."
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001471 ! peptide modification details
 relationship: has_units UO:0000221 ! dalton
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001526
 name: spectrum from database integer nativeID format
 def: "Native format defined by databasekey=xsd:long." [PSI:MS]
+comment: A unique identifier of a spectrum stored in a database (e.g. a PRIMARY KEY identifier).
 is_a: MS:1000767 ! native spectrum identifier format
 
 [Term]
@@ -9395,6 +9686,7 @@ is_a: MS:1000560 ! mass spectrometer file format
 id: MS:1001528
 name: Mascot query number
 def: "Native format defined by query=xsd:nonNegativeInteger." [PSI:MS]
+comment: The spectrum (query) number in a Mascot results file, starting from 1.
 is_a: MS:1000767 ! native spectrum identifier format
 is_a: MS:1001405 ! spectrum identification result details
 
@@ -9408,12 +9700,14 @@ is_a: MS:1001249 ! search input details
 id: MS:1001530
 name: mzML unique identifier
 def: "Native format defined by mzMLid=xsd:IDREF." [PSI:MS]
+comment: A unique identifier of a spectrum stored in an mzML file.
 is_a: MS:1001529 ! spectra data details
 
 [Term]
 id: MS:1001531
 name: spectrum from ProteinScape database nativeID format
 def: "Native format defined by databasekey=xsd:long." [PSI:MS]
+comment: A unique identifier of a spectrum stored in a ProteinScape database.
 is_a: MS:1000767 ! native spectrum identifier format
 is_a: MS:1001529 ! spectra data details
 
@@ -9421,6 +9715,7 @@ is_a: MS:1001529 ! spectra data details
 id: MS:1001532
 name: spectrum from database string nativeID format
 def: "Native format defined by databasekey=xsd:string." [PSI:MS]
+comment: A unique identifier of a spectrum stored in a database (e.g. a PRIMARY KEY identifier).
 is_a: MS:1000767 ! native spectrum identifier format
 is_a: MS:1001529 ! spectra data details
 
@@ -9631,7 +9926,6 @@ name: Scaffold:Peptide Probability
 def: "Scaffold peptide probability score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001569
@@ -9639,7 +9933,6 @@ name: IdentityE Score
 def: "Waters IdentityE peptide score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001570
@@ -9647,7 +9940,6 @@ name: ProteinLynx:Log Likelihood
 def: "ProteinLynx log likelihood score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001571
@@ -9655,7 +9947,6 @@ name: ProteinLynx:Ladder Score
 def: "Waters ProteinLynx Ladder score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001572
@@ -9663,7 +9954,6 @@ name: SpectrumMill:Score
 def: "Spectrum mill peptide score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001573
@@ -9671,7 +9961,6 @@ name: SpectrumMill:SPI
 def: "SpectrumMill SPI score (%)." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001574
@@ -9685,7 +9974,6 @@ name: Scaffold: Minimum Peptide Count
 def: "Minimum number of peptides a protein must have to be accepted." [PSI:PI]
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1002106 ! Scaffold input parameter
-relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001576
@@ -9693,7 +9981,6 @@ name: Scaffold: Minimum Protein Probability
 def: "Minimum protein probability a protein must have to be accepted." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002106 ! Scaffold input parameter
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001577
@@ -9701,7 +9988,6 @@ name: Scaffold: Minimum Peptide Probability
 def: "Minimum probability a peptide must have to be accepted for protein scoring." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002106 ! Scaffold input parameter
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001578
@@ -9709,7 +9995,6 @@ name: minimum number of enzymatic termini
 def: "Minimum number of enzymatic termini a peptide must have to be accepted." [PSI:PI]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1002094 ! common search engine input parameter
-relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001579
@@ -9717,7 +10002,6 @@ name: Scaffold:Protein Probability
 def: "Scaffold protein probability score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001580
@@ -9725,16 +10009,15 @@ name: SpectrumMill:Discriminant Score
 def: "Discriminant score from Agilent SpectrumMill software." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001581
 name: FAIMS compensation voltage
 def: "The DC potential applied to the asymmetric waveform in FAIMS that compensates for the difference between high and low field mobility of an ion." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
+synonym: "FAIMS CV" EXACT []
 is_a: MS:1002892 ! ion mobility attribute
 relationship: has_units UO:0000218 ! volt
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001582
@@ -9784,12 +10067,16 @@ is_a: MS:1001456 ! analysis software
 id: MS:1001589
 name: MyriMatch:MVH
 def: "Using the multivariate hypergeometric distribution and a peak list divided into several intensity classes, this score is the negative natural log probability that the predicted peaks matched to experimental peaks by random chance." [PSI:MS]
+synonym: "Pepitome:MVH" EXACT []
+synonym: "TagRecon:MVH" EXACT []
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 
 [Term]
 id: MS:1001590
 name: MyriMatch:mzFidelity
 def: "The negative natural log probability that predicted peaks match to experimental peaks by random chance by scoring the m/z delta of the matches in a multinomial distribution." [PSI:MS]
+synonym: "Pepitome:mzFidelity" EXACT []
+synonym: "TagRecon:mzFidelity" EXACT []
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 
 [Term]
@@ -9798,7 +10085,6 @@ name: anchor protein
 def: "A representative protein selected from a set of sequence same-set or spectrum same-set proteins." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001101 ! protein group or subset relationship
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001592
@@ -9806,7 +10092,6 @@ name: family member protein
 def: "A protein with significant homology to another protein, but some distinguishing peptide matches." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001101 ! protein group or subset relationship
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001593
@@ -9820,7 +10105,6 @@ name: sequence same-set protein
 def: "A protein which is indistinguishable or equivalent to another protein, having matches to an identical set of peptide sequences." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001101 ! protein group or subset relationship
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001595
@@ -9828,7 +10112,6 @@ name: spectrum same-set protein
 def: "A protein which is indistinguishable or equivalent to another protein, having matches to a set of peptide sequences that cannot be distinguished using the evidence in the mass spectra." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001101 ! protein group or subset relationship
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001596
@@ -9836,7 +10119,6 @@ name: sequence sub-set protein
 def: "A protein with a sub-set of the peptide sequence matches for another protein, and no distinguishing peptide matches." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001101 ! protein group or subset relationship
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001597
@@ -9844,7 +10126,6 @@ name: spectrum sub-set protein
 def: "A protein with a sub-set of the matched spectra for another protein, where the matches cannot be distinguished using the evidence in the mass spectra, and no distinguishing peptide matches." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001101 ! protein group or subset relationship
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001598
@@ -9852,7 +10133,6 @@ name: sequence subsumable protein
 def: "A sequence same-set or sequence sub-set protein where the matches are distributed across two or more proteins." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001101 ! protein group or subset relationship
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001599
@@ -9860,7 +10140,6 @@ name: spectrum subsumable protein
 def: "A spectrum same-set or spectrum sub-set protein where the matches are distributed across two or more proteins." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001101 ! protein group or subset relationship
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001600
@@ -9868,39 +10147,42 @@ name: protein inference confidence category
 def: "Confidence category of inferred protein (conclusive, non conclusive, ambiguous group or indistinguishable)." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001101 ! protein group or subset relationship
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001601
 name: ProteomeDiscoverer:Spectrum Files:Raw File names
 def: "OBSOLETE Name and location of the .raw file or files." [PSI:MS]
+comment: This term was made obsolete because it's recommended to use one of the 'mass spectrometer file format' terms (MS:1000560) instead.
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
+is_obsolete: true
 
 [Term]
 id: MS:1001602
 name: ProteomeDiscoverer:SRF File Selector:SRF File Path
 def: "OBSOLETE Path and name of the .srf (SEQUEST Result Format) file." [PSI:MS]
+comment: This term was made obsolete. Use attribute in mzIdentML / mzQuantML instead.
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
+is_obsolete: true
 
 [Term]
 id: MS:1001603
 name: ProteomeDiscoverer:Spectrum Selector:Ionization Source
 def: "OBSOLETE Ionization source (electro-, nano-, thermospray, electron impact, APCI, MALDI, FAB etc)." [PSI:MS]
+comment: This term was made obsolete because it's recommended to use one of the 'inlet type' (MS:1000007) or 'ionization type' (MS:1000008) terms instead.
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
+is_obsolete: true
 
 [Term]
 id: MS:1001604
 name: ProteomeDiscoverer:Activation Type
 def: "OBSOLETE Fragmentation method used (CID, MPD, ECD, PQD, ETD, HCD, Any)." [PSI:MS]
+comment: This term was made obsolete because it's recommended to use one of the 'ionization type' terms (MS:1000008) instead.
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
+is_obsolete: true
 
 [Term]
 id: MS:1001605
@@ -9908,15 +10190,15 @@ name: ProteomeDiscoverer:Spectrum Selector:Lower RT Limit
 def: "Lower retention-time limit." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001606
 name: ProteomeDiscoverer:Mass Analyzer
 def: "OBSOLETE Type of mass spectrometer used (ITMS, FTMS, TOFMS, SQMS, TQMS, SectorMS)." [PSI:MS]
+comment: This term was made obsolete because it's recommended to use mass analyzer type (MS:1000443) instead.
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
+is_obsolete: true
 
 [Term]
 id: MS:1001607
@@ -9924,7 +10206,6 @@ name: ProteomeDiscoverer:Max Precursor Mass
 def: "Maximum mass limit of a singly charged precursor ion." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001608
@@ -9932,7 +10213,6 @@ name: ProteomeDiscoverer:Min Precursor Mass
 def: "Minimum mass limit of a singly charged precursor ion." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001609
@@ -9940,23 +10220,24 @@ name: ProteomeDiscoverer:Spectrum Selector:Minimum Peak Count
 def: "Minimum number of peaks in a tandem mass spectrum that is allowed to pass the filter and to be subjected to further processing in the workflow." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001610
 name: ProteomeDiscoverer:MS Order
 def: "OBSOLETE Level of the mass spectrum (MS2 ... MS10)." [PSI:MS]
+comment: This term was made obsolete because it's recommended to use MS1 spectrum (MS:1000579) or MSn spectrum (MS:1000580) instead.
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
+is_obsolete: true
 
 [Term]
 id: MS:1001611
 name: ProteomeDiscoverer:Polarity Mode
 def: "OBSOLETE Polarity mode (positive or negative)." [PSI:MS]
+comment: This term was made obsolete because it's recommended to use scan polarity (MS:1000465) instead.
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
+is_obsolete: true
 
 [Term]
 id: MS:1001612
@@ -9964,7 +10245,6 @@ name: ProteomeDiscoverer:Spectrum Selector:Precursor Selection
 def: "Determines which precursor mass to use for a given MSn scan. This option applies only to higher-order MSn scans (n >= 3)." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001613
@@ -9972,15 +10252,15 @@ name: ProteomeDiscoverer:SN Threshold
 def: "Signal-to-Noise ratio below which peaks are removed." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001614
 name: ProteomeDiscoverer:Scan Type
 def: "OBSOLETE Scan type for the precursor ion (full, Single Ion Monitoring (SIM), Single Reaction Monitoring (SRM))." [PSI:MS]
+comment: This term was made obsolete because it's recommended to use MS1 spectrum (MS:1000579), MSn spectrum (MS:1000580), CRM spectrum (MS:1000581), SIM spectrum (MS:1000582) or SRM spectrum (MS:1000583) instead.
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
+is_obsolete: true
 
 [Term]
 id: MS:1001615
@@ -9988,7 +10268,6 @@ name: ProteomeDiscoverer:Spectrum Selector:Total Intensity Threshold
 def: "Used to filter out tandem mass spectra that have a total intensity current(sum of the intensities of all peaks in a spectrum) below the specified value." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001616
@@ -9996,7 +10275,6 @@ name: ProteomeDiscoverer:Spectrum Selector:Unrecognized Activation Type Replacem
 def: "Specifies the fragmentation method to use in the search algorithm if it is not included in the scan header." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001617
@@ -10004,7 +10282,6 @@ name: ProteomeDiscoverer:Spectrum Selector:Unrecognized Charge Replacements
 def: "Specifies the charge state of the precursor ions, if it is not defined in the scan header." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001618
@@ -10012,7 +10289,6 @@ name: ProteomeDiscoverer:Spectrum Selector:Unrecognized Mass Analyzer Replacemen
 def: "Specifies the mass spectrometer to use to produce the spectra, if it is not included in the scan header." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001619
@@ -10020,7 +10296,6 @@ name: ProteomeDiscoverer:Spectrum Selector:Unrecognized MS Order Replacements
 def: "Specifies the MS scan order used to produce the product spectra, if it is not included in the scan header." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001620
@@ -10028,7 +10303,6 @@ name: ProteomeDiscoverer:Spectrum Selector:Unrecognized Polarity Replacements
 def: "Specifies the polarity of the ions monitored if it is not included in the scan header." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001621
@@ -10036,7 +10310,6 @@ name: ProteomeDiscoverer:Spectrum Selector:Upper RT Limit
 def: "Upper retention-time limit." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001622
@@ -10044,7 +10317,6 @@ name: ProteomeDiscoverer:Non-Fragment Filter:Mass Window Offset
 def: "Specifies the size of the mass-to-charge ratio (m/z) window in daltons used to remove precursors." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001623
@@ -10052,7 +10324,6 @@ name: ProteomeDiscoverer:Non-Fragment Filter:Maximum Neutral Loss Mass
 def: "Maximum allowed mass of a neutral loss." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001624
@@ -10060,7 +10331,6 @@ name: ProteomeDiscoverer:Non-Fragment Filter:Remove Charge Reduced Precursor
 def: "Determines whether the charge-reduced precursor peaks found in an ETD or ECD spectrum are removed." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001625
@@ -10068,7 +10338,6 @@ name: ProteomeDiscoverer:Non-Fragment Filter:Remove Neutral Loss Peaks
 def: "Determines whether neutral loss peaks are removed from ETD and ECD spectra." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001626
@@ -10076,7 +10345,6 @@ name: ProteomeDiscoverer:Non-Fragment Filter:Remove Only Known Masses
 def: "Determines whether overtone peaks are removed from LTQ FT or LTQ FT Ultra ECD spectra." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001627
@@ -10084,7 +10352,6 @@ name: ProteomeDiscoverer:Non-Fragment Filter:Remove Precursor Overtones
 def: "Determines whether precursor overtone peaks in the spectrum are removed from the input spectrum." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001628
@@ -10092,7 +10359,6 @@ name: ProteomeDiscoverer:Non-Fragment Filter:Remove Precursor Peak
 def: "Determines whether precursor artifact peaks from the MS2 input spectra are removed." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001629
@@ -10100,7 +10366,6 @@ name: ProteomeDiscoverer:Spectrum Grouper:Allow Mass Analyzer Mismatch
 def: "Determines whether the fragment spectrum for scans with the same precursor mass is grouped, regardless of mass analyzer and activation type." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001630
@@ -10108,15 +10373,15 @@ name: ProteomeDiscoverer:Spectrum Grouper:Allow MS Order Mismatch
 def: "Determines whether spectra from different MS order scans can be grouped together." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001631
 name: ProteomeDiscoverer:Spectrum Grouper:Max RT Difference
 def: "OBSOLETE Chromatographic window where precursors to be grouped must reside to be considered the same species." [PSI:MS]
+comment: This term was made obsolete because it's recommended to use retention time window width (MS:1001907) instead.
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
+is_obsolete: true
 
 [Term]
 id: MS:1001632
@@ -10124,7 +10389,6 @@ name: ProteomeDiscoverer:Spectrum Grouper:Precursor Mass Criterion
 def: "Groups spectra measured within the given mass and retention-time tolerances into a single spectrum for analysis." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001633
@@ -10132,15 +10396,15 @@ name: ProteomeDiscoverer:Xtract:Highest Charge
 def: "Highest charge state that is allowed for the deconvolution of multiply charged data." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001634
 name: ProteomeDiscoverer:Xtract:Highest MZ
 def: "OBSOLETE Highest mass-to-charge (mz) value for spectral peaks in the measured spectrum that are considered for Xtract." [PSI:MS]
+comment: This term was made obsolete because it's recommended to use scan window upper limit (MS:1000500) instead.
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
+is_obsolete: true
 
 [Term]
 id: MS:1001635
@@ -10148,15 +10412,15 @@ name: ProteomeDiscoverer:Xtract:Lowest Charge
 def: "Lowest charge state that is allowed for the deconvolution of multiply charged data." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001636
 name: ProteomeDiscoverer:Xtract:Lowest MZ
 def: "OBSOLETE Lowest mass-to-charge (mz) value for spectral peaks in the measured spectrum that are considered for Xtract." [PSI:MS]
+comment: This term was made obsolete because it's recommended to use scan window lower limit (MS:1000501) instead.
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
+is_obsolete: true
 
 [Term]
 id: MS:1001637
@@ -10164,7 +10428,6 @@ name: ProteomeDiscoverer:Xtract:Monoisotopic Mass Only
 def: "Determines whether the isotopic pattern, i.e. all isotopes of a mass are removed from the spectrum." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001638
@@ -10172,7 +10435,6 @@ name: ProteomeDiscoverer:Xtract:Overlapping Remainder
 def: "Fraction of the more abundant peak that an overlapping multiplet must exceed in order to be processed (deconvoluted)." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001639
@@ -10180,7 +10442,6 @@ name: ProteomeDiscoverer:Xtract:Required Fitting Accuracy
 def: "Accuracy required for a pattern fit to be considered valid." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001640
@@ -10188,7 +10449,6 @@ name: ProteomeDiscoverer:Xtract:Resolution At 400
 def: "Resolution at mass 400." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001641
@@ -10196,7 +10456,6 @@ name: ProteomeDiscoverer:Lowest Charge State
 def: "Minimum charge state below which peptides are filtered out." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001642
@@ -10204,7 +10463,6 @@ name: ProteomeDiscoverer:Highest Charge State
 def: "Maximum charge above which peptides are filtered out." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001643
@@ -10212,7 +10470,6 @@ name: ProteomeDiscoverer:Spectrum Score Filter:Let Pass Above Scores
 def: "Determines whether spectra with scores above the threshold score are retained rather than filtered out." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001644
@@ -10220,7 +10477,6 @@ name: ProteomeDiscoverer:Dynamic Modification
 def: "Determine dynamic post-translational modifications (PTMs)." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001645
@@ -10228,15 +10484,15 @@ name: ProteomeDiscoverer:Static Modification
 def: "Static Modification to all occurrences of a named amino acid." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001646
 name: ProteomeDiscoverer:Mascot:Decoy Search
 def: "OBSOLETE Determines whether the Proteome Discoverer application searches an additional decoy database." [PSI:MS]
+comment: This term was made obsolete because it's recommended to use quality estimation with decoy database (MS:1001194) instead.
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
+is_obsolete: true
 
 [Term]
 id: MS:1001647
@@ -10244,7 +10500,6 @@ name: ProteomeDiscoverer:Mascot:Error tolerant Search
 def: "Determines whether to search error-tolerant." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001648
@@ -10252,7 +10507,6 @@ name: ProteomeDiscoverer:Mascot:Max MGF File Size
 def: "Maximum size of the .mgf (Mascot Generic Format) file in MByte." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001649
@@ -10260,7 +10514,6 @@ name: ProteomeDiscoverer:Mascot:Mascot Server URL
 def: "URL (Uniform resource Locator) of the Mascot server." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001650
@@ -10268,7 +10521,6 @@ name: ProteomeDiscoverer:Mascot:Number of attempts to submit the search
 def: "Number of attempts to submit the Mascot search." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001651
@@ -10276,15 +10528,15 @@ name: ProteomeDiscoverer:Mascot:X Static Modification
 def: "Number of attempts to submit the Mascot search." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001652
 name: ProteomeDiscoverer:Mascot:User Name
 def: "OBSOLETE Name of the user submitting the Mascot search." [PSI:MS]
+comment: This term was made obsolete because it's recommended to use researcher (MS:1001271) instead.
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
+is_obsolete: true
 
 [Term]
 id: MS:1001653
@@ -10292,23 +10544,24 @@ name: ProteomeDiscoverer:Mascot:Time interval between attempts to submit a searc
 def: "Time interval between attempts to submit a search in seconds." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001654
 name: ProteomeDiscoverer:Enzyme Name
 def: "OBSOLETE Specifies the enzyme reagent used for protein digestion." [PSI:MS]
+comment: This term was made obsolete because it's recommended to use cleavage agent name (MS:1001045) instead.
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
+is_obsolete: true
 
 [Term]
 id: MS:1001655
 name: ProteomeDiscoverer:Fragment Mass Tolerance
 def: "OBSOLETE Mass tolerance used for matching fragment peaks in Da or mmu." [PSI:MS]
+comment: This term was made obsolete because it's recommended to use search tolerance minus value (MS:1001413) or search tolerance plus value (MS:1001412) instead.
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
+is_obsolete: true
 
 [Term]
 id: MS:1001656
@@ -10316,7 +10569,6 @@ name: Mascot:Instrument
 def: "Type of instrument used to acquire the data in the raw file." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002095 ! Mascot input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001657
@@ -10324,7 +10576,6 @@ name: ProteomeDiscoverer:Maximum Missed Cleavage Sites
 def: "Maximum number of missed cleavage sites to consider during the digest." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001658
@@ -10332,15 +10583,15 @@ name: ProteomeDiscoverer:Mascot:Peptide CutOff Score
 def: "Minimum score in the IonScore column that each peptide must exceed in order to be reported." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001659
 name: ProteomeDiscoverer:Precursor Mass Tolerance
 def: "OBSOLETE Mass window for which precursor ions are considered to be the same species." [PSI:MS]
+comment: This term was made obsolete because it's recommended to use search tolerance minus value (MS:1001413) or search tolerance plus value (MS:1001412) instead.
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
+is_obsolete: true
 
 [Term]
 id: MS:1001660
@@ -10348,15 +10599,15 @@ name: ProteomeDiscoverer:Mascot:Protein CutOff Score
 def: "Minimum protein score in the IonScore column that each protein must exceed in order to be reported." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001661
 name: ProteomeDiscoverer:Protein Database
 def: "OBSOLETE Database to use in the search (configured on the Mascot server)." [PSI:MS]
+comment: This term was made obsolete because it's recommended to use database name (MS:1001013) instead.
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
+is_obsolete: true
 
 [Term]
 id: MS:1001662
@@ -10364,7 +10615,6 @@ name: ProteomeDiscoverer:Mascot:Protein Relevance Factor
 def: "Specifies a factor that is used in calculating a threshold that determines whether a protein appears in the results report." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001663
@@ -10372,7 +10622,6 @@ name: ProteomeDiscoverer:Target FDR Relaxed
 def: "Specifies the relaxed target false discovery rate (FDR, 0.0 - 1.0) for peptide hits with moderate confidence." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001664
@@ -10380,31 +10629,33 @@ name: ProteomeDiscoverer:Target FDR Strict
 def: "Specifies the strict target false discovery rate (FDR, 0.0 - 1.0) for peptide hits with high confidence." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001665
 name: ProteomeDiscoverer:Mascot:Taxonomy
 def: "OBSOLETE Limits searches to entries from a particular species or group of species." [PSI:MS]
+comment: This term was made obsolete because it's recommended to use taxonomy: scientific name (MS:1001469) instead.
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
+is_obsolete: true
 
 [Term]
 id: MS:1001666
 name: ProteomeDiscoverer:Use Average Precursor Mass
 def: "OBSOLETE Use average mass for the precursor." [PSI:MS]
+comment: This term was made obsolete because it's recommended to use parent mass type average (MS:1001212) instead.
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
+is_obsolete: true
 
 [Term]
 id: MS:1001667
 name: Mascot:use MudPIT scoring
 def: "OBSOLETE Determines whether to use MudPIT or normal scoring." [PSI:MS]
+comment: This term was made obsolete because it's recommended to use Mascot:ProteinScoringMethod (MS:1001318) instead.
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002095 ! Mascot input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
+is_obsolete: true
 
 [Term]
 id: MS:1001668
@@ -10412,7 +10663,6 @@ name: ProteomeDiscoverer:Absolute XCorr Threshold
 def: "Minimum cross-correlation threshold that determines whether peptides in an .srf file are imported." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001669
@@ -10420,7 +10670,6 @@ name: ProteomeDiscoverer:SEQUEST:Calculate Probability Score
 def: "Determines whether to calculate a probability score for every peptide match." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001670
@@ -10428,7 +10677,6 @@ name: ProteomeDiscoverer:SEQUEST:CTerminal Modification
 def: "Dynamic C-terminal modification that is used during the search." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001671
@@ -10436,7 +10684,6 @@ name: ProteomeDiscoverer:SEQUEST:Fragment Ion Cutoff Percentage
 def: "Percentage of the theoretical ions that must be found in order for a peptide to be scored and retained." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001672
@@ -10444,7 +10691,6 @@ name: ProteomeDiscoverer:SEQUEST:Max Identical Modifications Per Peptide
 def: "Maximum number of identical modifications that a single peptide can have." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001673
@@ -10452,7 +10698,6 @@ name: ProteomeDiscoverer:Max Modifications Per Peptide
 def: "Maximum number of different modifications that a peptide can have, e.g. because of steric hindrance." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001674
@@ -10460,7 +10705,6 @@ name: ProteomeDiscoverer:SEQUEST:Maximum Peptides Considered
 def: "Maximum number of peptides that are searched and scored per spectrum." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001675
@@ -10468,7 +10712,6 @@ name: ProteomeDiscoverer:Maximum Peptides Output
 def: "Maximum number of peptide matches reported per spectrum." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001676
@@ -10476,7 +10719,6 @@ name: ProteomeDiscoverer:Maximum Protein References Per Peptide
 def: "Maximum number of proteins that a single identified peptide can be associated with during protein assembly." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001677
@@ -10484,7 +10726,6 @@ name: ProteomeDiscoverer:SEQUEST:NTerminal Modification
 def: "Dynamic N-terminal modification that is used during the search." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001678
@@ -10492,7 +10733,6 @@ name: ProteomeDiscoverer:Peptide CTerminus
 def: "Static modification for the C terminal of the peptide used during the search." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001679
@@ -10500,7 +10740,6 @@ name: ProteomeDiscoverer:Peptide NTerminus
 def: "Static modification for the N terminal of the peptide used during the search." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001680
@@ -10508,7 +10747,6 @@ name: ProteomeDiscoverer:SEQUEST:Peptide Relevance Factor
 def: "Specifies a factor to apply to the protein score." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001681
@@ -10516,15 +10754,15 @@ name: ProteomeDiscoverer:Protein Relevance Threshold
 def: "Specifies a peptide threshold that determines whether the protein that it is a part of is scored and retained in the report." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001682
 name: ProteomeDiscoverer:Search Against Decoy Database
 def: "OBSOLETE Determines whether the Proteome Discoverer application searches against a decoy database." [PSI:MS]
+comment: This term was made obsolete because it's recommended to use quality estimation with decoy database (MS:1001194) instead.
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
+is_obsolete: true
 
 [Term]
 id: MS:1001683
@@ -10532,7 +10770,6 @@ name: ProteomeDiscoverer:SEQUEST:Use Average Fragment Masses
 def: "Use average masses for the fragments." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001684
@@ -10540,7 +10777,6 @@ name: ProteomeDiscoverer:Use Neutral Loss a Ions
 def: "Determines whether a ions with neutral loss are used for spectrum matching." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001685
@@ -10548,7 +10784,6 @@ name: ProteomeDiscoverer:Use Neutral Loss b Ions
 def: "Determines whether b ions with neutral loss are used for spectrum matching." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001686
@@ -10556,7 +10791,6 @@ name: ProteomeDiscoverer:Use Neutral Loss y Ions
 def: "Determines whether y ions with neutral loss are used for spectrum matching." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001687
@@ -10564,7 +10798,6 @@ name: ProteomeDiscoverer:Use Neutral Loss z Ions
 def: "Determines whether z ions with neutral loss are used for spectrum matching." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001688
@@ -10572,7 +10805,6 @@ name: ProteomeDiscoverer:SEQUEST:Weight of a Ions
 def: "Uses a ions for spectrum matching with this relative factor." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001689
@@ -10580,7 +10812,6 @@ name: ProteomeDiscoverer:SEQUEST:Weight of b Ions
 def: "Uses b ions for spectrum matching with this relative factor." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001690
@@ -10588,7 +10819,6 @@ name: ProteomeDiscoverer:SEQUEST:Weight of c Ions
 def: "Uses c ions for spectrum matching with this relative factor." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001691
@@ -10596,7 +10826,6 @@ name: ProteomeDiscoverer:SEQUEST:Weight of d Ions
 def: "Uses c ions for spectrum matching with this relative factor." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001692
@@ -10604,7 +10833,6 @@ name: ProteomeDiscoverer:SEQUEST:Weight of v Ions
 def: "Uses c ions for spectrum matching with this relative factor." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001693
@@ -10612,7 +10840,6 @@ name: ProteomeDiscoverer:SEQUEST:Weight of w Ions
 def: "Uses c ions for spectrum matching with this relative factor." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001694
@@ -10620,7 +10847,6 @@ name: ProteomeDiscoverer:SEQUEST:Weight of x Ions
 def: "Uses x ions for spectrum matching with this relative factor." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001695
@@ -10628,7 +10854,6 @@ name: ProteomeDiscoverer:SEQUEST:Weight of y Ions
 def: "Uses y ions for spectrum matching with this relative factor." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001696
@@ -10636,7 +10861,6 @@ name: ProteomeDiscoverer:SEQUEST:Weight of z Ions
 def: "Uses z ions for spectrum matching with this relative factor." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001697
@@ -10644,7 +10868,6 @@ name: ProteomeDiscoverer:ZCore:Protein Score Cutoff
 def: "Sets a minimum protein score that each protein must exceed in order to be reported." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001698
@@ -10652,7 +10875,6 @@ name: ProteomeDiscoverer:Reporter Ions Quantizer:Integration Method
 def: "Specifies which peak to select if more than one peak is found inside the integration window." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001699
@@ -10660,7 +10882,6 @@ name: ProteomeDiscoverer:Reporter Ions Quantizer:Integration Window Tolerance
 def: "Specifies the mass-to-charge window that enables one to look for the reporter peaks." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001700
@@ -10668,15 +10889,15 @@ name: ProteomeDiscoverer:Reporter Ions Quantizer:Quantitation Method
 def: "Quantitation method for isobarically labeled quantitation." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001701
 name: ProteomeDiscoverer:Spectrum Exporter:Export Format
 def: "OBSOLETE Format of the exported spectra (dta, mgf or mzData)." [PSI:MS]
+comment: This term was made obsolete because it's recommended to use one of the 'mass spectrometer file format' terms (MS:1000560) instead.
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
+is_obsolete: true
 
 [Term]
 id: MS:1001702
@@ -10684,7 +10905,6 @@ name: ProteomeDiscoverer:Spectrum Exporter:File name
 def: "Name of the output file that contains the exported data." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001703
@@ -10692,7 +10912,6 @@ name: ProteomeDiscoverer:Search Modifications Only For Identified Proteins
 def: "Influences the modifications search." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001704
@@ -10700,7 +10919,6 @@ name: ProteomeDiscoverer:SEQUEST:Std High Confidence XCorr Charge1
 def: "Standard high confidence XCorr parameter for charge = 1." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001705
@@ -10708,7 +10926,6 @@ name: ProteomeDiscoverer:SEQUEST:Std High Confidence XCorr Charge2
 def: "Standard high confidence XCorr parameter for charge = 2." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001706
@@ -10716,7 +10933,6 @@ name: ProteomeDiscoverer:SEQUEST:Std High Confidence XCorr Charge3
 def: "Standard high confidence XCorr parameter for charge = 3." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001707
@@ -10724,7 +10940,6 @@ name: ProteomeDiscoverer:SEQUEST:Std High Confidence XCorr Charge4
 def: "Standard high confidence XCorr parameter for charge >= 4." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001708
@@ -10732,7 +10947,6 @@ name: ProteomeDiscoverer:SEQUEST:Std Medium Confidence XCorr Charge1
 def: "Standard medium confidence XCorr parameter for charge = 1." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001709
@@ -10740,7 +10954,6 @@ name: ProteomeDiscoverer:SEQUEST:Std Medium Confidence XCorr Charge2
 def: "Standard medium confidence XCorr parameter for charge = 2." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001710
@@ -10748,7 +10961,6 @@ name: ProteomeDiscoverer:SEQUEST:Std Medium Confidence XCorr Charge3
 def: "Standard medium confidence XCorr parameter for charge = 3." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001711
@@ -10756,7 +10968,6 @@ name: ProteomeDiscoverer:SEQUEST:Std Medium Confidence XCorr Charge4
 def: "Standard medium confidence XCorr parameter for charge >= 4." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001712
@@ -10764,7 +10975,6 @@ name: ProteomeDiscoverer:SEQUEST:FT High Confidence XCorr Charge1
 def: "FT high confidence XCorr parameter for charge = 1." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001713
@@ -10772,7 +10982,6 @@ name: ProteomeDiscoverer:SEQUEST:FT High Confidence XCorr Charge2
 def: "FT high confidence XCorr parameter for charge = 2." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001714
@@ -10780,7 +10989,6 @@ name: ProteomeDiscoverer:SEQUEST:FT High Confidence XCorr Charge3
 def: "FT high confidence XCorr parameter for charge = 3." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001715
@@ -10788,7 +10996,6 @@ name: ProteomeDiscoverer:SEQUEST:FT High Confidence XCorr Charge4
 def: "FT high confidence XCorr parameter for charge >= 4." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001716
@@ -10796,7 +11003,6 @@ name: ProteomeDiscoverer:SEQUEST:FT Medium Confidence XCorr Charge1
 def: "FT medium confidence XCorr parameter for charge = 1." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001717
@@ -10804,7 +11010,6 @@ name: ProteomeDiscoverer:SEQUEST:FT Medium Confidence XCorr Charge2
 def: "FT medium confidence XCorr parameter for charge = 2." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001718
@@ -10812,7 +11017,6 @@ name: ProteomeDiscoverer:SEQUEST:FT Medium Confidence XCorr Charge3
 def: "FT medium confidence XCorr parameter for charge = 3." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001719
@@ -10820,39 +11024,42 @@ name: ProteomeDiscoverer:SEQUEST:FT Medium Confidence XCorr Charge4
 def: "FT medium confidence XCorr parameter for charge >= 4." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001720
 name: ProteomeDiscoverer:1. Dynamic Modification
 def: "OBSOLETE ProteomeDiscoverer's 1st dynamic post-translational modification (PTM) input parameter." [PSI:PI]
+comment: This term was made obsolete because it's recommended to use ProteomeDiscoverer:Dynamic Modification (MS:1001644) instead.
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
+is_obsolete: true
 
 [Term]
 id: MS:1001721
 name: ProteomeDiscoverer:2. Dynamic Modification
 def: "OBSOLETE ProteomeDiscoverer's 2nd dynamic post-translational modification (PTM) input parameter." [PSI:PI]
+comment: This term was made obsolete because it's recommended to use ProteomeDiscoverer:Dynamic Modification (MS:1001644) instead.
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
+is_obsolete: true
 
 [Term]
 id: MS:1001722
 name: ProteomeDiscoverer:3. Dynamic Modification
 def: "OBSOLETE ProteomeDiscoverer's 3rd dynamic post-translational modification (PTM) input parameter." [PSI:PI]
+comment: This term was made obsolete because it's recommended to use ProteomeDiscoverer:Dynamic Modification (MS:1001644) instead.
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
+is_obsolete: true
 
 [Term]
 id: MS:1001723
 name: ProteomeDiscoverer:4. Dynamic Modification
 def: "OBSOLETE ProteomeDiscoverer's 4th dynamic post-translational modification (PTM) input parameter." [PSI:PI]
+comment: This term was made obsolete because it's recommended to use ProteomeDiscoverer:Dynamic Modification (MS:1001644) instead.
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
+is_obsolete: true
 
 [Term]
 id: MS:1001724
@@ -10860,7 +11067,6 @@ name: ProteomeDiscoverer:Static Modification for X
 def: "Static Modification for X." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001725
@@ -10868,7 +11074,6 @@ name: ProteomeDiscoverer:Initial minimal peptide probability
 def: "Minimal initial peptide probability to contribute to analysis." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001726
@@ -10876,7 +11081,6 @@ name: ProteomeDiscoverer:Minimal peptide probability
 def: "Minimum adjusted peptide probability contributing to protein probability." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001727
@@ -10884,7 +11088,6 @@ name: ProteomeDiscoverer:Minimal peptide weight
 def: "Minimum peptide weight contributing to protein probability." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001728
@@ -10892,7 +11095,6 @@ name: ProteomeDiscoverer:Number of input1 spectra
 def: "Number of spectra from 1+ precursor ions." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001729
@@ -10900,7 +11102,6 @@ name: ProteomeDiscoverer:Number of input2 spectra
 def: "Number of spectra from 2+ precursor ions." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001730
@@ -10908,7 +11109,6 @@ name: ProteomeDiscoverer:Number of input3 spectra
 def: "Number of spectra from 3+ precursor ions." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001731
@@ -10916,7 +11116,6 @@ name: ProteomeDiscoverer:Number of input4 spectra
 def: "Number of spectra from 4+ precursor ions." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001732
@@ -10924,7 +11123,6 @@ name: ProteomeDiscoverer:Number of input5 spectra
 def: "Number of spectra from 5+ precursor ions." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001733
@@ -10932,23 +11130,24 @@ name: ProteomeDiscoverer:Number of predicted correct proteins
 def: "Total number of predicted correct protein ids (sum of probabilities)." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001734
 name: ProteomeDiscoverer:Organism
 def: "OBSOLETE Sample organism (used for annotation purposes)." [PSI:MS]
+comment: This term was made obsolete because it's recommended to use taxonomy: scientific name (MS:1001469) instead.
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
+is_obsolete: true
 
 [Term]
 id: MS:1001735
 name: ProteomeDiscoverer:Reference Database
 def: "OBSOLETE Full path database name." [PSI:MS]
+comment: This term was made obsolete. Use attribute in mzIdentML / mzQuantML instead.
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
+is_obsolete: true
 
 [Term]
 id: MS:1001736
@@ -10956,31 +11155,33 @@ name: ProteomeDiscoverer:Residue substitution list
 def: "Residues considered equivalent when comparing peptides." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001737
 name: ProteomeDiscoverer:Source file extension
 def: "OBSOLETE File type (if not pepXML)." [PSI:MS]
+comment: This term was made obsolete because it's recommended to use mass spectrometer file format (MS:1000560) instead.
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
+is_obsolete: true
 
 [Term]
 id: MS:1001738
 name: ProteomeDiscoverer:Source Files
 def: "OBSOLETE Input pepXML files." [PSI:MS]
+comment: This term was made obsolete because it's recommended to use pepXML file (MS:1001421) instead.
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
+is_obsolete: true
 
 [Term]
 id: MS:1001739
 name: ProteomeDiscoverer:Source Files old
 def: "OBSOLETE Input pepXML files (old)." [PSI:MS]
+comment: This term was made obsolete because it's recommended to use pepXML file (MS:1001421) instead.
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
+is_obsolete: true
 
 [Term]
 id: MS:1001740
@@ -10988,7 +11189,6 @@ name: ProteomeDiscoverer:WinCyg reference database
 def: "Windows full path for database." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001741
@@ -10996,7 +11196,6 @@ name: ProteomeDiscoverer:WinCyg source files
 def: "Windows pepXML file names." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001742
@@ -11010,7 +11209,6 @@ name: ProteomeDiscoverer:Mascot:Weight of A Ions
 def: "Determines if to use A ions for spectrum matching." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001744
@@ -11018,7 +11216,6 @@ name: ProteomeDiscoverer:Mascot:Weight of B Ions
 def: "Determines if to use B ions for spectrum matching." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001745
@@ -11026,7 +11223,6 @@ name: ProteomeDiscoverer:Mascot:Weight of C Ions
 def: "Determines if to use C ions for spectrum matching." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001746
@@ -11034,7 +11230,6 @@ name: ProteomeDiscoverer:Mascot:Weight of D Ions
 def: "Determines if to use D ions for spectrum matching." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001747
@@ -11042,7 +11237,6 @@ name: ProteomeDiscoverer:Mascot:Weight of V Ions
 def: "Determines if to use V ions for spectrum matching." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001748
@@ -11050,7 +11244,6 @@ name: ProteomeDiscoverer:Mascot:Weight of W Ions
 def: "Determines if to use W ions for spectrum matching." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001749
@@ -11058,7 +11251,6 @@ name: ProteomeDiscoverer:Mascot:Weight of X Ions
 def: "Determines if to use X ions for spectrum matching." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001750
@@ -11066,7 +11258,6 @@ name: ProteomeDiscoverer:Mascot:Weight of Y Ions
 def: "Determines if to use Y ions for spectrum matching." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001751
@@ -11074,7 +11265,6 @@ name: ProteomeDiscoverer:Mascot:Weight of Z Ions
 def: "Determines if to use z ions for spectrum matching." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001752
@@ -11082,7 +11272,6 @@ name: ProteomeDiscoverer:Spectrum Selector:Use New Precursor Reevaluation
 def: "Determines if to use precursor reevaluation." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001753
@@ -11090,7 +11279,6 @@ name: ProteomeDiscoverer:Spectrum Selector:SN Threshold FTonly
 def: "Signal-to-Noise ratio below which peaks are removed (in FT mode only)." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001754
@@ -11098,7 +11286,6 @@ name: ProteomeDiscoverer:Mascot:Please Do not Touch this
 def: "Unknown Mascot parameter which ProteomeDiscoverer uses for mascot searches." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001755
@@ -11106,7 +11293,6 @@ name: contact phone number
 def: "Phone number of the contact person or organization." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000585 ! contact attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001756
@@ -11114,7 +11300,6 @@ name: contact fax number
 def: "Fax number for the contact person or organization." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000585 ! contact attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001757
@@ -11122,7 +11307,6 @@ name: contact toll-free phone number
 def: "Toll-free phone number of the contact person or organization." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000585 ! contact attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001758
@@ -11130,7 +11314,6 @@ name: Mascot:SigThresholdType
 def: "Significance threshold type used in Mascot reporting (either 'identity' or 'homology')." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002095 ! Mascot input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001759
@@ -11138,7 +11321,6 @@ name: Mascot:ProteinGrouping
 def: "Strategy used by Mascot to group proteins with same peptide matches (one of 'none', 'Occam's razor' or 'family clustering')." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002095 ! Mascot input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001760
@@ -11146,7 +11328,6 @@ name: Percolator:features
 def: "List of Percolator features that were used in processing the peptide matches. Typical Percolator features are 'retentionTime', 'dM', 'mScore', 'lgDScore', 'mrCalc', 'charge' and 'dMppm'." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002107 ! Percolator input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001761
@@ -11346,7 +11527,6 @@ name: Mascot:PreferredTaxonomy
 def: "NCBI TaxID taxonomy ID to prefer when two or more proteins match the same set of peptides or when protein entry in database represents multiple sequences." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002095 ! Mascot input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001795
@@ -11368,6 +11548,9 @@ is_a: MS:1001457 ! data processing software
 id: MS:1001797
 name: travelling wave ion mobility mass spectrometer
 def: "OBSOLETE An ion mobility mass spectrometry technique based on the superimposition of travelling voltage waves on a radially-confining RF voltage in a gas-filled, stacked-ring ion guide." [PSI:MS]
+comment: This child of the former purgatory term ion mobility spectrometry was made obsolete.
+synonym: "TWIMS" EXACT []
+is_obsolete: true
 
 [Term]
 id: MS:1001798
@@ -11438,7 +11621,6 @@ name: technical replicate
 def: "The study variable is 'technical replicate'. The string value denotes the category of technical replicate, e.g. 'run generated from same sample'." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001807 ! study variable attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001809
@@ -11476,7 +11658,6 @@ name: generic experimental condition
 def: "The experimental condition is given in the value of this term." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001807 ! study variable attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001815
@@ -11484,7 +11665,6 @@ name: time series, time point X
 def: "The experimental design followed a time series design. The time point of this run is given in the value of this term." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1001807 ! study variable attribute
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001816
@@ -11492,7 +11672,6 @@ name: dilution series, concentration X
 def: "The experimental design followed a dilution series design. The concentration of this run is given in the value of this term." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001807 ! study variable attribute
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001817
@@ -11572,7 +11751,6 @@ name: SRM transition ID
 def: "Identifier for an SRM transition in an external document describing additional information about the transition." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001828 ! feature attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001830
@@ -11593,7 +11771,6 @@ name: quantitation software comment or customizations
 def: "Quantitation software comment or any customizations to the default setup of the software." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001129 ! quantification information
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001833
@@ -11643,7 +11820,6 @@ name: LC-MS feature intensity
 def: "Maximum peak intensity of the LC-MS feature." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002735 ! feature-level quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001841
@@ -11651,7 +11827,6 @@ name: LC-MS feature volume
 def: "Real (intensity times area) volume of the LC-MS feature." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002735 ! feature-level quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001842
@@ -11659,7 +11834,6 @@ name: sequence-level spectral count
 def: "The number of MS2 spectra identified for a raw peptide sequence without PTMs and charge state in spectral counting." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002737 ! peptide-level quantification datatype
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001843
@@ -11667,7 +11841,6 @@ name: MS1 feature maximum intensity
 def: "Maximum intensity of MS1 feature." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002735 ! feature-level quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001844
@@ -11675,15 +11848,15 @@ name: MS1 feature area
 def: "Area of MS1 feature." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002735 ! feature-level quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001845
 name: peak area
 def: "OBSOLETE Area of MS1 peak (e.g. SILAC, 15N)." [PSI:PI]
+comment: This term was made obsolete because it was a duplication of MS:1001844.
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
+is_obsolete: true
 
 [Term]
 id: MS:1001846
@@ -11691,7 +11864,6 @@ name: isotopic pattern area
 def: "Area of all peaks belonging to the isotopic pattern of light or heavy peak (e.g. 15N)." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001847
@@ -11699,7 +11871,6 @@ name: reporter ion intensity
 def: "Intensity of MS2 reporter ion (e.g. iTraq)." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001848
@@ -11711,9 +11882,10 @@ is_a: MS:1002066 ! ratio calculation method
 id: MS:1001849
 name: sum of MatchedFeature values
 def: "OBSOLETE Peptide quantification value calculated as sum of MatchedFeature quantification values." [PSI:PI]
+comment: This term was made obsolete because the concept MatchedFeature was dropped.
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002735 ! feature-level quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
+is_obsolete: true
 
 [Term]
 id: MS:1001850
@@ -11721,7 +11893,6 @@ name: normalized peptide value
 def: "Normalized peptide value." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002737 ! peptide-level quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001851
@@ -11729,7 +11900,6 @@ name: protein value: sum of peptide values
 def: "Protein quantification value calculated as sum of peptide values." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002738 ! protein-level quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001852
@@ -11737,7 +11907,6 @@ name: normalized protein value
 def: "Normalized protein value." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002738 ! protein-level quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001853
@@ -11745,7 +11914,6 @@ name: max fold change
 def: "Global datatype: Maximum of all pair-wise fold changes of group means (e.g. Progenesis)." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001854
@@ -11753,7 +11921,6 @@ name: ANOVA p-value
 def: "Global datatype: p-value of ANOVA of group means (e.g. Progenesis)." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002072 ! p-value
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001855
@@ -11761,7 +11928,6 @@ name: t-test p-value
 def: "P-value of t-Test of two groups." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002072 ! p-value
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001856
@@ -11769,7 +11935,6 @@ name: reporter ion raw value
 def: "Intensity (or area) of MS2 reporter ion (e.g. iTraq)." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001857
@@ -11777,7 +11942,6 @@ name: reporter ion normalized value
 def: "Normalized value of MS2 reporter ion (e.g. iTraq)." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001858
@@ -11785,7 +11949,6 @@ name: XIC area
 def: "Area of the extracted ion chromatogram (e.g. of a transition in SRM)." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001859
@@ -11793,7 +11956,6 @@ name: normalized XIC area
 def: "Normalized area of the extracted ion chromatogram (e.g. of a transition in SRM)." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001860
@@ -11801,7 +11963,6 @@ name: protein value: mean of peptide ratios
 def: "Protein quantification value calculated as mean of peptide ratios." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002738 ! protein-level quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001861
@@ -11852,7 +12013,6 @@ def: "Estimation of the q-value for distinct peptides once redundant identificat
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002484 ! peptide-level statistical threshold
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001869
@@ -11861,7 +12021,6 @@ def: "Estimation of the q-value for proteins." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001116 ! single protein identification statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001870
@@ -11870,7 +12029,6 @@ def: "Estimation of the p-value for distinct peptides once redundant identificat
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001092 ! peptide sequence-level identification statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001871
@@ -11879,7 +12037,6 @@ def: "Estimation of the p-value for proteins." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001116 ! single protein identification statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001872
@@ -11888,7 +12045,6 @@ def: "Estimation of the e-value for distinct peptides once redundant identificat
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001092 ! peptide sequence-level identification statistic
 relationship: has_domain MS:1002306 ! value greater than zero
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001873
@@ -11897,16 +12053,16 @@ def: "Estimation of the e-value for proteins." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001116 ! single protein identification statistic
 relationship: has_domain MS:1002306 ! value greater than zero
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001874
 name: FDRScore
 def: "OBSOLETE A smoothing of the distribution of q-values calculated for PSMs from individual search engines, such that ordering of result quality is maintained and all FDRScore values are guaranteed to have a value > 0." [PMID:19253293]
+comment: This term was made obsolete because it was split into the more specific terms for PSM-level FDRScore (1002355), distinct peptide-level FDRScore (MS:1002360), protein-level FDRScore (MS:1002365) and protein group-level FDRScore (MS:1002374).
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1001153 ! search engine specific score
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
+is_obsolete: true
 
 [Term]
 id: MS:1001875
@@ -11914,7 +12070,6 @@ name: modification motif
 def: "The regular expression describing the sequence motif for a modification." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001056 ! modification specificity rule
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001876
@@ -11944,7 +12099,6 @@ def: "The potential difference between two adjacent interface voltages affecting
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000482 ! source attribute
 relationship: has_units UO:0000218 ! volt
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001880
@@ -11970,7 +12124,6 @@ name: coefficient of variation
 def: "Variation of a set of signal measurements calculated as the standard deviation relative to the mean." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1001882 ! transition validation attribute
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001884
@@ -11978,7 +12131,6 @@ name: signal-to-noise ratio
 def: "Unitless number providing the ratio of the total measured intensity of a signal relative to the estimated noise level for that signal." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1001882 ! transition validation attribute
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001885
@@ -11986,7 +12138,6 @@ name: command-line parameters
 def: "Parameters string passed to a command-line interface software application, omitting the executable name." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000630 ! data processing parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001886
@@ -12019,7 +12170,6 @@ name: Progenesis:protein normalised abundance
 def: "The data type normalised abundance for proteins produced by Progenesis LC-MS." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002738 ! protein-level quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001891
@@ -12027,7 +12177,6 @@ name: Progenesis:peptide normalised abundance
 def: "The data type normalised abundance for peptides produced by Progenesis LC-MS." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002737 ! peptide-level quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001892
@@ -12035,7 +12184,6 @@ name: Progenesis:protein raw abundance
 def: "The data type raw abundance for proteins produced by Progenesis LC-MS." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002738 ! protein-level quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001893
@@ -12043,7 +12191,6 @@ name: Progenesis:peptide raw abundance
 def: "The data type raw abundance for peptide produced by Progenesis LC-MS." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002737 ! peptide-level quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001894
@@ -12051,7 +12198,6 @@ name: Progenesis:confidence score
 def: "The data type confidence score produced by Progenesis LC-MS." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001895
@@ -12059,7 +12205,6 @@ name: Progenesis:peptide count
 def: "The data type peptide count produced by Progenesis LC-MS." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002737 ! peptide-level quantification datatype
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001896
@@ -12067,7 +12212,6 @@ name: Progenesis:feature intensity
 def: "The data type feature intensity produced by Progenesis LC-MS." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002735 ! feature-level quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001897
@@ -12075,7 +12219,6 @@ name: MaxQuant:peptide counts (unique)
 def: "The data type peptide counts (unique) produced by MaxQuant." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002737 ! peptide-level quantification datatype
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001898
@@ -12083,7 +12226,6 @@ name: MaxQuant:peptide counts (all)
 def: "The data type peptide counts (all) produced by MaxQuant." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002737 ! peptide-level quantification datatype
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001899
@@ -12091,7 +12233,6 @@ name: MaxQuant:peptide counts (razor+unique)
 def: "The data type peptide counts (razor+unique) produced by MaxQuant." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002737 ! peptide-level quantification datatype
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001900
@@ -12099,7 +12240,6 @@ name: MaxQuant:sequence length
 def: "The data type sequence length produced by MaxQuant." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002737 ! peptide-level quantification datatype
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001901
@@ -12107,7 +12247,6 @@ name: MaxQuant:PEP
 def: "The data type PEP (posterior error probability) produced by MaxQuant." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001902
@@ -12115,7 +12254,6 @@ name: MaxQuant:LFQ intensity
 def: "The data type LFQ intensity produced by MaxQuant." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001903
@@ -12123,7 +12261,6 @@ name: MaxQuant:feature intensity
 def: "The data type feature intensity produced by MaxQuant." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002735 ! feature-level quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001904
@@ -12131,7 +12268,6 @@ name: MaxQuant:MS/MS count
 def: "The data type MS2 count produced by MaxQuant." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001905
@@ -12139,7 +12275,6 @@ name: emPAI value
 def: "The emPAI value of protein abundance, produced from the emPAI algorithm." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002738 ! protein-level quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001906
@@ -12147,7 +12282,6 @@ name: APEX value
 def: "The APEX value of protein abundance, produced from the APEX software." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002738 ! protein-level quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001907
@@ -12157,7 +12291,6 @@ xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000915 ! retention time window attribute
 relationship: has_units UO:0000010 ! second
 relationship: has_units UO:0000031 ! minute
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001908
@@ -12198,7 +12331,6 @@ def: "Potential difference setting of the Thermo Scientific S-lens stacked-ring 
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000482 ! source attribute
 relationship: has_units UO:0000218 ! volt
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001914
@@ -12224,6 +12356,8 @@ relationship: has_regexp MS:1001958 ! (?<=[HKR]P)(?!P)
 id: MS:1001917
 name: glutamyl endopeptidase
 def: "Enzyme glutamyl endopeptidase (EC 3.4.21.19)." [BRENDA:3.4.21.19]
+synonym: "staphylococcal protease" EXACT []
+synonym: "Glu-C" EXACT []
 is_a: MS:1001045 ! cleavage agent name
 relationship: has_regexp MS:1001959 ! (?<=[^E]E)
 
@@ -12240,7 +12374,6 @@ name: ProteomeXchange accession number
 def: "Main identifier of a ProteomeXchange dataset." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001921
@@ -12248,16 +12381,15 @@ name: ProteomeXchange accession number version number
 def: "Version number of a ProteomeXchange accession number." [PSI:PI]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
-relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001922
 name: Digital Object Identifier (DOI)
 def: "DOI unique identifier of a publication." [PSI:PI, http://dx.doi.org]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
+synonym: "doi" EXACT []
 is_a: MS:1000878 ! external reference identifier
 relationship: has_regexp MS:1002480 ! (10[.][0-9]\{4,\}(?:[.][0-9]+)*/(?:(?![\"&\'<>])[^ \t\\r\n\\v\\f])+)
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001923
@@ -12265,7 +12397,6 @@ name: external reference keyword
 def: "Free text attribute that can enrich the information about an entity." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002840 ! external reference data
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001924
@@ -12273,7 +12404,6 @@ name: journal article keyword
 def: "Keyword present in a scientific publication." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001923 ! external reference keyword
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001925
@@ -12281,7 +12411,6 @@ name: submitter keyword
 def: "Keyword assigned by the data submitter." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001923 ! external reference keyword
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001926
@@ -12289,7 +12418,6 @@ name: curator keyword
 def: "Keyword assigned by a data curator." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001923 ! external reference keyword
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001927
@@ -12297,7 +12425,6 @@ name: Tranche file hash
 def: "Hash assigned by the Tranche resource to an individual file." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001928
@@ -12305,7 +12432,6 @@ name: Tranche project hash
 def: "Hash assigned by the Tranche resource to a whole project." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001929
@@ -12313,7 +12439,6 @@ name: PRIDE experiment URI
 def: "URI that allows the access to one experiment in the PRIDE database." [PSI:PI]
 xref: value-type:xsd\:anyURI "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
-relationship: has_value_type xsd\:anyURI ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001930
@@ -12321,7 +12446,6 @@ name: PRIDE project URI
 def: "URI that allows the access to one project in the PRIDE database." [PSI:PI]
 xref: value-type:xsd\:anyURI "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
-relationship: has_value_type xsd\:anyURI ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001931
@@ -12335,7 +12459,6 @@ name: source interface model
 def: "The source interface model." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: part_of MS:1001931 ! source interface
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001933
@@ -12343,7 +12466,6 @@ name: source sprayer
 def: "The source sprayer." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: part_of MS:1000458 ! source
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001934
@@ -12357,7 +12479,6 @@ name: source sprayer manufacturer
 def: "The source sprayer manufacturer." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: part_of MS:1001933 ! source sprayer
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001936
@@ -12365,7 +12486,6 @@ name: source sprayer model
 def: "The source sprayer model." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: part_of MS:1001933 ! source sprayer
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001937
@@ -12416,7 +12536,7 @@ def: "Potential difference between Q2 and Q3 in a triple quadrupole instrument i
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000510 ! precursor activation attribute
 relationship: has_units UO:0000218 ! volt
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
+synonym: "CXP" EXACT []
 
 [Term]
 id: MS:1001945
@@ -12460,7 +12580,6 @@ name: PEAKS:peptideScore
 def: "The PEAKS peptide '-10lgP Score'." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001951
@@ -12468,7 +12587,6 @@ name: PEAKS:proteinScore
 def: "The PEAKS protein '-10lgP Score'." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001952
@@ -12476,7 +12594,6 @@ name: ZCore:probScore
 def: "The ZCore probability score." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001953
@@ -12484,7 +12601,6 @@ name: source interface manufacturer
 def: "The source interface manufacturer." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: part_of MS:1001931 ! source interface
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001954
@@ -12492,7 +12608,6 @@ name: acquisition parameter
 def: "Parameters used in the mass spectrometry acquisition." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: part_of MS:1001458 ! spectrum generation information
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001955
@@ -12536,7 +12651,6 @@ name: peptide spectrum match scoring algorithm
 def: "Algorithm used to score the match between a spectrum and a peptide ion." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: part_of MS:1001458 ! spectrum generation information
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001962
@@ -12544,7 +12658,6 @@ name: Mascot:C13 counts
 def: "C13 peaks to use in peak detection." [PSI:MS]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1002095 ! Mascot input parameter
-relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001963
@@ -12552,7 +12665,6 @@ name: ProteinExtractor:Weighting
 def: "Weighting factor for protein list compilation by ProteinExtractor." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001964
@@ -12560,7 +12672,6 @@ name: ProteinScape:second round Mascot
 def: "Flag indicating a second round search with Mascot." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002100 ! ProteinScape input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001965
@@ -12568,7 +12679,6 @@ name: ProteinScape:second round Phenyx
 def: "Flag indicating a second round search with Phenyx." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002100 ! ProteinScape input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001966
@@ -12583,7 +12693,8 @@ def: "OBSOLETE The ion drift time of an MS2 product ion." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002222 ! SRM transition attribute
 relationship: has_units UO:0000028 ! millisecond
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
+comment: This term was made obsolete because it was replaced by ion mobility drift time (MS:1002476).
+is_obsolete: true
 
 [Term]
 id: MS:1001968
@@ -12598,7 +12709,6 @@ def: "phosphoRS score for PTM site location at the PSM-level." [DOI:10.1021/pr20
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001968 ! PTM localization PSM-level statistic
 relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001970
@@ -12607,7 +12717,6 @@ def: "Probability that the respective isoform is correct." [DOI:10.1021/pr200611
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001968 ! PTM localization PSM-level statistic
 relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001971
@@ -12616,7 +12725,6 @@ def: "Estimate of the probability that the respective site is truly phosphorylat
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001968 ! PTM localization PSM-level statistic
 relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001972
@@ -12624,7 +12732,6 @@ name: PTM scoring algorithm version
 def: "Version of the post-translational modification scoring algorithm." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001471 ! peptide modification details
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001973
@@ -12640,29 +12747,28 @@ xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001968 ! PTM localization PSM-level statistic
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001975
 name: delta m/z
 def: "The difference between a theoretically calculated m/z and the corresponding experimentally measured m/z. It can be expressed as absolute or relative value." [PSI:MS]
+synonym: "m/z difference" EXACT []
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001405 ! spectrum identification result details
 relationship: has_units UO:0000166 ! parts per notation unit
 relationship: has_units UO:0000187 ! percent
 relationship: has_units UO:0000221 ! dalton
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001976
 name: delta M
 def: "The difference between a theoretically calculated molecular mass M and the corresponding experimentally measured M. It can be expressed as absolute or relative value." [PSI:MS]
+synonym: "mass difference" EXACT []
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001405 ! spectrum identification result details
 relationship: has_units UO:0000166 ! parts per notation unit
 relationship: has_units UO:0000187 ! percent
 relationship: has_units UO:0000221 ! dalton
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001977
@@ -12677,7 +12783,6 @@ def: "The PTM score from MSQuant software." [DOI:10.1021/pr900721e, PMID:1988874
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001968 ! PTM localization PSM-level statistic
 relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001979
@@ -12686,7 +12791,6 @@ def: "The PTM score from MaxQuant software." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001968 ! PTM localization PSM-level statistic
 relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001980
@@ -12695,7 +12799,6 @@ def: "The Phospho (STY) Probabilities from MaxQuant software." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001968 ! PTM localization PSM-level statistic
 relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001981
@@ -12703,7 +12806,6 @@ name: MaxQuant:Phospho (STY) Score Diffs
 def: "The Phospho (STY) Score Diffs from MaxQuant software." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001968 ! PTM localization PSM-level statistic
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001982
@@ -12712,7 +12814,6 @@ def: "The P-site localization probability value from MaxQuant software." [PSI:MS
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001968 ! PTM localization PSM-level statistic
 relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001983
@@ -12721,7 +12822,6 @@ def: "The PTM Delta Score value from MaxQuant software (Difference between highe
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001968 ! PTM localization PSM-level statistic
 relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001984
@@ -12736,7 +12836,6 @@ def: "A-score for PTM site location at the PSM-level." [DOI:10.1038/nbt1240, PMI
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001968 ! PTM localization PSM-level statistic
 relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001986
@@ -12745,7 +12844,6 @@ def: "H-Score for peptide phosphorylation site location." [DOI:10.1021/pr1006813
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001968 ! PTM localization PSM-level statistic
 relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001987
@@ -12817,6 +12915,7 @@ is_a: MS:1000592 ! smoothing
 id: MS:1001998
 name: sophisticated numerical annotation procedure
 def: "It searches for known patterns in the measured spectrum." [DOI:10.1021/ac951158i, PMID:21619291]
+synonym: "SNAP" EXACT []
 is_a: MS:1000801 ! area peak picking
 
 [Term]
@@ -12837,7 +12936,6 @@ name: MS1 label-based raw feature quantitation
 def: "MS1 label-based raw feature quantitation." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002018 ! MS1 label-based analysis
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002002
@@ -12845,7 +12943,6 @@ name: MS1 label-based peptide level quantitation
 def: "MS1 label-based peptide level quantitation." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002018 ! MS1 label-based analysis
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002003
@@ -12853,7 +12950,6 @@ name: MS1 label-based protein level quantitation
 def: "MS1 label-based protein level quantitation." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002018 ! MS1 label-based analysis
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002004
@@ -12861,7 +12957,6 @@ name: MS1 label-based proteingroup level quantitation
 def: "MS1 label-based proteingroup level quantitation." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002018 ! MS1 label-based analysis
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002005
@@ -12873,18 +12968,21 @@ is_a: MS:1000901 ! retention time normalization standard
 id: MS:1002006
 name: SRM transition type
 def: "The type of the transitions, e.g. target or decoy." [PSI:MS]
+synonym: "MRM transition type" EXACT []
 relationship: part_of MS:1000908 ! transition
 
 [Term]
 id: MS:1002007
 name: target SRM transition
 def: "A transition used to target a specific compound that may be in the sample." [PSI:MS]
+synonym: "target MRM transition" EXACT []
 is_a: MS:1002006 ! SRM transition type
 
 [Term]
 id: MS:1002008
 name: decoy SRM transition
 def: "A transition not expected to be present in the sample and used to calculate statistical confidence of target transition detections in some workflows." [PSI:MS]
+synonym: "decoy MRM transition" EXACT []
 is_a: MS:1002006 ! SRM transition type
 
 [Term]
@@ -12903,6 +13001,7 @@ is_a: MS:1002009 ! isobaric label quantitation analysis
 id: MS:1002011
 name: desorption electrospray ionization
 def: "Combination of electrospray and desorption ionization method that ionizes gases, liquids and solids in open air under atmospheric pressure." [DOI:10.1126/science.1104404, PMID:15486296]
+synonym: "DESI" EXACT []
 is_a: MS:1000240 ! atmospheric pressure ionization
 
 [Term]
@@ -12912,7 +13011,6 @@ def: "Relative probability that PTM site assignment is correct, derived from the
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001968 ! PTM localization PSM-level statistic
 relationship: has_units UO:0000187 ! percent
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002013
@@ -12921,7 +13019,6 @@ def: "Collision energy at the start of the collision energy ramp." [PSI:PI]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000045 ! collision energy
 relationship: has_units UO:0000266 ! electronvolt
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002014
@@ -12930,7 +13027,6 @@ def: "Collision energy at the end of the collision energy ramp." [PSI:PI]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000045 ! collision energy
 relationship: has_units UO:0000266 ! electronvolt
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002015
@@ -12938,7 +13034,6 @@ name: spectral count peptide level quantitation
 def: "Spectral count peptide level quantitation." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001836 ! spectral counting quantitation analysis
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002016
@@ -12946,7 +13041,6 @@ name: spectral count protein level quantitation
 def: "Spectral count protein level quantitation." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001836 ! spectral counting quantitation analysis
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002017
@@ -12954,7 +13048,6 @@ name: spectral count proteingroup level quantitation
 def: "Spectral count proteingroup level quantitation." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001836 ! spectral counting quantitation analysis
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002018
@@ -12968,7 +13061,6 @@ name: label-free raw feature quantitation
 def: "Label-free raw feature quantitation." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001834 ! LC-MS label-free quantitation analysis
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002020
@@ -12976,7 +13068,6 @@ name: label-free peptide level quantitation
 def: "Label-free peptide level quantitation." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001834 ! LC-MS label-free quantitation analysis
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002021
@@ -12984,7 +13075,6 @@ name: label-free protein level quantitation
 def: "Label-free protein level quantitation." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001834 ! LC-MS label-free quantitation analysis
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002022
@@ -12992,7 +13082,6 @@ name: label-free proteingroup level quantitation
 def: "Label-free proteingroup level quantitation." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001834 ! LC-MS label-free quantitation analysis
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002023
@@ -13006,7 +13095,6 @@ name: MS2 tag-based feature level quantitation
 def: "MS2 tag-based feature level quantitation." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002023 ! MS2 tag-based analysis
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002025
@@ -13014,7 +13102,6 @@ name: MS2 tag-based peptide level quantitation
 def: "MS2 tag-based peptide level quantitation." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002023 ! MS2 tag-based analysis
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002026
@@ -13022,7 +13109,6 @@ name: MS2 tag-based protein level quantitation
 def: "MS2 tag-based protein level quantitation." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002023 ! MS2 tag-based analysis
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002027
@@ -13030,7 +13116,6 @@ name: MS2 tag-based proteingroup level quantitation
 def: "MS2 tag-based proteingroup level quantitation." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002023 ! MS2 tag-based analysis
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002028
@@ -13038,7 +13123,6 @@ name: nucleic acid base modification
 def: "Nucleic acid base modification (substitution, insertion or deletion)." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001471 ! peptide modification details
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002029
@@ -13046,7 +13130,6 @@ name: original nucleic acid sequence
 def: "Specification of the original nucleic acid sequence, prior to a modification. The value slot should hold the DNA or RNA sequence." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001471 ! peptide modification details
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002030
@@ -13054,7 +13137,6 @@ name: modified nucleic acid sequence
 def: "Specification of the modified nucleic acid sequence. The value slot should hold the DNA or RNA sequence." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001471 ! peptide modification details
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002031
@@ -13062,7 +13144,6 @@ name: PASSEL transition group browser URI
 def: "URI to retrieve transition group data for a PASSEL (PeptideAtlas SRM Experiment Library) experiment." [PSI:PI]
 xref: value-type:xsd\:anyURI "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
-relationship: has_value_type xsd\:anyURI ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002032
@@ -13070,7 +13151,6 @@ name: PeptideAtlas dataset URI
 def: "URI that allows access to a PeptideAtlas dataset." [PSI:PI]
 xref: value-type:xsd\:anyURI "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
-relationship: has_value_type xsd\:anyURI ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002033
@@ -13106,6 +13186,7 @@ is_a: MS:1002033 ! contact role
 id: MS:1002038
 name: label free sample
 def: "A sample that has not been labelled or modified. This is often referred to as \"light\" to distinguish from \"heavy\"." [PSI:PI]
+synonym: "light sample" EXACT []
 is_a: MS:1000548 ! sample attribute
 
 [Term]
@@ -13124,7 +13205,6 @@ is_a: MS:1000482 ! source attribute
 is_a: MS:1002039 ! inlet attribute
 relationship: has_units UO:0000012 ! kelvin
 relationship: has_units UO:0000027 ! degree Celsius
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002041
@@ -13134,7 +13214,6 @@ xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000482 ! source attribute
 relationship: has_units UO:0000012 ! kelvin
 relationship: has_units UO:0000027 ! degree Celsius
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002042
@@ -13144,7 +13223,6 @@ xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000857 ! run attribute
 relationship: has_units UO:0000010 ! second
 relationship: has_units UO:0000031 ! minute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002043
@@ -13158,7 +13236,6 @@ name: ProteinProspector:score
 def: "The ProteinProspector result 'Score'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002045
@@ -13166,7 +13243,6 @@ name: ProteinProspector:expectation value
 def: "The ProteinProspector result 'Expectation value'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002046
@@ -13174,7 +13250,6 @@ name: native source path
 def: "The original source path used for directory-based sources." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001458 ! spectrum generation information
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002047
@@ -13185,6 +13260,7 @@ is_a: MS:1001456 ! analysis software
 [Term]
 id: MS:1002048
 name: MS-GF+
+synonym: "MS-GFDB" EXACT []
 def: "MS-GF+ software used to analyze the spectra." [PSI:PI]
 is_a: MS:1001456 ! analysis software
 
@@ -13194,7 +13270,6 @@ name: MS-GF:RawScore
 def: "MS-GF raw score." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002050
@@ -13202,7 +13277,6 @@ name: MS-GF:DeNovoScore
 def: "MS-GF de novo score." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002051
@@ -13210,7 +13284,6 @@ name: MS-GF:Energy
 def: "MS-GF energy score." [PSI:PI]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002052
@@ -13220,7 +13293,6 @@ xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002353 ! PSM-level e-value
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002109 ! lower score better
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002053
@@ -13230,7 +13302,6 @@ xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002353 ! PSM-level e-value
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002109 ! lower score better
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002054
@@ -13239,7 +13310,6 @@ def: "MS-GF Q-value." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002354 ! PSM-level q-value
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002055
@@ -13247,7 +13317,6 @@ name: MS-GF:PepQValue
 def: "MS-GF peptide-level Q-value." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002056
@@ -13255,7 +13324,6 @@ name: MS-GF:PEP
 def: "MS-GF posterior error probability." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002057
@@ -13285,6 +13353,8 @@ is_a: MS:1002126 ! database UniProtKB
 id: MS:1002061
 name: decoy DB from UniProtKB/TrEMBL
 def: "OBSOLETE Decoy database from a TrEMBL protein sequence database." [PSI:PI]
+comment: This term was made obsolete, because a combination of database name, DB composition , decoy DB type , decoy DB generation algorithm, decoy DB accession regexp and decoy DB details suffices.
+is_obsolete: true
 
 [Term]
 id: MS:1002062
@@ -13304,7 +13374,6 @@ name: peptide consensus RT
 def: "Peptide consensus retention time." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002737 ! peptide-level quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002065
@@ -13312,7 +13381,6 @@ name: peptide consensus m/z
 def: "Peptide consensus mass/charge ratio." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002737 ! peptide-level quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002066
@@ -13320,7 +13388,6 @@ name: ratio calculation method
 def: "Method used to calculate the ratio." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002067
@@ -13328,7 +13395,6 @@ name: protein value: median of peptide ratios
 def: "Protein quantification value calculated as median of peptide ratios." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002738 ! protein-level quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002068
@@ -13342,7 +13408,6 @@ name: metabolic labelling purity
 def: "Metabolic labelling: Description of labelling purity. Usually the purity of feeding material (e.g. 95%), or the inclusion rate derived from isotopic peak pattern shape." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001055 ! modification parameters
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002070
@@ -13350,7 +13415,6 @@ name: t-test
 def: "Perform a t-test (two groups). Specify in string value, whether paired / unpaired, variance equal / different, one- / two-sided version is performed." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001861 ! quantification data processing
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002071
@@ -13358,7 +13422,6 @@ name: ANOVA-test
 def: "Perform an ANOVA-test (more than two groups). Specify in string value, which version is performed." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001861 ! quantification data processing
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002072
@@ -13367,7 +13430,6 @@ def: "P-value as result of one of the processing steps described. Specify in the
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002073
@@ -13403,17 +13465,19 @@ is_a: MS:1001536 ! Bruker Daltonics micrOTOF series
 id: MS:1002078
 name: ProteomeDiscoverer:1. Static Modification
 def: "OBSOLETE ProteomeDiscoverer's 1st static post-translational modification (PTM) input parameter." [PSI:PI]
+comment: This term was made obsolete because it's recommended to use ProteomeDiscoverer:Static Modification (MS:1001645) instead.
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
+is_obsolete: true
 
 [Term]
 id: MS:1002079
 name: ProteomeDiscoverer:2. Static Modification
 def: "OBSOLETE ProteomeDiscoverer's 2nd static post-translational modification (PTM) input parameter." [PSI:PI]
+comment: This term was made obsolete because it's recommended to use ProteomeDiscoverer:Static Modification (MS:1001645) instead.
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
+is_obsolete: true
 
 [Term]
 id: MS:1002080
@@ -13422,7 +13486,6 @@ def: "Precursor clipping range before." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_units UO:0000221 ! dalton
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002081
@@ -13431,7 +13494,6 @@ def: "Precursor clipping range after." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_units UO:0000221 ! dalton
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002082
@@ -13441,7 +13503,6 @@ xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000503 ! scan attribute
 relationship: has_units UO:0000010 ! second
 relationship: has_units UO:0000031 ! minute
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002083
@@ -13451,7 +13512,6 @@ xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000503 ! scan attribute
 relationship: has_units UO:0000010 ! second
 relationship: has_units UO:0000031 ! minute
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002084
@@ -13489,7 +13549,6 @@ name: ProteomeDiscoverer:Peptide Without Protein XCorr Threshold
 def: "XCorr threshold for storing peptides that do not belong to a protein." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002090
@@ -13497,7 +13556,6 @@ name: Calculate Probability Scores
 def: "Flag indicating that a probability score for the assessment that a reported peptide match is a random occurrence is calculated." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002094 ! common search engine input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002091
@@ -13505,7 +13563,6 @@ name: ProteomeDiscoverer:Maximum Delta Cn
 def: "Delta Cn threshold for filtering out PSM's." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002092
@@ -13513,7 +13570,6 @@ name: Percolator:Validation based on
 def: "Algorithm (e.g. q-value or PEP) used for calculation of the validation score using Percolator." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002107 ! Percolator input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002093
@@ -13705,10 +13761,11 @@ is_a: MS:1001139 ! quantitation software name
 id: MS:1002125
 name: combined FDRScore
 def: "OBSOLETE FDRScore values specifically obtained for distinct combinations of single, pairs or triplets of search engines making a given PSM, used for integrating results from these distinct pools." [PMID:19253293]
+comment: This term was made obsolete because it was split into the more specific terms for PSM-level combined FDRScore (MS:1002356), distinct peptide-level combined FDRScore (MS:1002361), protein-level combined FDRScore (MS:1002366) and protein group-level combined FDRScore (MS:1002375).
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1001153 ! search engine specific score
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
+is_obsolete: true
 
 [Term]
 id: MS:1002126
@@ -13879,7 +13936,6 @@ name: protein level PSM counts
 def: "The number of spectra identified for this protein in spectral counting." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002738 ! protein-level quantification datatype
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002154
@@ -14242,7 +14298,6 @@ name: PAnalyzer:conclusive protein
 def: "A protein identified by at least one unique (distinct, discrete) peptide (peptides are considered different only if they can be distinguished by evidence in mass spectrum)." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001600 ! protein inference confidence category
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002214
@@ -14250,7 +14305,6 @@ name: PAnalyzer:indistinguishable protein
 def: "A member of a group of proteins sharing all peptides that are exclusive to the group (peptides are considered different only if they can be distinguished by evidence in mass spectrum)." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001600 ! protein inference confidence category
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002215
@@ -14258,7 +14312,6 @@ name: PAnalyzer:non-conclusive protein
 def: "A protein sharing all its matched peptides with either conclusive or indistinguishable proteins (peptides are considered different only if they can be distinguished by evidence in mass spectrum)." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001600 ! protein inference confidence category
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002216
@@ -14266,7 +14319,6 @@ name: PAnalyzer:ambiguous group member
 def: "A protein sharing at least one peptide not matched to either conclusive or indistinguishable proteins (peptides are considered different only if they can be distinguished by evidence in mass spectrum)." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001600 ! protein inference confidence category
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002217
@@ -14274,7 +14326,6 @@ name: decoy peptide
 def: "A putative identified peptide issued from a decoy sequence database." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001105 ! peptide sequence-level identification attribute
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002218
@@ -14283,7 +14334,6 @@ def: "Collision energy at the start of the collision energy ramp in percent, nor
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000138 ! normalized collision energy
 relationship: has_units UO:0000187 ! percent
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002219
@@ -14292,7 +14342,6 @@ def: "Collision energy at the end of the collision energy ramp in percent, norma
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000138 ! normalized collision energy
 relationship: has_units UO:0000187 ! percent
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002220
@@ -14320,7 +14369,6 @@ name: precursor ion detection probability
 def: "Probability of detecting precursor when parent protein is present." [PSI:PI]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002222 ! SRM transition attribute
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002224
@@ -14328,7 +14376,6 @@ name: product ion detection probability
 def: "Probability of detecting product ion when precursor ion is present." [PSI:PI]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002222 ! SRM transition attribute
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002225
@@ -14356,7 +14403,6 @@ name: number of product ion observations
 def: "The number of times the specific product ion has been observed in a series of SRM experiments." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002222 ! SRM transition attribute
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002228
@@ -14364,7 +14410,6 @@ name: number of precursor ion observations
 def: "The number of times the specific precursor ion has been observed in a series of SRM experiments." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002222 ! SRM transition attribute
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002229
@@ -14372,7 +14417,6 @@ name: ProteomeDiscoverer:Mascot:Significance Middle
 def: "Calculated relaxed significance when performing a decoy search for high-confidence peptides." [PSI:PI]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002230
@@ -14380,7 +14424,6 @@ name: ProteomeDiscoverer:Mascot:Significance High
 def: "Calculated relaxed significance when performing a decoy search for medium-confidence peptides." [PSI:PI]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002231
@@ -14401,16 +14444,15 @@ name: ProteomeDiscoverer:SEQUEST:Low resolution spectra contained
 def: "Flag indicating if low-resolution spectra are taken into consideration." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002234
 name: selected precursor m/z
 def: "Mass-to-charge ratio of a precursor ion selected for fragmentation." [PSI:PI]
+synonym: "selected ion m/z" RELATED []
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000455 ! ion selection attribute
 relationship: has_units MS:1000040 ! m/z
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002235
@@ -14418,7 +14460,6 @@ name: ProteoGrouper:PDH score
 def: "A score assigned to a single protein accession (modelled as ProteinDetectionHypothesis in mzIdentML), based on summed peptide level scores." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002236
@@ -14426,7 +14467,6 @@ name: ProteoGrouper:PAG score
 def: "A score assigned to a protein group (modelled as ProteinAmbiguityGroup in mzIdentML), based on all summed peptide level scores that have been assigned to the group as unique or razor peptides." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002368 ! search engine specific score for protein groups
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002237
@@ -14500,7 +14540,6 @@ name: SEQUEST:spscore
 def: "The SEQUEST result 'SpScore'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002249
@@ -14508,7 +14547,6 @@ name: SEQUEST:sprank
 def: "The SEQUEST result 'SpRank'." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002250
@@ -14516,7 +14554,6 @@ name: SEQUEST:deltacnstar
 def: "The SEQUEST result 'DeltaCnStar'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002251
@@ -14531,7 +14568,6 @@ def: "The Comet result 'XCorr'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002108 ! higher score better
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002253
@@ -14539,7 +14575,6 @@ name: Comet:deltacn
 def: "The Comet result 'DeltaCn'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002254
@@ -14547,7 +14582,6 @@ name: Comet:deltacnstar
 def: "The Comet result 'DeltaCnStar'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002255
@@ -14555,7 +14589,6 @@ name: Comet:spscore
 def: "The Comet result 'SpScore'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002256
@@ -14563,7 +14596,6 @@ name: Comet:sprank
 def: "The Comet result 'SpRank'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002257
@@ -14571,7 +14603,6 @@ name: Comet:expectation value
 def: "The Comet result 'Expectation value'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001153 ! search engine specific score
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002258
@@ -14579,7 +14610,6 @@ name: Comet:matched ions
 def: "The Comet result 'Matched Ions'." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002259
@@ -14587,7 +14617,6 @@ name: Comet:total ions
 def: "The Comet result 'Total Ions'." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002260
@@ -14595,7 +14624,6 @@ name: PSM:FDR threshold
 def: "False-discovery rate threshold for peptide-spectrum matches." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002483 ! PSM-level statistical threshold
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002261
@@ -14610,7 +14638,6 @@ def: "The Byonic score is the primary indicator of PSM correctness. The Byonic s
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002108 ! higher score better
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002263
@@ -14619,7 +14646,6 @@ def: "The drop in Byonic score from the top-scoring peptide to the next peptide 
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002108 ! higher score better
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002264
@@ -14628,7 +14654,6 @@ def: "The drop in Byonic score from the top-scoring peptide to the next peptide 
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002108 ! higher score better
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002265
@@ -14637,7 +14662,6 @@ def: "Byonic posterior error probability." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002109 ! lower score better
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002266
@@ -14646,7 +14670,6 @@ def: "The log p-value of the PSM. This is the log of the probability that the PS
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002109 ! lower score better
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002267
@@ -14656,7 +14679,6 @@ xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
 is_a: MS:1002363 ! search engine specific score for proteins
 relationship: has_order MS:1002109 ! lower score better
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002268
@@ -14666,7 +14688,6 @@ xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001116 ! single protein identification statistic
 is_a: MS:1001153 ! search engine specific score
 relationship: has_order MS:1002109 ! lower score better
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002269
@@ -14675,7 +14696,6 @@ def: "Best (largest) Byonic score of a PSM." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
 relationship: has_order MS:1002108 ! higher score better
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002270
@@ -14702,7 +14722,6 @@ def: "Detector potential difference in volts." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000481 ! detector attribute
 relationship: has_units UO:0000218 ! volt
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002274
@@ -14774,6 +14793,7 @@ is_a: MS:1001838 ! SRM quantitation analysis
 id: MS:1002285
 name: Trans-Proteomic Pipeline
 def: "A suite of open source tools for the processing of MS2 proteomics data developed by the Seattle Proteome Center at the Institute for Systems Biology." [PSI:PI]
+synonym: "TPP" EXACT []
 is_a: MS:1001456 ! analysis software
 
 [Term]
@@ -14793,6 +14813,7 @@ is_a: MS:1002286 ! Trans-Proteomic Pipeline software
 id: MS:1002288
 name: iProphet
 def: "A program in the TPP that calculates distinct peptide probabilities based on several lines of corroborating evidence including search results from multiple search engines via the pepXML format." [PMID:21876204]
+synonym: "InterProphet" EXACT []
 is_a: MS:1002286 ! Trans-Proteomic Pipeline software
 
 [Term]
@@ -14885,7 +14906,6 @@ name: Bruker Container nativeID format
 def: "Native identifier (UUID)." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000767 ! native spectrum identifier format
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002304
@@ -14924,7 +14944,6 @@ def: "The absolute value of the log-base10 of the Byonic posterior error probabi
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002108 ! higher score better
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002310
@@ -14933,7 +14952,6 @@ def: "The absolute value of the log-base10 of the Byonic posterior error probabi
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
 relationship: has_order MS:1002108 ! higher score better
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002311
@@ -14942,7 +14960,6 @@ def: "The absolute value of the log-base10 Byonic two-dimensional posterior erro
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002108 ! higher score better
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002312
@@ -14974,7 +14991,6 @@ name: ProteomeDiscoverer:Amanda:high confidence threshold
 def: "Strict confidence probability score." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002317
@@ -14982,7 +14998,6 @@ name: ProteomeDiscoverer:Amanda:middle confidence threshold
 def: "Relaxed confidence probability score." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002318
@@ -14990,7 +15005,6 @@ name: ProteomeDiscoverer:automatic workload
 def: "Flag indicating automatic estimation of the workload level." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002319
@@ -14998,7 +15012,6 @@ name: Amanda:AmandaScore
 def: "The Amanda score of the scoring function for a PSM." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002320
@@ -15006,7 +15019,6 @@ name: ProteomeDiscoverer:max differential modifications
 def: "Maximum dynamic modifications per PSM." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002321
@@ -15014,7 +15026,6 @@ name: ProteomeDiscoverer:max equal modifications
 def: "Maximum equal modifications per PSM." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002322
@@ -15022,7 +15033,6 @@ name: ProteomeDiscoverer:min peptide length
 def: "Minimum peptide length." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002323
@@ -15030,7 +15040,6 @@ name: ProteomeDiscoverer:max peptide length
 def: "Maximum peptide length." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002324
@@ -15038,7 +15047,6 @@ name: ProteomeDiscoverer:max number neutral loss
 def: "Maximum number of same neutral losses." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002325
@@ -15046,7 +15054,6 @@ name: ProteomeDiscoverer:max number neutral loss modifications
 def: "Max number of same neutral losses of modifications." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002326
@@ -15054,7 +15061,6 @@ name: ProteomeDiscoverer:use flanking ions
 def: "Flag for usage of flanking ions." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002327
@@ -15062,7 +15068,6 @@ name: ProteomeDiscoverer:max number of same modifs
 def: "The maximum number of possible equal modifications per PSM." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002328
@@ -15070,7 +15075,6 @@ name: ProteomeDiscoverer:perform deisotoping
 def: "Defines whether a simple deisotoping shall be performed." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002329
@@ -15078,23 +15082,24 @@ name: ProteomeDiscoverer:ion settings
 def: "Specifies the fragment ions and neutral losses that are calculated." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002330
 name: ProteomeDiscoverer:3. Static Modification
 def: "OBSOLETE ProteomeDiscoverer's 3rd static post-translational modification (PTM) input parameter." [PSI:PI]
+comment: This term was made obsolete because it's recommended to use ProteomeDiscoverer:Static Modification (MS:1001645) instead.
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
+is_obsolete: true
 
 [Term]
 id: MS:1002331
 name: ProteomeDiscoverer:5. Dynamic Modification
 def: "OBSOLETE ProteomeDiscoverer's 5th dynamic post-translational modification (PTM) input parameter." [PSI:PI]
+comment: This term was made obsolete because it's recommended to use ProteomeDiscoverer:Dynamic Modification (MS:1001644) instead.
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
+is_obsolete: true
 
 [Term]
 id: MS:1002332
@@ -15139,7 +15144,6 @@ def: "The probability based score of the Andromeda search engine." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002108 ! higher score better
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002339
@@ -15147,7 +15151,6 @@ name: site:global FDR
 def: "Estimation of global false discovery rate of peptides with a post-translational modification." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001405 ! spectrum identification result details
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002340
@@ -15155,7 +15158,6 @@ name: ProteomeXchange project tag
 def: "Tag that can be added to a ProteomeXchange dataset, to enable the grouping of datasets. One tag can be used for indicating that a given dataset is part of a bigger project, like e.g. the Human Proteome Project." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002341
@@ -15163,7 +15165,6 @@ name: second-pass peptide identification
 def: "A putative identified peptide found in a second-pass search of protein sequences selected from a first-pass search." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001105 ! peptide sequence-level identification attribute
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002342
@@ -15176,6 +15177,8 @@ is_a: MS:1001457 ! data processing software
 id: MS:1002343
 name: ion stability type
 def: "OBSOLETE Stability type of the ion." [PSI:PI]
+comment: This child of the former purgatory term ion was made obsolete.
+is_obsolete: true
 
 [Term]
 id: MS:1002344
@@ -15221,7 +15224,6 @@ def: "Estimation of the global false discovery rate of peptide spectrum matches.
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002701 ! PSM-level result list statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002351
@@ -15230,7 +15232,6 @@ def: "Estimation of the local false discovery rate of peptide spectrum matches."
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002347 ! PSM-level identification statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002352
@@ -15239,7 +15240,6 @@ def: "Estimation of the p-value for peptide spectrum matches." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002347 ! PSM-level identification statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002353
@@ -15248,7 +15248,6 @@ def: "Estimation of the e-value for peptide spectrum matches." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002347 ! PSM-level identification statistic
 relationship: has_domain MS:1002306 ! value greater than zero
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002354
@@ -15257,7 +15256,6 @@ def: "Estimation of the q-value for peptide spectrum matches." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002347 ! PSM-level identification statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002355
@@ -15267,7 +15265,6 @@ xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1002363 ! search engine specific score for proteins
 relationship: has_domain MS:1002349 ! value greater than zero but less than or equal to 1
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002356
@@ -15277,7 +15274,6 @@ xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1002363 ! search engine specific score for proteins
 relationship: has_domain MS:1002349 ! value greater than zero but less than or equal to 1
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002357
@@ -15286,7 +15282,6 @@ def: "Probability that the reported peptide ion is truly responsible for some or
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002347 ! PSM-level identification statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002358
@@ -15301,7 +15296,6 @@ def: "Estimation of the local false discovery rate for distinct peptides once re
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001092 ! peptide sequence-level identification statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002360
@@ -15311,7 +15305,6 @@ xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002358 ! search engine specific peptide sequence-level identification statistic
 is_a: MS:1002363 ! search engine specific score for proteins
 relationship: has_domain MS:1002349 ! value greater than zero but less than or equal to one
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002361
@@ -15321,7 +15314,6 @@ xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002358 ! search engine specific peptide sequence-level identification statistic
 is_a: MS:1002363 ! search engine specific score for proteins
 relationship: has_domain MS:1002349 ! value greater than zero but less than or equal to one
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002362
@@ -15330,7 +15322,6 @@ def: "Probability that the reported distinct peptide sequence (irrespective of m
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001092 ! peptide sequence-level identification statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002363
@@ -15344,7 +15335,6 @@ name: protein-level local FDR
 def: "Estimation of the local false discovery rate of proteins." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001116 ! single protein identification statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002365
@@ -15353,7 +15343,6 @@ def: "MzidLibrary FDRScore for proteins specifically obtained for distinct combi
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
 relationship: has_domain MS:1002349 ! value greater than zero but less than or equal to one
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002366
@@ -15362,7 +15351,6 @@ def: "MzidLibrary Combined FDRScore for proteins." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
 relationship: has_domain MS:1002349 ! value greater than zero but less than or equal to one
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002367
@@ -15371,7 +15359,6 @@ def: "Probability that a specific protein sequence has been correctly identified
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001116 ! single protein identification statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002368
@@ -15385,7 +15372,6 @@ name: protein group-level global FDR
 def: "Estimation of the global false discovery rate of protein groups." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002706 ! protein group-level result list statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002370
@@ -15393,7 +15379,6 @@ name: protein group-level local FDR
 def: "Estimation of the local false discovery rate of protein groups." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002348 ! protein group-level identification statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002371
@@ -15402,7 +15387,6 @@ def: "Estimation of the p-value for protein groups." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002348 ! protein group-level identification statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002372
@@ -15411,7 +15395,6 @@ def: "Estimation of the e-value for protein groups." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002348 ! protein group-level identification statistic
 relationship: has_domain MS:1002306 ! value greater than zero
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002373
@@ -15420,7 +15403,6 @@ def: "Estimation of the q-value for protein groups." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002348 ! protein group-level identification statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002374
@@ -15429,7 +15411,6 @@ def: "mzidLibrary FDRScore for protein groups." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002368 ! search engine specific score for protein groups
 relationship: has_domain MS:1002349 ! value greater than zero but less than or equal to one
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002375
@@ -15438,7 +15419,6 @@ def: "mzidLibrary Combined FDRScore for proteins specifically obtained for disti
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002368 ! search engine specific score for protein groups
 relationship: has_domain MS:1002349 ! value greater than zero but less than or equal to one
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002376
@@ -15447,7 +15427,6 @@ def: "Probability that at least one of the members of a group of protein sequenc
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002348 ! protein group-level identification statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002377
@@ -15455,7 +15434,6 @@ name: ProteomeDiscoverer:Relaxed Score Threshold
 def: "Specifies the threshold value for relaxed scoring." [PSI:PI]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002378
@@ -15463,7 +15441,6 @@ name: ProteomeDiscoverer:Strict Score Threshold
 def: "Specifies the threshold value for strict scoring." [PSI:PI]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002379
@@ -15471,7 +15448,6 @@ name: ProteomeDiscoverer:Peptide Without Protein Cut Off Score
 def: "Cut off score for storing peptides that do not belong to a protein." [PSI:PI]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002380
@@ -15479,7 +15455,6 @@ name: false localization rate
 def: "Estimation of the false localization rate for modification site assignment." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001405 ! spectrum identification result details
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002381
@@ -15548,7 +15523,6 @@ name: PIA:FDRScore calculated
 def: "Indicates whether the FDR score was calculated for the input file." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002389 ! PIA workflow parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002391
@@ -15556,7 +15530,6 @@ name: PIA:Combined FDRScore calculated
 def: "Indicates whether the combined FDR score was calculated for the PIA compilation." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002389 ! PIA workflow parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002392
@@ -15564,7 +15537,6 @@ name: PIA:PSM sets created
 def: "Indicates whether PSM sets were created." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002389 ! PIA workflow parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002393
@@ -15572,7 +15544,6 @@ name: PIA:used top identifications for FDR
 def: "The number of top identifications per spectrum used for the FDR calculation, 0 means all." [PSI:PI]
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1002389 ! PIA workflow parameter
-relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002394
@@ -15581,7 +15552,6 @@ def: "The score given to a protein by any protein inference." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
 relationship: has_order MS:1002108 ! higher score better
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002395
@@ -15589,7 +15559,6 @@ name: PIA:protein inference
 def: "The used algorithm for the protein inference using PIA." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002389 ! PIA workflow parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002396
@@ -15597,7 +15566,6 @@ name: PIA:protein inference filter
 def: "A filter used by PIA for the protein inference." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002389 ! PIA workflow parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002397
@@ -15605,7 +15573,6 @@ name: PIA:protein inference scoring
 def: "The used scoring method for the protein inference using PIA." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002389 ! PIA workflow parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002398
@@ -15613,7 +15580,6 @@ name: PIA:protein inference used score
 def: "The used base score for the protein inference using PIA." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002389 ! PIA workflow parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002399
@@ -15621,7 +15587,6 @@ name: PIA:protein inference used PSMs
 def: "The method to determine the PSMs used for scoring by the protein inference." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002389 ! PIA workflow parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002400
@@ -15629,7 +15594,6 @@ name: PIA:filter
 def: "A filter used for the report generation." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002389 ! PIA workflow parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002401
@@ -15655,7 +15619,6 @@ name: count of identified proteins
 def: "The number of proteins that have been identified, which must match the number of groups that pass the threshold in the file." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002704 ! protein-level result list attribute
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002405
@@ -15669,7 +15632,6 @@ name: count of identified clusters
 def: "The number of protein clusters that have been identified, which must match the number of clusters that pass the threshold in the file." [DOI:10.1002/pmic.201400080, PMID:25092112]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002405 ! protein group-level result list attribute
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002407
@@ -15677,7 +15639,6 @@ name: cluster identifier
 def: "An identifier applied to protein groups to indicate that they are linked by shared peptides." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002698 ! protein cluster identification attribute
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002408
@@ -15685,7 +15646,6 @@ name: number of distinct protein sequences
 def: "The number of protein clusters that have been identified, which must match the number of clusters that pass the threshold in the file." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002405 ! protein group-level result list attribute
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002409
@@ -15712,7 +15672,6 @@ name: total XIC area
 def: "Summed area of all the extracted ion chromatogram for the peptide (e.g. of all the transitions in SRM)." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002737 ! peptide-level quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002413
@@ -15720,7 +15679,6 @@ name: product background
 def: "The background area for the quantified transition." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002414
@@ -15734,7 +15692,6 @@ name: protein group passes threshold
 def: "A Boolean attribute to determine whether the protein group has passed the threshold indicated in the file." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002346 ! protein group-level identification attribute
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002416
@@ -15766,7 +15723,6 @@ name: PASSEL experiment URI
 def: "URI that allows access to a PASSEL experiment." [PSI:PI]
 xref: value-type:xsd\:anyURI "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
-relationship: has_value_type xsd\:anyURI ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002421
@@ -15780,7 +15736,6 @@ name: Paragon: sample type
 def: "The Paragon method setting indicating the type of sample at the high level, generally meaning the type of quantitation labelling or lack thereof. 'Identification' is indicated for samples without any labels for quantitation." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002421 ! Paragon input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002423
@@ -15788,7 +15743,6 @@ name: Paragon: cysteine alkylation
 def: "The Paragon method setting indicating the actual cysteine alkylation agent; 'None' is indicated if there was no cysteine alkylation." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002421 ! Paragon input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002424
@@ -15796,7 +15750,6 @@ name: Paragon: instrument setting
 def: "The Paragon method setting (translating to a large number of lower level settings) indicating the instrument used or a category of instrument." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002421 ! Paragon input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002425
@@ -15804,7 +15757,6 @@ name: Paragon: search effort
 def: "The Paragon method setting that controls the two major modes of search effort of the Paragon algorithm: the Rapid mode uses a conventional database search, while the Thorough mode uses a hybrid search, starting with the same approach as the Rapid mode but then follows it with a separate tag-based approach enabling a more extensive search." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002421 ! Paragon input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002426
@@ -15812,7 +15764,6 @@ name: Paragon: ID focus
 def: "A Paragon method setting that allows the inclusion of large sets of features such as biological modification or substitutions." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002421 ! Paragon input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002427
@@ -15820,7 +15771,6 @@ name: Paragon: FDR analysis
 def: "The Paragon method setting that controls whether FDR analysis is conducted." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002421 ! Paragon input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002428
@@ -15828,7 +15778,6 @@ name: Paragon: quantitation
 def: "The Paragon method setting that controls whether quantitation analysis is conducted." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002421 ! Paragon input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002429
@@ -15836,7 +15785,6 @@ name: Paragon: background correction
 def: "The Paragon method setting that controls whether the 'Background Correction' analysis is conducted; this processing estimates a correction to the attenuation in extremity ratios that can occur in isobaric quantatitation workflows on complex samples." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002421 ! Paragon input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002430
@@ -15844,7 +15792,6 @@ name: Paragon: bias correction
 def: "The Paragon method setting that controls whether 'Bias Correction' is invoked in quantitation analysis; this correction is a normalization to set the central tendency of protein ratios to unity." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002421 ! Paragon input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002431
@@ -15852,7 +15799,6 @@ name: Paragon: channel to use as denominator in ratios
 def: "The Paragon method setting that controls which label channel is used as the denominator in calculating relative expression ratios." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002421 ! Paragon input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002432
@@ -15866,7 +15812,6 @@ name: Paragon: modified data dictionary or parameter translation
 def: "This metric detects if any changes have been made to the originally installed key control files for the software; if no changes have been made, then the software version and settings are sufficient to enable exact reproduction; if changes have been made, then the modified ParameterTranslation- and ProteinPilot DataDictionary-XML files much also be provided in order to exactly reproduce a result." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002432 ! search engine specific input metadata
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002434
@@ -15874,7 +15819,6 @@ name: number of spectra searched
 def: "Number of spectra in a search." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1001249 ! search input details
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002435
@@ -15882,7 +15826,6 @@ name: data processing start time
 def: "The time that a data processing action was started." [PSI:MS]
 xref: value-type:xsd\:dateTime "The allowed value-type for this CV term."
 is_a: MS:1000630 ! data processing parameter
-relationship: has_value_type xsd\:dateTime ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002436
@@ -15890,7 +15833,6 @@ name: Paragon: digestion
 def: "The Paragon method setting indicating the actual digestion agent - unlike other search tools, this setting does not include options that control partial specificity like 'semitrypsin'; if trypsin is used, trypsin is set, and partially conforming peptides are found in the Thorough mode of search; 'None' should be indicated only if there was really no digestion done." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001249 ! search input details
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002437
@@ -15898,7 +15840,6 @@ name: number of decoy sequences
 def: "The number of decoy sequences, if the concatenated target-decoy approach is used." [PSI:PI]
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1001011 ! search database details
-relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002438
@@ -15960,7 +15901,6 @@ name: Paragon:special factor
 def: "The Paragon method setting indicating a list of one or more 'special factors', which generally capture secondary effects (relative to other settings) as a set of probabilities of modification features that override the assumed levels. For example the 'gel-based ID' special factor causes an increase probability of oxidation on several resides because of the air exposure impact on a gel, in addition to other effects." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002421 ! Paragon input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002448
@@ -15968,7 +15908,6 @@ name: PEAKS:inChorusPeptideScore
 def: "The PEAKS inChorus peptide score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002449
@@ -15976,7 +15915,6 @@ name: PEAKS:inChorusProteinScore
 def: "The PEAKS inChorus protein score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002450
@@ -16013,22 +15951,28 @@ is_a: MS:1002094 ! common search engine input parameter
 id: MS:1002455
 name: H2O neutral loss
 def: "OBSOLETE Neutral loss of water." [PSI:PI]
+comment: This term was obsoleted because it should be replaced by MS:1000336 with value H2O.
 is_a: MS:1000336 ! neutral loss
 is_a: MS:1002473 ! ion series considered in search
+is_obsolete: true
 
 [Term]
 id: MS:1002456
 name: NH3 neutral loss
 def: "OBSOLETE Neutral loss of ammonia." [PSI:PI]
+comment: This term was obsoleted because it should be replaced by MS:1000336 with value NH3.
 is_a: MS:1000336 ! neutral loss
 is_a: MS:1002473 ! ion series considered in search
+is_obsolete: true
 
 [Term]
 id: MS:1002457
 name: H3PO4 neutral loss
 def: "OBSOLETE Neutral loss of phosphoric acid." [PSI:PI]
+comment: This term was obsoleted because it should be replaced by MS:1000336 with value H3PO4.
 is_a: MS:1000336 ! neutral loss
 is_a: MS:1002473 ! ion series considered in search
+is_obsolete: true
 
 [Term]
 id: MS:1002458
@@ -16088,7 +16032,6 @@ def: "The probability based PeptideShaker PSM score." [PSI:PI]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002108 ! higher score better
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002467
@@ -16097,7 +16040,6 @@ def: "The probability based PeptideShaker PSM confidence." [PSI:PI]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002108 ! higher score better
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002468
@@ -16107,7 +16049,6 @@ xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002358 ! search engine specific peptide sequence-level identification statistic
 is_a: MS:1002363 ! search engine specific score for proteins
 relationship: has_order MS:1002108 ! higher score better
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002469
@@ -16116,7 +16057,6 @@ def: "The probability based PeptideShaker peptide confidence." [PSI:PI]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
 relationship: has_order MS:1002108 ! higher score better
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002470
@@ -16126,7 +16066,6 @@ xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
 is_a: MS:1002368 ! search engine specific score for protein groups
 relationship: has_order MS:1002108 ! higher score better
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002471
@@ -16135,7 +16074,6 @@ def: "The probability based PeptideShaker protein group confidence." [PSI:PI]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
 relationship: has_order MS:1002108 ! higher score better
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002472
@@ -16156,7 +16094,6 @@ def: "The sum of peptide-level scores for peptides mapped only to non-canonical 
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002368 ! search engine specific score for protein groups
 relationship: has_order MS:1002108 ! higher score better
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002475
@@ -16164,7 +16101,6 @@ name: ProteoAnnotator:count alternative peptides
 def: "The count of the number of peptide sequences mapped to non-canonical gene models only within the group." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002368 ! search engine specific score for protein groups
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002476
@@ -16174,7 +16110,6 @@ xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000455 ! ion selection attribute
 is_a: MS:1002892 ! ion mobility attribute
 relationship: has_units UO:0000028 ! millisecond
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002477
@@ -16184,7 +16119,6 @@ xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002893 ! ion mobility array
 relationship: has_units UO:0000028 ! millisecond
 relationship: has_units UO:0000010 ! second
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002478
@@ -16247,7 +16181,6 @@ name: MassIVE dataset identifier
 def: "Dataset identifier issued by the MassIVE repository. A dataset can refer to either a single sample as part of a study, or all samples that are part of the study corresponding to a publication." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002488
@@ -16255,7 +16188,6 @@ name: MassIVE dataset URI
 def: "URI that allows the access to one dataset in the MassIVE repository. A dataset can refer to either a single sample as part of a study, or all samples that are part of the study corresponding to a publication." [PSI:PI]
 xref: value-type:xsd\:anyURI "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
-relationship: has_value_type xsd\:anyURI ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002489
@@ -16322,7 +16254,9 @@ is_a: MS:1002658 ! identification parameter
 id: MS:1002499
 name: peptide level score
 def: "OBSOLETE Peptide level score." [PSI:PI]
+comment: This term was obsoleted because it was never intended to go in the CV.
 is_a: MS:1002358 ! search engine specific peptide sequence-level identification statistic
+is_obsolete: true
 
 [Term]
 id: MS:1002500
@@ -16330,7 +16264,6 @@ name: peptide passes threshold
 def: "A Boolean attribute to determine whether the peptide has passed the threshold indicated in the file." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001105 ! peptide sequence-level identification attribute
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002501
@@ -16356,7 +16289,6 @@ name: modification index
 def: "The order of modifications to be referenced elsewhere in the document." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1001055 ! modification parameters
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002505
@@ -16377,7 +16309,6 @@ def: "Mod position score: false localization rate." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002506 ! modification position score
 relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002508
@@ -16391,7 +16322,6 @@ name: cross-link donor
 def: "The Cross-linking donor, assigned according to the following rules: the export software SHOULD use the following rules to choose the cross-link donor as the: longer peptide, then higher peptide neutral mass, then alphabetical order." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002508 ! cross-linking attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002510
@@ -16399,7 +16329,6 @@ name: cross-link acceptor
 def: "Cross-linking acceptor, assigned according to the following rules: the export software SHOULD use the following rules to choose the cross-link donor as the: longer peptide, then higher peptide neutral mass, then alphabetical order." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002508 ! cross-linking attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002511
@@ -16407,7 +16336,6 @@ name: cross-link spectrum identification item
 def: "Cross-linked spectrum identification item." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002508 ! cross-linking attribute
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002512
@@ -16415,7 +16343,6 @@ name: cross-linking score
 def: "Cross-linking scoring value." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002513
@@ -16423,7 +16350,6 @@ name: molecules per cell
 def: "The absolute abundance of protein in a cell." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002514
@@ -16437,7 +16363,6 @@ name: internal peptide reference used
 def: "States whether an internal peptide reference is used or not in absolute quantitation analysis." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001832 ! quantitation software comment or customizations
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002516
@@ -16445,7 +16370,6 @@ name: internal protein reference used
 def: "States whether an internal protein reference is used or not in absolute quantitation analysis." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001832 ! quantitation software comment or customizations
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002517
@@ -16453,7 +16377,6 @@ name: internal reference abundance
 def: "The absolute abundance of the spiked in reference peptide or protein used for absolute quantitation analysis." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002518
@@ -16461,7 +16384,6 @@ name: Progenesis:protein group normalised abundance
 def: "The data type normalised abundance for protein groups produced by Progenesis LC-MS." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002739 ! protein group-level quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002519
@@ -16469,7 +16391,6 @@ name: Progenesis:protein group raw abundance
 def: "The data type raw abundance for protein groups produced by Progenesis LC-MS." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002739 ! protein group-level quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002520
@@ -16477,7 +16398,6 @@ name: peptide group ID
 def: "Peptide group identifier for peptide-level stats." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001105 ! peptide sequence-level identification attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002521
@@ -16491,7 +16411,6 @@ name: ProteomeDiscoverer:1. Static Terminal Modification
 def: "Determine 1st static terminal post-translational modifications (PTMs)." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002523
@@ -16527,6 +16446,7 @@ is_a: MS:1000503 ! scan attribute
 id: MS:1002528
 name: synchronous prefilter selection
 def: "Synchronous prefilter selection." [PSI:PI]
+synonym: "SPS" EXACT []
 is_a: MS:1002527 ! instrument specific scan attribute
 
 [Term]
@@ -16570,7 +16490,6 @@ def: "The ProLuCID result 'XCorr'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002108 ! higher score better
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002535
@@ -16578,7 +16497,6 @@ name: ProLuCID:deltacn
 def: "The ProLuCID result 'DeltaCn'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002536
@@ -16587,7 +16505,6 @@ def: "D-Score for PTM site location at the PSM-level." [PMID:23307401]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001968 ! PTM localization PSM-level statistic
 relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002537
@@ -16596,7 +16513,6 @@ def: "MD-Score for PTM site location at the PSM-level." [PMID:21057138]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001968 ! PTM localization PSM-level statistic
 relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002538
@@ -16604,7 +16520,6 @@ name: PTM localization confidence metric
 def: "Localization confidence metric for a post translational modification (PTM)." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001405 ! spectrum identification result details
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002539
@@ -16612,7 +16527,6 @@ name: PeptideShaker PTM confidence type
 def: "PeptideShaker quality criteria for the confidence of PTM localizations." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002538 ! PTM localization confidence metric
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002540
@@ -16620,7 +16534,6 @@ name: PeptideShaker PSM confidence type
 def: "PeptideShaker quality criteria for the confidence of PSM's." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002347 ! PSM-level identification statistic
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002541
@@ -16628,7 +16541,6 @@ name: PeptideShaker peptide confidence type
 def: "PeptideShaker quality criteria for the confidence of peptide identifications." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002358 ! search engine specific peptide sequence-level identification statistic
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002542
@@ -16636,7 +16548,6 @@ name: PeptideShaker protein confidence type
 def: "PeptideShaker quality criteria for the confidence of protein identifications." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001116 ! single protein identification statistic
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002543
@@ -16657,7 +16568,6 @@ def: "The xi result 'Score'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002108 ! higher score better
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002546
@@ -16691,7 +16601,6 @@ def: "phosphoRS score for PTM site location at the peptide-level." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002549 ! PTM localization distinct peptide-level statistic
 relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002551
@@ -16700,7 +16609,6 @@ def: "A-score for PTM site location at the peptide-level." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002549 ! PTM localization distinct peptide-level statistic
 relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002552
@@ -16709,7 +16617,6 @@ def: "H-Score for peptide phosphorylation site location at the peptide-level." [
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002549 ! PTM localization distinct peptide-level statistic
 relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002553
@@ -16718,7 +16625,6 @@ def: "D-Score for PTM site location at the peptide-level." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002549 ! PTM localization distinct peptide-level statistic
 relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002554
@@ -16727,7 +16633,6 @@ def: "MD-Score for PTM site location at the peptide-level." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002549 ! PTM localization distinct peptide-level statistic
 relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002555
@@ -16741,7 +16646,6 @@ name: Ascore threshold
 def: "Threshold for Ascore PTM site location score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002555 ! PTM localization score threshold
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002557
@@ -16749,7 +16653,6 @@ name: D-Score threshold
 def: "Threshold for D-score PTM site location score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002555 ! PTM localization score threshold
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002558
@@ -16757,7 +16660,6 @@ name: MD-Score threshold
 def: "Threshold for MD-score PTM site location score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002555 ! PTM localization score threshold
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002559
@@ -16765,7 +16667,6 @@ name: H-Score threshold
 def: "Threshold for H-score PTM site location score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002555 ! PTM localization score threshold
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002560
@@ -16773,7 +16674,6 @@ name: DeBunker:score threshold
 def: "Threshold for DeBunker PTM site location score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002555 ! PTM localization score threshold
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002561
@@ -16781,7 +16681,6 @@ name: Mascot:PTM site assignment confidence threshold
 def: "Threshold for Mascot PTM site assignment confidence." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002555 ! PTM localization score threshold
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002562
@@ -16789,7 +16688,6 @@ name: MSQuant:PTM-score threshold
 def: "Threshold for MSQuant:PTM-score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002555 ! PTM localization score threshold
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002563
@@ -16797,7 +16695,6 @@ name: MaxQuant:PTM Score threshold
 def: "Threshold for MaxQuant:PTM Score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002555 ! PTM localization score threshold
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002564
@@ -16805,7 +16702,6 @@ name: MaxQuant:P-site localization probability threshold
 def: "Threshold for MaxQuant:P-site localization probability." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002555 ! PTM localization score threshold
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002565
@@ -16813,7 +16709,6 @@ name: MaxQuant:PTM Delta Score threshold
 def: "Threshold for MaxQuant:PTM Delta Score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002555 ! PTM localization score threshold
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002566
@@ -16821,7 +16716,6 @@ name: MaxQuant:Phospho (STY) Probabilities threshold
 def: "Threshold for MaxQuant:Phospho (STY) Probabilities." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002555 ! PTM localization score threshold
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002567
@@ -16829,7 +16723,6 @@ name: phosphoRS score threshold
 def: "Threshold for phosphoRS score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002555 ! PTM localization score threshold
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002568
@@ -16837,7 +16730,6 @@ name: phosphoRS site probability threshold
 def: "Threshold for phosphoRS site probability." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002555 ! PTM localization score threshold
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002569
@@ -16845,7 +16737,6 @@ name: ProteomeDiscoverer:Number of Spectra Processed At Once
 def: "Number of spectra processed at once in a ProteomeDiscoverer search." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002570
@@ -16853,7 +16744,6 @@ name: sequence multiply subsumable protein
 def: "A protein for which the matched peptide sequences are the same, or a subset of, the matched peptide sequences for two or more other proteins combined. These other proteins need not all be in the same group." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001101 ! protein group or subset relationship
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002571
@@ -16861,7 +16751,6 @@ name: spectrum multiply subsumable protein
 def: "A protein for which the matched spectra are the same, or a subset of, the matched spectra for two or more other proteins combined. These other proteins need not all be in the same group." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001101 ! protein group or subset relationship
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002572
@@ -17031,7 +16920,6 @@ name: splash key
 def: "Spectral Hash key, an unique identifier for spectra." [PMID:27824832]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001405 ! spectrum identification result details
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002600
@@ -17225,6 +17113,7 @@ is_a: MS:1002622 ! iTRAQ reagent
 id: MS:1002631
 name: Electron-Transfer/Higher-Energy Collision Dissociation (EThcD)
 def: "A dissociation process combining electron-transfer and higher-energy collision dissociation (EThcD). It combines ETD (reaction time) followed by HCD (activation energy)." [PSI:PI]
+synonym: "EThcD" EXACT []
 is_a: MS:1000044 ! dissociation method
 
 [Term]
@@ -17233,7 +17122,6 @@ name: jPOST dataset identifier
 def: "Dataset identifier issued by the jPOST repository. A dataset can refer to either a single sample as part of a study, or all samples that are part of the study corresponding to a publication." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002633
@@ -17241,7 +17129,6 @@ name: jPOST dataset URI
 def: "URI that allows the access to one dataset in the jPOST repository. A dataset can refer to either a single sample as part of a study, or all samples that are part of the study corresponding to a publication." [PSI:PI]
 xref: value-type:xsd\:anyURI "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
-relationship: has_value_type xsd\:anyURI ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002634
@@ -17267,7 +17154,6 @@ name: chromosome name
 def: "The name or number of the chromosome to which a given peptide has been mapped." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002636 ! proteogenomics attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002638
@@ -17275,15 +17161,15 @@ name: chromosome strand
 def: "The strand (+ or -) to which the peptide has been mapped." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002636 ! proteogenomics attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002639
 name: peptide start on chromosome
 def: "OBSOLETE The overall start position on the chromosome to which a peptide has been mapped i.e. the position of the first base of the first codon, using a zero-based counting system." [PSI:PI]
+comment: This term was obsoleted because it contains redundant info contained in term MS:1002643 - peptide start positions on chromosome.
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002636 ! proteogenomics attribute
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
+is_obsolete: true
 
 [Term]
 id: MS:1002640
@@ -17291,7 +17177,6 @@ name: peptide end on chromosome
 def: "The overall end position on the chromosome to which a peptide has been mapped i.e. the position of the third base of the last codon, using a zero-based counting system." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002636 ! proteogenomics attribute
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002641
@@ -17299,7 +17184,6 @@ name: peptide exon count
 def: "The number of exons to which the peptide has been mapped." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002636 ! proteogenomics attribute
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002642
@@ -17307,7 +17191,6 @@ name: peptide exon nucleotide sizes
 def: "A comma separated list of the number of DNA bases within each exon to which a peptide has been mapped. Assuming standard operation of a search engine, the peptide exon sizes should sum to exactly three times the peptide length." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002636 ! proteogenomics attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002643
@@ -17315,7 +17198,6 @@ name: peptide start positions on chromosome
 def: "A comma separated list of start positions within exons to which the peptide has been mapped, relative to peptide-chromosome start, assuming a zero-based counting system. The first value MUST match the value in peptide start on chromosome." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002636 ! proteogenomics attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002644
@@ -17323,7 +17205,6 @@ name: genome reference version
 def: "The reference genome and versioning string as used for mapping. All coordinates are within this frame of reference." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002636 ! proteogenomics attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002645
@@ -17336,6 +17217,7 @@ is_a: MS:1001457 ! data processing software
 id: MS:1002646
 name: native spectrum identifier format, combined spectra
 def: "Describes how the native spectrum identifiers that have been combined prior to searching or interpretation are formated." [PSI:PI]
+synonym: "nativeID format, combined spectra" EXACT []
 relationship: part_of MS:1000577 ! source data file
 
 [Term]
@@ -17344,7 +17226,6 @@ name: Thermo nativeID format, combined spectra
 def: "Thermo comma separated list of spectra that have been combined prior to searching or interpretation." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002646 ! native spectrum identifier format, combined spectra
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002648
@@ -17352,7 +17233,6 @@ name: Waters nativeID format, combined spectra
 def: "Waters comma separated list of spectra that have been combined prior to searching or interpretation." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002646 ! native spectrum identifier format, combined spectra
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002649
@@ -17360,7 +17240,6 @@ name: WIFF nativeID format, combined spectra
 def: "WIFF comma separated list of spectra that have been combined prior to searching or interpretation." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002646 ! native spectrum identifier format, combined spectra
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002650
@@ -17368,7 +17247,6 @@ name: Bruker/Agilent YEP nativeID format, combined spectra
 def: "Bruker/Agilent comma separated list of spectra that have been combined prior to searching or interpretation." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002646 ! native spectrum identifier format, combined spectra
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002651
@@ -17376,55 +17254,54 @@ name: Bruker BAF nativeID format, combined spectra
 def: "Bruker BAF comma separated list of spectra that have been combined prior to searching or interpretation." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002646 ! native spectrum identifier format, combined spectra
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002652
 name: Bruker FID nativeID format, combined spectra
 def: "Bruker FID comma separated list of spectra that have been combined prior to searching or interpretation." [PSI:PI]
+comment: The nativeID must be the same as the source file ID.
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002646 ! native spectrum identifier format, combined spectra
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002653
 name: multiple peak list nativeID format, combined spectra
 def: "Comma separated list of spectra that have been combined prior to searching or interpretation." [PSI:PI]
+comment: Used for conversion of peak list files with multiple spectra, i.e. MGF, PKL, merged DTA files. Index is the spectrum number in the file, starting from 0.
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002646 ! native spectrum identifier format, combined spectra
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002654
 name: single peak list nativeID format, combined spectra
 def: "Comma separated list of spectra that have been combined prior to searching or interpretation." [PSI:PI]
+comment: The nativeID must be the same as the source file ID. Used for conversion of peak list files with one spectrum per file, typically folder of PKL or DTAs, each sourceFileRef is different.
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002646 ! native spectrum identifier format, combined spectra
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002655
 name: scan number only nativeID format, combined spectra
 def: "Comma separated list of spectra that have been combined prior to searching or interpretation." [PSI:PI]
+comment: Used for conversion from mzXML, or DTA folder where native scan numbers can be derived.
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002646 ! native spectrum identifier format, combined spectra
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002656
 name: spectrum identifier nativeID format, combined spectra
 def: "Comma separated list of spectra that have been combined prior to searching or interpretation." [PSI:PI]
+comment: Used for conversion from mzData. The spectrum id attribute is referenced.
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002646 ! native spectrum identifier format, combined spectra
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002657
 name: mzML unique identifier, combined spectra
 def: "Comma separated list of spectra that have been combined prior to searching or interpretation." [PSI:PI]
+comment: A unique identifier of a spectrum stored in an mzML file.
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002646 ! native spectrum identifier format, combined spectra
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002658
@@ -17458,7 +17335,6 @@ def: "Morpheus score for PSMs." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002108 ! higher score better
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002663
@@ -17467,7 +17343,6 @@ def: "Summed Morpheus score for protein groups." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002368 ! search engine specific score for protein groups
 relationship: has_order MS:1002108 ! higher score better
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002664
@@ -17476,7 +17351,6 @@ def: "Parent term for interaction scores derived from cross-linking." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002675 ! cross-linking result details
 relationship: has_regexp MS:1002665 ! ([:digit:]+[.][a|b]:[:digit:]+:[:digit:]+[.][:digit:]+([Ee][+-][0-9]+)*:(true|false]\{1\}))
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002665
@@ -17502,7 +17376,6 @@ name: frag: iTRAQ 4plex reporter ion
 def: "Standard reporter ion for iTRAQ 4Plex. The value slot holds the integer mass of the iTRAQ 4Plex reporter ion, e.g. 114." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002307 ! fragmentation ion type
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002669
@@ -17510,7 +17383,6 @@ name: frag: iTRAQ 8plex reporter ion
 def: "Standard reporter ion for iTRAQ 8Plex. The value slot holds the integer mass of the iTRAQ 8Plex reporter ion, e.g. 113." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002307 ! fragmentation ion type
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002670
@@ -17518,7 +17390,6 @@ name: frag: TMT reporter ion
 def: "Standard reporter ion for TMT. The value slot holds the integer mass of the TMT reporter ion and can be suffixed with either N or C, indicating whether the mass difference is encoded at a Nitrogen or Carbon atom, e.g. 127N." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002307 ! fragmentation ion type
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002671
@@ -17526,7 +17397,6 @@ name: frag: TMT ETD reporter ion
 def: "Standard reporter ion for TMT with ETD fragmentation. The value slot holds the integer mass of the TMT ETD reporter ion and can be suffixed with either N or C, indicating whether the mass difference is encoded at a Nitrogen or Carbon atom, e.g. 127C." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002307 ! fragmentation ion type
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002672
@@ -17560,7 +17430,6 @@ xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002664 ! interaction score derived from cross-linking
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
 relationship: has_regexp MS:1002665 ! ([:digit:]+[.][a|b]:[:digit:]+:[:digit:]+[.][:digit:]+([Ee][+-][0-9]+)*:(true|false]\{1\}))
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002677
@@ -17570,7 +17439,6 @@ xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002664 ! interaction score derived from cross-linking
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
 relationship: has_regexp MS:1002665 ! ([:digit:]+[.][a|b]:[:digit:]+:[:digit:]+[.][:digit:]+([Ee][+-][0-9]+)*:(true|false]\{1\}))
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002678
@@ -17591,7 +17459,6 @@ def: "Energy for an ion experiencing supplemental collision with a stationary ga
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000510 ! precursor activation attribute
 relationship: has_units UO:0000266 ! electronvolt
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002681
@@ -17601,7 +17468,6 @@ xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1001153 ! search engine specific score
 relationship: has_order MS:1002108 ! higher score better
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002682
@@ -17611,7 +17477,6 @@ xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1001153 ! search engine specific score
 relationship: has_order MS:1002108 ! higher score better
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002683
@@ -17621,7 +17486,6 @@ xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1001153 ! search engine specific score
 relationship: has_order MS:1002108 ! higher score better
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002684
@@ -17632,7 +17496,6 @@ is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1001153 ! search engine specific score
 relationship: has_order MS:1002108 ! higher score better
 relationship: has_domain MS:1002306 ! value greater than zero
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002685
@@ -17643,7 +17506,6 @@ is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1001153 ! search engine specific score
 relationship: has_order MS:1002108 ! higher score better
 relationship: has_domain MS:1002306 ! value greater than zero
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002686
@@ -17654,7 +17516,6 @@ is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1001153 ! search engine specific score
 relationship: has_order MS:1002108 ! higher score better
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002687
@@ -17780,37 +17641,9 @@ is_a: MS:1001180 ! Cleavage agent regular expression
 id: MS:1002708
 name: LysargiNase
 def: "Metalloproteinase found in Methanosarcina acetivorans that cleaves on the N-terminal side of lysine and arginine residues." [PMID:25419962]
+synonym: "Tryp-N" EXACT []
 is_a: MS:1001045 ! cleavage agent name
 relationship: has_regexp MS:1002707 ! (?=[KR])
-
-[Term]
-id: MS:1002709
-name: compound data type
-def: "A data type representing more than a single value." []
-
-[Term]
-id: MS:1002710
-name: list of type
-def: "A data type defining a list of values of a single type." []
-is_a: MS:1002709 ! compound data type
-
-[Term]
-id: MS:1002711
-name: list of strings
-def: "A list of xsd:string." []
-is_a: MS:1002710 ! list of type
-
-[Term]
-id: MS:1002712
-name: list of integers
-def: "A list of xsd:integer." []
-is_a: MS:1002710 ! list of type
-
-[Term]
-id: MS:1002713
-name: list of floats
-def: "A list of xsd:float." []
-is_a: MS:1002710 ! list of type
 
 [Term]
 id: MS:1002719
@@ -17832,7 +17665,6 @@ xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002353 ! PSM-level e-value
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002109 ! lower score better
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002722
@@ -17842,7 +17674,6 @@ xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002353 ! PSM-level e-value
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002109 ! lower score better
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002723
@@ -17851,7 +17682,6 @@ def: "MSPathFinder Q-value." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002354 ! PSM-level q-value
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002724
@@ -17859,7 +17689,6 @@ name: MSPathFinder:PepQValue
 def: "MSPathFinder peptide-level Q-value." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002725
@@ -17867,7 +17696,6 @@ name: MSPathFinder:RawScore
 def: "MSPathFinder raw score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002726
@@ -17917,7 +17745,6 @@ name: peptide-level spectral count
 def: "The number of MS2 spectra identified for a peptide sequence specified by the amino acid one-letter codes plus optional PTMs in spectral counting." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002737 ! peptide-level quantification datatype
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002734
@@ -17925,7 +17752,6 @@ name: peptide ion-level spectral count
 def: "The number of MS2 spectra identified for a molecular ion defined by the peptide sequence represented by the amino acid one-letter codes, plus optional PTMs plus optional charged aducts plus the charge state, in spectral counting." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002737 ! peptide-level quantification datatype
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002735
@@ -18027,7 +17853,6 @@ name: Mascot:IntegratedSpectralLibrarySearch
 def: "Means that Mascot has integrated the search results of database and spectral library search into a single data set." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002095 ! Mascot input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002750
@@ -18397,7 +18222,6 @@ name: adduct ion X m/z
 def: "Theoretical m/z of the X component in the adduct M+X or M-X. This term was formerly called 'adduct ion mass', but it is not really a mass. It corresponds to the column mislabelled as 'mass' at https://fiehnlab.ucdavis.edu/staff/kind/Metabolomics/MS-Adduct-Calculator." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1003056 ! adduct ion property
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002811
@@ -18405,7 +18229,6 @@ name: adduct ion isotope
 def: "Isotope of the matrix molecule M of an adduct formation." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1003056 ! adduct ion property
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002812
@@ -18420,12 +18243,12 @@ def: "Adduct formation formula of the form M+X or M-X, as constrained by the pro
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002809 ! adduct ion attribute
 relationship: has_regexp MS:1002812 ! (\[[:digit:]{0,1}M([+][:digit:]{0,1}(H|K|(Na)|(Li)|(Cl)|(Br)|(NH3)|(NH4)|(CH3OH)|(IsoProp)|(DMSO)|(FA)|(Hac)|(TFA)|(NaCOOH)|(HCOOH)|(CF3COOH)|(ACN))){0,}([-][:digit:]{0,1}(H|(H2O)|(CH2)|(CH4)|(NH3)|(CO)|(CO2)|(COCH2)|(HCOOH)|(C2H4)|(C4H8)|(C3H2O3)|(C5H8O4)|(C6H10O4)|(C6H10O5)|(C6H8O6))){0,}\][:digit:]{0,1}[+-])
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002814
 name: volt-second per square centimeter
 def: "An electrical mobility unit that equals the speed [cm/s] an ion reaches when pulled through a gas by a Voltage[V] over a certain distance [cm]." [PSI:PI]
+synonym: "Vs/cm^2" EXACT []
 is_a: UO:0000000 ! unit
 
 [Term]
@@ -18436,7 +18259,6 @@ xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000455 ! ion selection attribute
 is_a: MS:1002892 ! ion mobility attribute
 relationship: has_units MS:1002814 ! volt-second per square centimeter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002816
@@ -18446,7 +18268,6 @@ xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002893 ! ion mobility array
 relationship: has_units UO:0000028 ! millisecond
 relationship: has_units UO:0000010 ! second
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002817
@@ -18466,21 +18287,20 @@ name: Bruker TDF nativeID format, combined spectra
 def: "Bruker TDF comma separated list of spectra that have been combined prior to searching or interpretation." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002646 ! native spectrum identifier format, combined spectra
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002820
 name: M+H ion
 def: "Adduct formed by protonation of a matrix molecule M, i.e. the addition of a matrix molecule M plus a proton." [PSI:MS]
-is_a: MS:1002807 ! positive mode adduct ion
 property_value: ionMass: "M + 1.007276" xsd:string
+is_a: MS:1002807 ! positive mode adduct ion
 
 [Term]
 id: MS:1002821
 name: M-H ion
 def: "Adduct formed by deprotonation of a matrix molecule M, i.e. the removal of a proton from a matrix molecule M." [PSI:MS]
-is_a: MS:1002808 ! negative mode adduct ion
 property_value: ionMass: "M - 1.007276" xsd:string
+is_a: MS:1002808 ! negative mode adduct ion
 
 [Term]
 id: MS:1002822
@@ -18519,7 +18339,6 @@ def: "MetaMorpheus score for PSMs." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002108 ! higher score better
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002828
@@ -18528,7 +18347,6 @@ def: "MetaMorpheus score for protein groups." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002368 ! search engine specific score for protein groups
 relationship: has_order MS:1002108 ! higher score better
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002829
@@ -18536,7 +18354,6 @@ name: XCMS:into
 def: "Feature intensity produced by XCMS findPeaks() from integrated peak intensity." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002735 ! feature-level quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002830
@@ -18544,7 +18361,6 @@ name: XCMS:intf
 def: "Feature intensity produced by XCMS findPeaks() from baseline corrected integrated peak intensity." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002735 ! feature-level quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002831
@@ -18552,7 +18368,6 @@ name: XCMS:maxo
 def: "Feature intensity produced by XCMS findPeaks() from maximum peak intensity." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002735 ! feature-level quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002832
@@ -18560,7 +18375,6 @@ name: XCMS:area
 def: "Feature intensity produced by XCMS findPeaks() from feature area that is not normalized by the scan rate." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002735 ! feature-level quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002833
@@ -18574,7 +18388,6 @@ name: ProteomeDiscoverer:Delta Score
 def: "The Delta Score reported by Proteome Discoverer version 2." [PSI:PI]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002835
@@ -18588,7 +18401,6 @@ name: iProX dataset identifier
 def: "Dataset identifier issued by the iProX repository. A dataset can refer to either a single sample as part of a study, or all samples that are part of the study corresponding to a publication." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002837
@@ -18596,7 +18408,6 @@ name: iProX dataset URI
 def: "URI that allows the access to one dataset in the iProX repository. A dataset can refer to either a single sample as part of a study, or all samples that are part of the study corresponding to a publication." [PSI:PI]
 xref: value-type:xsd\:anyURI "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
-relationship: has_value_type xsd\:anyURI ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002838
@@ -18622,25 +18433,22 @@ name: external HDF5 dataset
 def: "The HDF5 dataset location containing the binary data, relative to the dataset containing the mzML. Also indicates that there is no data in the <binary> section of the BinaryDataArray." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002840 ! external reference data
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002842
 name: external offset
 def: "The position in the external data where the array begins." [PSI:PI]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
-is_a: MS:1002840 ! external reference data
 relationship: has_units UO:0000189 ! Count
-relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term.
+is_a: MS:1002840 ! external reference data
 
 [Term]
 id: MS:1002843
 name: external array length
 def: "Describes how many fields an array contains." [PSI:PI]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
-is_a: MS:1002840 ! external reference data
 relationship: has_units UO:0000189 ! Count
-relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term.
+is_a: MS:1002840 ! external reference data
 
 [Term]
 id: MS:1002844
@@ -18654,7 +18462,6 @@ name: Associated file URI
 def: "URI of one external file associated to the PRIDE experiment (maybe through a PX submission)." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002844 ! Experiment additional parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002846
@@ -18662,7 +18469,6 @@ name: Associated raw file URI
 def: "URI of one raw data file associated to the PRIDE experiment (maybe through a PX submission)." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002845 ! Associated file URI
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002847
@@ -18670,7 +18476,6 @@ name: ProteomeCentral dataset URI
 def: "URI associated to one PX submission in ProteomeCentral." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002844 ! Experiment additional parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002848
@@ -18678,7 +18483,6 @@ name: Result file URI
 def: "URI of one file labeled as 'Result', associated to one PX submission." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002845 ! Associated file URI
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002849
@@ -18686,7 +18490,6 @@ name: Search engine output file URI
 def: "URI of one search engine output file associated to one PX submission." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002845 ! Associated file URI
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002850
@@ -18694,7 +18497,6 @@ name: Peak list file URI
 def: "URI of one of one search engine output file associated to one PX submission." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002845 ! Associated file URI
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002851
@@ -18702,7 +18504,6 @@ name: Other type file URI
 def: "URI of one file labeled as 'Other', associated to one PX submission." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002845 ! Associated file URI
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002852
@@ -18710,7 +18511,6 @@ name: Dataset FTP location
 def: "FTP location of one entire PX data set." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002844 ! Experiment additional parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002853
@@ -18754,7 +18554,6 @@ name: Additional associated raw file URI
 def: "Additional URI of one raw data file associated to the PRIDE experiment (maybe through a PX submission). The URI is provided via an additional resource to PRIDE." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002845 ! Associated file URI
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002860
@@ -18762,7 +18561,6 @@ name: Gel image file URI
 def: "URI of one gel image file associated to one PX submission." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002845 ! Associated file URI
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002861
@@ -18770,7 +18568,6 @@ name: Reprocessed complete dataset
 def: "All the raw files included in the original dataset (or group of original datasets) have been reanalysed." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002844 ! Experiment additional parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002862
@@ -18778,7 +18575,6 @@ name: Reprocessed subset dataset
 def: "A subset of the raw files included in the original dataset (or group of original datasets) has been reanalysed." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002844 ! Experiment additional parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002863
@@ -18804,7 +18600,6 @@ name: Reference
 def: "Literature reference associated with one dataset (including the authors, title, year and journal details). The value field can be used for the PubMedID, or to specify if one manuscript is just submitted or accepted, but it does not have a PubMedID yet." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002844 ! Experiment additional parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002867
@@ -18845,7 +18640,6 @@ name: Panorama Public dataset identifier
 def: "Dataset identifier issued by the Panorama Public repository. A dataset can refer to either a single sample as part of a study, or all samples that are part of the study corresponding to a publication." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002873
@@ -18853,7 +18647,6 @@ name: Panorama Public dataset URI
 def: "URI that allows the access to one dataset in the Panorama Public repository. A dataset can refer to either a single sample as part of a study, or all samples that are part of the study corresponding to a publication." [PSI:PI]
 xref: value-type:xsd\:anyURI "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
-relationship: has_value_type xsd\:anyURI ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002874
@@ -18939,7 +18732,6 @@ name: Progenesis QI normalised abundance
 def: "The normalised abundance produced by Progenesis QI LC-MS." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002886 ! small molecule quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002888
@@ -18953,7 +18745,6 @@ name: Progenesis MetaScope score
 def: "The confidence score produced by Progenesis QI." [PSI:PI]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002888 ! small molecule confidence measure
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002890
@@ -18961,7 +18752,6 @@ name: fragmentation score
 def: "The fragmentation confidence score." [PSI:PI]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002888 ! small molecule confidence measure
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002891
@@ -18969,7 +18759,6 @@ name: isotopic fit score
 def: "The isotopic fit confidence score." [PSI:PI]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002888 ! small molecule confidence measure
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002892
@@ -18990,7 +18779,6 @@ name: InChIKey
 def: "Unique chemical structure identifier for chemical compounds." [PMID:273343401]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001405 ! spectrum identification result details
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002895
@@ -19004,15 +18792,15 @@ name: compound identification confidence level
 def: "Confidence level for annotation of identified compounds as defined by the Metabolomics Standards Initiative (MSI). The value slot can have the values 'Level 0' until 'Level 4'." [PMID:29748461]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002895 ! small molecule identification attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002897
 name: isotopomer peak
 def: "OBSOLETE Identifies a peak when no de-isotoping has been performed. The value slot reports the isotopomer peak, e.g. '2H', '13C', '15N', '18O', '31P'." [PSI:PI]
+comment: This term was obsoleted because it was replaced by the more exact terms MS:1002956 'isotopic ion MS peak', MS:1002957 'isotopomer MS peak' and MS:1002958 'isotopologue MS peak' instead.
 xref: value-type:xsd:string "The allowed value-type for this CV term."
 is_a: MS:1000231 ! peak
-relationship: has_value_type xsd:string ! The allowed value-type for this CV term.
+is_obsolete: true
 
 [Term]
 id: MS:1002898
@@ -19075,7 +18863,6 @@ def: "Estimation of the global false discovery rate of proteoforms." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002905 ! proteoform-level identification statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002908
@@ -19084,7 +18871,6 @@ def: "Estimation of the local false discovery rate of proteoforms." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002905 ! proteoform-level identification statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002909
@@ -19098,7 +18884,6 @@ name: proteoform-level global FDR threshold
 def: "Threshold for the global false discovery rate of proteoforms." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002909 ! proteoform-level statistical threshold
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002911
@@ -19106,7 +18891,6 @@ name: proteoform-level local FDR threshold
 def: "Threshold for the local false discovery rate of proteoforms." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002909 ! proteoform-level statistical threshold
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002912
@@ -19132,7 +18916,6 @@ name: TopPIC:error tolerance
 def: "Error tolerance for precursor and fragment masses in PPM." [PSI:PI]
 xref: value-type:xsd\:integer "The allowed value-type for this CV term."
 is_a: MS:1002912 ! TopPIC input parameter
-relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002916
@@ -19140,7 +18923,6 @@ name: TopPIC:max shift
 def: "Maximum value of the mass shift (in Dalton) of an unexpected modification." [PSI:PI]
 xref: value-type:xsd\:integer "The allowed value-type for this CV term."
 is_a: MS:1002912 ! TopPIC input parameter
-relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002917
@@ -19148,7 +18930,6 @@ name: TopPIC:min shift
 def: "Minimum value of the mass shift (in Dalton) of an unexpected modification." [PSI:PI]
 xref: value-type:xsd\:integer "The allowed value-type for this CV term."
 is_a: MS:1002912 ! TopPIC input parameter
-relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002918
@@ -19156,7 +18937,6 @@ name: TopPIC:shift num
 def: "Maximum number of unexpected modifications in a proteoform spectrum match." [PSI:PI]
 xref: value-type:xsd\:integer "The allowed value-type for this CV term."
 is_a: MS:1002912 ! TopPIC input parameter
-relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002919
@@ -19164,7 +18944,6 @@ name: TopPIC:spectral cutoff type
 def: "Spectrum-level cutoff type for filtering identified proteoform spectrum matches." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002912 ! TopPIC input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002920
@@ -19172,7 +18951,6 @@ name: TopPIC:spectral cutoff value
 def: "Spectrum-level cutoff value for filtering identified proteoform spectrum matches." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002912 ! TopPIC input parameter
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002921
@@ -19180,7 +18958,6 @@ name: TopPIC:proteoform-level cutoff type
 def: "Proteoform-level cutoff type for filtering identified proteoform spectrum matches." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002912 ! TopPIC input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002922
@@ -19188,7 +18965,6 @@ name: TopPIC:proteoform-level cutoff value
 def: "Proteoform-level cutoff value for filtering identified proteoform spectrum matches." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002912 ! TopPIC input parameter
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002923
@@ -19196,7 +18972,6 @@ name: TopPIC:generating function
 def: "P-value and E-value estimation using generating function." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002912 ! TopPIC input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002924
@@ -19204,7 +18979,6 @@ name: TopPIC:combined spectrum number
 def: "Number of combined spectra." [PSI:PI]
 xref: value-type:xsd\:integer "The allowed value-type for this CV term."
 is_a: MS:1002912 ! TopPIC input parameter
-relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002925
@@ -19218,7 +18992,6 @@ name: TopPIC:thread number
 def: "Number of threads used in TopPIC." [PSI:PI]
 xref: value-type:xsd\:integer "The allowed value-type for this CV term."
 is_a: MS:1002912 ! TopPIC input parameter
-relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002927
@@ -19226,7 +18999,6 @@ name: TopPIC:use TopFD feature
 def: "Proteoform identification using TopFD feature file." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002912 ! TopPIC input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002928
@@ -19236,7 +19008,6 @@ xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1002353 ! PSM-level e-value
 relationship: has_order MS:1002109 ! lower score better
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002929
@@ -19245,7 +19016,6 @@ def: "TopPIC spectrum-level FDR." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1002351 ! PSM-level local FDR
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002930
@@ -19254,7 +19024,6 @@ def: "TopPIC proteoform-level FDR." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002908 ! proteoform-level local FDR
 is_a: MS:1002906 ! search engine specific score for proteoforms
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002931
@@ -19263,7 +19032,6 @@ def: "TopPIC spectrum-level p-value." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1002352 ! PSM-level p-value
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002932
@@ -19271,7 +19039,6 @@ name: TopPIC:MIScore
 def: "Modification identification score." [PMID:27291504]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001968 ! PTM localization PSM-level statistic
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002933
@@ -19279,7 +19046,6 @@ name: TopPIC:MIScore threshold
 def: "TopPIC:MIScore threshold." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002555 ! PTM localization score threshold
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002934
@@ -19305,7 +19071,6 @@ name: TopMG:error tolerance
 def: "Error tolerance for precursor and fragment masses in PPM." [PSI:PI]
 xref: value-type:xsd\:integer "The allowed value-type for this CV term."
 is_a: MS:1002934 ! TopMG input parameter
-relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002938
@@ -19313,7 +19078,6 @@ name: TopMG:max shift
 def: "Maximum value of the mass shift (in Dalton)." [PSI:PI]
 xref: value-type:xsd\:integer "The allowed value-type for this CV term."
 is_a: MS:1002934 ! TopMG input parameter
-relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002939
@@ -19321,7 +19085,6 @@ name: TopMG:spectral cutoff type
 def: "Spectrum-level cutoff type for filtering identified proteoform spectrum matches." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002934 ! TopMG input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002940
@@ -19329,7 +19092,6 @@ name: TopMG:spectral cutoff value
 def: "Spectrum-level cutoff value for filtering identified proteoform spectrum matches." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002934 ! TopMG input parameter
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002941
@@ -19337,7 +19099,6 @@ name: TopMG:proteoform-level cutoff type
 def: "Proteoform-level cutoff type for filtering identified proteoform spectrum matches." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002934 ! TopMG input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002942
@@ -19345,7 +19106,6 @@ name: TopMG:proteoform-level cutoff value
 def: "Proteoform-level cutoff value for filtering identified proteoform spectrum matches." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002934 ! TopMG input parameter
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002943
@@ -19359,7 +19119,6 @@ name: TopMG:thread number
 def: "Number of threads used in TopMG." [PSI:PI]
 xref: value-type:xsd\:integer "The allowed value-type for this CV term."
 is_a: MS:1002934 ! TopMG input parameter
-relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002945
@@ -19367,7 +19126,6 @@ name: TopMG:use TopFD feature
 def: "Proteoform identification using TopFD feature file." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002934 ! TopMG input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002946
@@ -19375,7 +19133,6 @@ name: TopMG:proteoform graph gap size
 def: "Gap size in constructing proteoform graph." [PSI:PI]
 xref: value-type:xsd\:integer "The allowed value-type for this CV term."
 is_a: MS:1002934 ! TopMG input parameter
-relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002947
@@ -19383,7 +19140,6 @@ name: TopMG:variable PTM number
 def: "Maximum number of variable PTMs." [PSI:PI]
 xref: value-type:xsd\:integer "The allowed value-type for this CV term."
 is_a: MS:1002934 ! TopMG input parameter
-relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002948
@@ -19391,7 +19147,6 @@ name: TopMG:variable PTM number in proteoform graph gap
 def: "Maximum number of variable PTMs in a proteoform graph gap." [PSI:PI]
 xref: value-type:xsd\:integer "The allowed value-type for this CV term."
 is_a: MS:1002934 ! TopMG input parameter
-relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002949
@@ -19399,7 +19154,6 @@ name: TopMG:use ASF-DIAGONAL
 def: "Protein filtering using ASF-DIAGONAL method." [PMID:29327814]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002934 ! TopMG input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002950
@@ -19409,7 +19163,6 @@ xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002353 ! PSM-level e-value
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002109 ! lower score better
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002951
@@ -19418,7 +19171,6 @@ def: "TopMG spectrum-level FDR." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002351 ! PSM-level local FDR
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002952
@@ -19427,7 +19179,6 @@ def: "TopMG proteoform-level FDR." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002908 ! proteoform-level local FDR
 is_a: MS:1002906 ! search engine specific score for proteoforms
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002953
@@ -19436,7 +19187,6 @@ def: "TopMG spectrum-level p-value." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002352 ! PSM-level p-value
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002954
@@ -19445,7 +19195,6 @@ def: "Structural molecular descriptor for the effective interaction area between
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1000861 ! molecular entity property
 relationship: has_units UO:0000324 ! square angstrom
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002955
@@ -19453,7 +19202,6 @@ name: hr-ms compound identification confidence level
 def: "Refined High Resolution mass spectrometry confidence level for annotation of identified compounds as proposed by Schymanski et al. The value slot can have the values 'Level 1', 'Level 2', 'Level 2a', 'Level 2b', 'Level 3', 'Level 4', and 'Level 5'." [PMID:24476540]
 xref: value-type:xsd:string "The allowed value-type for this CV term."
 is_a: MS:1002895 ! small molecule identification attribute
-relationship: has_value_type xsd:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002956
@@ -19461,7 +19209,6 @@ name: isotopic ion MS peak
 def: "A mass spectrometry peak that represents one or more isotopic ions. The value slot contains a description of the represented isotope set, e.g. 'M+1 peak'." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000231 ! peak
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002957
@@ -19469,7 +19216,6 @@ name: isotopomer MS peak
 def: "The described isotopomer mass spectrometric signal. The value slot contains a description of the represented isotopomer, e.g. '13C peak', '15N peak', '2H peak', '18O peak' or '31P peak'." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002956 ! isotopic ion MS peak
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002958
@@ -19477,7 +19223,6 @@ name: isotopologue MS peak
 def: "The described isotopologue mass spectrometric signal. The value slot contains a description of the represented isotopologue, e.g. '13C1 peak' or '15N1 peak'." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002956 ! isotopic ion MS peak
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002959
@@ -19485,7 +19230,6 @@ name: isomer
 def: "One of several species (or molecular entities) that have the same atomic composition (molecular formula) but different line formulae or different stereochemical formulae." [https://goldbook.iupac.org/html/I/I03289.html]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000859 ! molecule
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002960
@@ -19493,7 +19237,6 @@ name: isotopomer
 def: "An isomer that differs from another only in the spatial distribution of the constitutive isotopic atoms." [https://goldbook.iupac.org/html/I/I03352.html]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002959 ! isomer
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002961
@@ -19501,7 +19244,6 @@ name: isotopologue
 def: "A molecular entity that differs only in isotopic composition (number of isotopic substitutions)." [https://goldbook.iupac.org/html/I/I03351.html]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002959 ! isomer
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002962
@@ -19681,7 +19423,6 @@ def: "The IdentiPy result 'RHNS'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001153 ! search engine specific score
 relationship: has_order MS:1002108 ! higher score better
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002989
@@ -19690,7 +19431,6 @@ def: "The IdentiPy result 'hyperscore'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001153 ! search engine specific score
 relationship: has_order MS:1002108 ! higher score better
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002990
@@ -19712,7 +19452,6 @@ xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
 relationship: has_order MS:1002108 ! higher score better
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002996
@@ -19726,7 +19465,6 @@ name: ProteomeXchange dataset identifier reanalysis number
 def: "Index number of a reanalysis within a ProteomeXchange reprocessed dataset identifier container (RPXD)." [PSI:PI]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
-relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002998
@@ -19783,7 +19521,6 @@ def: "Array of population mean ion mobility values based on ion separation in ga
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002893 ! ion mobility array
 relationship: has_units MS:1002814 ! volt-second per square centimeter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003007
@@ -19793,7 +19530,6 @@ xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002893 ! ion mobility array
 relationship: has_units UO:0000028 ! millisecond
 relationship: has_units UO:0000010 ! second
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003008
@@ -19802,7 +19538,6 @@ def: "Array of raw ion mobility values based on ion separation in gaseous phase 
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002893 ! ion mobility array
 relationship: has_units MS:1002814 ! volt-second per square centimeter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003009
@@ -19857,7 +19592,6 @@ is_a: MS:1002490 ! peptide-level scoring
 is_a: MS:1001153 ! search engine specific score
 relationship: has_order MS:1002108 ! higher score better
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003017
@@ -19868,7 +19602,6 @@ is_a: MS:1002490 ! peptide-level scoring
 is_a: MS:1001153 ! search engine specific score
 relationship: has_order MS:1002108 ! higher score better
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003018
@@ -19916,7 +19649,6 @@ xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1001153 ! search engine specific score
 relationship: has_order MS:1002108 ! higher score better
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003025
@@ -19954,7 +19686,6 @@ name: Mascot:MinNumSigUniqueSeqs
 def: "Minimum number of significant unique sequences required in a protein hit. The setting is only relevant if the protein grouping strategy is 'family clustering'." [PSI:PI]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1002095 ! Mascot input parameter
-relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003031
@@ -19962,7 +19693,6 @@ name: CPTAC accession number
 def: "Main identifier of a CPTAC dataset." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003032
@@ -19970,7 +19700,6 @@ name: compound identification confidence code in MS-DIAL
 def: "The confidence code to describe the confidence of annotated compounds as defined by the MS-DIAL program." [PMID:25938372, http://prime.psc.riken.jp/Metabolomics_Software/MS-DIAL]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002895 ! small molecule identification attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003033
@@ -20085,6 +19814,9 @@ id: MS:1003051
 name: peptidoform ion
 def: "Peptidoform that has formed an adduct with an ion, thereby rendering it potentially detectable with a mass spectrometer. Commonly called a 'precursor' or 'precursor ion' or 'parent ion'." [PSI:PI]
 is_a: MS:1003049 ! peptidoform
+synonym: "precursor" RELATED []
+synonym: "precursor ion" RELATED []
+synonym: "parent ion" RELATED []
 
 [Term]
 id: MS:1003052
@@ -20264,10 +19996,9 @@ is_a: MS:1003078 ! interpreted spectrum attribute
 id: MS:1003081
 name: unidentified modification monoisotopic mass delta
 def: "Monoisotopic mass delta in Daltons of an amino acid residue modification whose atomic composition or molecular identity has not been determined. This term should not be used for modifications of known molecular identity such as those available in Unimod, RESID or PSI-MOD. This term MUST NOT be used inside the <Modification> element in mzIdentML." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001471 ! peptide modification details
+xref: value-type:xsd\:double "The allowed value-type for this CV term."
 relationship: has_units UO:0000221 ! dalton
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003082
@@ -20288,7 +20019,6 @@ name: processed data file
 def: "File that contains data that has been substantially processed or transformed from what was originally acquired by an instrument." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000577 ! source data file
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003085
@@ -20297,7 +20027,6 @@ def: "Intensity of the precursor ion in the previous MSn-1 scan (prior in time t
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001141 ! intensity of precursor ion
 is_a: MS:1000499 ! spectrum attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003086
@@ -20306,7 +20035,6 @@ def: "Intensity of the precursor ion current as measured by its apex point over 
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001141 ! intensity of precursor ion
 is_a: MS:1000499 ! spectrum attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003087
@@ -20345,7 +20073,6 @@ name: number of mantissa bits truncated
 def: "Number of extraneous mantissa bits truncated to improve subsequent compression." [PSI:MS]
 xref: value-type:xsd\:positiveInteger "Number of mantissa bits truncated."
 is_a: MS:1003091 ! binary data compression parameter
-relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003093
@@ -20378,7 +20105,6 @@ name: MaxQuant protein group-level score
 def: "The probability based MaxQuant protein group score." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002368 ! search engine specific score for protein groups
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003098
@@ -20386,7 +20112,6 @@ name: Andromeda peptide PEP
 def: "Peptide probability from Andromeda." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002358 ! search engine specific peptide sequence-level identification statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003099
@@ -20394,7 +20119,6 @@ name: MaxQuant-DIA peptide PEP
 def: "Peptide probability from MaxQuant-DIA algorithm." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002358 ! search engine specific peptide sequence-level identification statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003100
@@ -20402,7 +20126,6 @@ name: MaxQuant-DIA score
 def: "PSM evidence score from MaxQuant-DIA algorithm." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003101
@@ -20410,7 +20133,6 @@ name: MaxQuant-DIA PEP
 def: "PSM evidence PEP probability from MaxQuant-DIA algorithm." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003102
@@ -20418,7 +20140,6 @@ name: NIST msp comment
 def: "Term for a comment field withing the NIST msp file format" [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000499 ! spectrum attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003103
@@ -20470,7 +20191,6 @@ def: "SIM-XL identification search engine score" [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002108 ! higher score better
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003111
@@ -20490,7 +20210,6 @@ name: OpenMS:ConsensusID PEP
 def: "The OpenMS ConsesusID tool posterior error probability" [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003114
@@ -20498,7 +20217,6 @@ name: OpenMS:Best PSM Score
 def: "The score of the best PSM selected by the underlying identification tool" [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002358 ! search engine specific peptide sequence-level identification statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003115
@@ -20506,7 +20224,6 @@ name: OpenMS:Target-decoy PSM q-value
 def: "The OpenMS Target-decoy q-values at PSM level" [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003116
@@ -20514,7 +20231,6 @@ name: OpenMS:Target-decoy peptide q-value
 def: "The OpenMS Target-decoy q-values at peptide sequence level" [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002358 ! search engine specific peptide sequence-level identification statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003117
@@ -20522,7 +20238,6 @@ name: OpenMS:Target-decoy protein q-value
 def: "The OpenMS Target-decoy q-values at protein level" [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003118
@@ -20537,7 +20252,6 @@ name: EPIFANY:Protein posterior probability
 def: "Protein Posterior probability calculated by EPIFANY protein inference algorithm" [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003120
@@ -20545,7 +20259,6 @@ name: OpenMS:LFQ intensity
 def: "The data type LFQ intensity produced by OpenMS." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003121
@@ -20553,7 +20266,6 @@ name: OpenMS:LFQ spectral count
 def: "The data type LFQ spectral count produced by OpenMS." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003122
@@ -20581,7 +20293,6 @@ xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002354 ! PSM-level q-value
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002109 ! lower score better
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003126
@@ -20590,7 +20301,6 @@ def: "ProSight spectrum-level P-score." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002109 ! lower score better
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003127
@@ -20600,7 +20310,6 @@ xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002353 ! PSM-level e-value
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002109 ! lower score better
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003128
@@ -20609,7 +20318,6 @@ def: "ProSight spectrum-level C-score." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002108 ! higher score better
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003129
@@ -20619,7 +20327,6 @@ xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002905 ! proteoform-level identification statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
 relationship: has_order MS:1002109 ! lower score better
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003130
@@ -20628,7 +20335,6 @@ def: "ProSight proteoform-level Q-value." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1003129 ! proteoform-level Q-value
 relationship: has_order MS:1002109 ! lower score better
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003131
@@ -20649,7 +20355,6 @@ def: "Estimation of the Q-value for isoforms." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1003132 ! isoform-level identification statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003134
@@ -20658,7 +20363,6 @@ def: "ProSight isoform-level Q-value." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1003133 ! isoform-level Q-value
 relationship: has_order MS:1002109 ! lower score better
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003135
@@ -20667,7 +20371,6 @@ def: "ProSight protein-level Q-value." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001869 ! protein-level q-value
 relationship: has_order MS:1002109 ! lower score better
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003136
@@ -20688,7 +20391,6 @@ def: "If true, runs delta m mode in ProSight." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1003136 ! ProSight input parameter
 is_a: MS:1003137 ! TDPortal input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003139
@@ -20697,7 +20399,6 @@ def: "If true, runs Subsequence Search mode in ProSight." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1003136 ! ProSight input parameter
 is_a: MS:1003137 ! TDPortal input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003140
@@ -20706,7 +20407,6 @@ def: "If true, runs Annotated Proteoform Search mode in ProSight." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1003136 ! ProSight input parameter
 is_a: MS:1003137 ! TDPortal input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003141
@@ -20764,15 +20464,14 @@ relationship: has_regexp MS:1002505 ! regular expression for modification locali
 [Term]
 id: MS:1003149
 name: PTMProphet normalized information content
-def: "PTMProphet-computed PSM-specific normalized (0.0 - 1.0) measure of information content across all modifications of a specific type." [DOI:10.1021/acs.jproteome.9b00205, PMID:31290668]
+def: " PTMProphet-computed PSM-specific normalized (0.0 – 1.0) measure of information content across all modifications of a specific type." [DOI:10.1021/acs.jproteome.9b00205, PMID:31290668]
 is_a: MS:1001968 ! PTM localization PSM-level statistic
 relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
-
 
 [Term]
 id: MS:1003150
 name: PTMProphet information content
-def: "PTMProphet-computed PSM-specific measure of information content per modification type ranging from 0 to m, where m is the number of modifications of a specific type." [DOI:10.1021/acs.jproteome.9b00205, PMID:31290668]
+def: " PTMProphet-computed PSM-specific measure of information content per modification type ranging from 0 to m, where m is the number of modifications of a specific type." [DOI:10.1021/acs.jproteome.9b00205, PMID:31290668]
 is_a: MS:1001968 ! PTM localization PSM-level statistic
 relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
 
@@ -20782,7 +20481,6 @@ name: SHA-256
 def: "SHA-256 (member of Secure Hash Algorithm-2 family) is a cryptographic hash function designed by the National Security Agency (NSA) and published by the NIST as a U. S. government standard. It is also used to verify file integrity." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000561 ! data file checksum type
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003152
@@ -20798,7 +20496,6 @@ xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002893 ! ion mobility array
 relationship: has_units UO:0000028 ! millisecond
 relationship: has_units UO:0000010 ! second
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003154
@@ -20808,7 +20505,6 @@ xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002893 ! ion mobility array
 relationship: has_units UO:0000028 ! millisecond
 relationship: has_units UO:0000010 ! second
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003155
@@ -20817,7 +20513,6 @@ def: "Array of ion mobility values based on ion separation in gaseous phase due 
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002893 ! ion mobility array
 relationship: has_units MS:1002814 ! volt-second per square centimeter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003156
@@ -20827,7 +20522,6 @@ xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002893 ! ion mobility array
 relationship: has_units UO:0000028 ! millisecond
 relationship: has_units UO:0000010 ! second
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003157
@@ -20836,7 +20530,6 @@ def: "Array of m/z values representing the lower bound m/z of the quadrupole pos
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000513 ! binary data array
 relationship: has_units MS:1000040 ! m/z
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003158
@@ -20845,7 +20538,6 @@ def: "Array of m/z values representing the upper bound m/z of the quadrupole pos
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000513 ! binary data array
 relationship: has_units MS:1000040 ! m/z
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003159
@@ -20864,20 +20556,6 @@ id: MS:1003161
 name: quality control data format
 def: "Grouping term for quality control data formats." [PSI:MS]
 is_a: MS:1001459 ! file format
-
-[Term]
-id: MS:1003162
-name: PTX-QC
-def: "Proteomics (PTX) - QualityControl (QC) software for QC report generation and visualization." [DOI:10.1021/acs.jproteome.5b00780, PMID:26653327, https://github.com/cbielow/PTXQC/]
-is_a: MS:1001456 ! analysis software
-synonym: "PTXQC" EXACT []
-
-[Term]
-id: MS:1003163
-name: analyte mixture members
-def: "The set of analyte identifiers that compose an interpretation of a spectrum." [PSI:PI]
-is_a: MS:1003078 ! interpreted spectrum attribute
-relationship: has_value_type MS:1002712 ! list of integers
 
 [Term]
 id: PEFF:0000001
@@ -20901,396 +20579,355 @@ is_a: PEFF:0000001 ! PEFF CV term
 id: PEFF:0000008
 name: DbName
 def: "PEFF keyword for the sequence database name." [PSI:PEFF]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: PEFF:0000002 ! PEFF file header section term
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
+xref: value-type:xsd\:string "The allowed value-type for this CV term."
 
 [Term]
 id: PEFF:0000009
 name: Prefix
 def: "PEFF keyword for the sequence database prefix." [PSI:PEFF]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: PEFF:0000002 ! PEFF file header section term
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
+xref: value-type:xsd\:string "The allowed value-type for this CV term."
 
 [Term]
 id: PEFF:0000010
 name: DbDescription
 def: "PEFF keyword for the sequence database short description." [PSI:PEFF]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: PEFF:0000002 ! PEFF file header section term
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
+xref: value-type:xsd\:string "The allowed value-type for this CV term."
 
 [Term]
 id: PEFF:0000011
 name: Decoy
 def: "PEFF keyword for the specifying whether the sequence database is a decoy database." [PSI:PEFF]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: PEFF:0000002 ! PEFF file header section term
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
+xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 
 [Term]
 id: PEFF:0000012
 name: DbSource
 def: "PEFF keyword for the source of the database file." [PSI:PEFF]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: PEFF:0000002 ! PEFF file header section term
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
+xref: value-type:xsd\:string "The allowed value-type for this CV term."
 
 [Term]
 id: PEFF:0000013
 name: DbVersion
 def: "PEFF keyword for the database version (release date) according to database provider." [PSI:PEFF]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: PEFF:0000002 ! PEFF file header section term
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
+xref: value-type:xsd\:string "The allowed value-type for this CV term."
 
 [Term]
 id: PEFF:0000014
 name: DbDate
 def: "OBSOLETE PEFF keyword for the database date (release or file date of the source) according to database provider." [PSI:PEFF]
+comment: This term was obsoleted.
 is_a: PEFF:0000002 ! PEFF file header section term
+is_obsolete: true
 
 [Term]
 id: PEFF:0000015
 name: NumberOfEntries
 def: "PEFF keyword for the sumber of sequence entries in the database." [PSI:PEFF]
-xref: value-type:xsd\:integer "The allowed value-type for this CV term."
 is_a: PEFF:0000002 ! PEFF file header section term
-relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term.
+xref: value-type:xsd\:integer "The allowed value-type for this CV term."
 
 [Term]
 id: PEFF:0000016
 name: Conversion
 def: "PEFF keyword for the description of the conversion from original format to this current one." [PSI:PEFF]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: PEFF:0000002 ! PEFF file header section term
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
+xref: value-type:xsd\:string "The allowed value-type for this CV term."
 
 [Term]
 id: PEFF:0000017
 name: SequenceType
 def: "PEFF keyword for the molecular type of the sequences." [PSI:PEFF]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: PEFF:0000002 ! PEFF file header section term
+xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: has_regexp PEFF:1002002 ! regular expression for PEFF molecular sequence type
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0000018
 name: SpecificKey
 def: "PEFF keyword for database specific keywords not included in the current controlled vocabulary." [PSI:PEFF]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: PEFF:0000002 ! PEFF file header section term
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
+xref: value-type:xsd\:string "The allowed value-type for this CV term."
 
 [Term]
 id: PEFF:0000019
 name: SpecificValue
 def: "PEFF keyword for the specific values for a custom key." [PSI:PEFF]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: PEFF:0000002 ! PEFF file header section term
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
+xref: value-type:xsd\:string "The allowed value-type for this CV term."
 
 [Term]
 id: PEFF:0000020
 name: DatabaseDescription
 def: "PEFF keyword for the short description of the PEFF file." [PSI:PEFF]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: PEFF:0000002 ! PEFF file header section term
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
+xref: value-type:xsd\:string "The allowed value-type for this CV term."
 
 [Term]
 id: PEFF:0000021
 name: GeneralComment
 def: "PEFF keyword for a general comment." [PSI:PEFF]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: PEFF:0000002 ! PEFF file header section term
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
+xref: value-type:xsd\:string "The allowed value-type for this CV term."
 
 [Term]
 id: PEFF:0000022
 name: ProteoformDb
 def: "PEFF keyword that when set to 'true' indicates that the database contains complete proteoforms." [PSI:PEFF]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: PEFF:0000002 ! PEFF file header section term
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
+xref: value-type:xsd\:string "The allowed value-type for this CV term."
 
 [Term]
 id: PEFF:0000023
 name: OptionalTagDef
 def: "PEFF keyword for the short tag (abbreviation) and longer definition used to annotate a sequence annotation (such as variant or modification) in the OptionalTag location." [PSI:PEFF]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: PEFF:0000002 ! PEFF file header section term
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
+xref: value-type:xsd\:string "The allowed value-type for this CV term."
 
 [Term]
 id: PEFF:0000024
 name: HasAnnotationIdentifiers
 def: "PEFF keyword that when set to 'true' indicates that entries in the database have identifiers for each annotation." [PSI:PEFF]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: PEFF:0000002 ! PEFF file header section term
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
+xref: value-type:xsd\:string "The allowed value-type for this CV term."
 
 [Term]
 id: PEFF:0001001
 name: DbUniqueId
 def: "OBSOLETE Sequence database unique identifier." [PSI:PEFF]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
+comment: This term was made obsolete because decided in Heidelberg 2018-04 that this is redundant.
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
+xref: value-type:xsd\:string "The allowed value-type for this CV term."
+is_obsolete: true
 
 [Term]
 id: PEFF:0001002
 name: PName
 def: "PEFF keyword for the protein full name." [PSI:PEFF]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
+xref: value-type:xsd\:string "The allowed value-type for this CV term."
 
 [Term]
 id: PEFF:0001003
 name: NcbiTaxId
 def: "PEFF keyword for the NCBI taxonomy identifier." [PSI:PEFF]
-xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
+xref: value-type:xsd\:int "The allowed value-type for this CV term."
 
 [Term]
 id: PEFF:0001004
 name: TaxName
 def: "PEFF keyword for the taxonomy name (latin or common name)." [PSI:PEFF]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
+xref: value-type:xsd\:string "The allowed value-type for this CV term."
 
 [Term]
 id: PEFF:0001005
 name: GName
 def: "PEFF keyword for the gene name." [PSI:PEFF]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
+xref: value-type:xsd\:string "The allowed value-type for this CV term."
 
 [Term]
 id: PEFF:0001006
 name: Length
 def: "PEFF keyword for the sequence length." [PSI:PEFF]
-xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
+xref: value-type:xsd\:int "The allowed value-type for this CV term."
 
 [Term]
 id: PEFF:0001007
 name: SV
 def: "PEFF keyword for the sequence version." [PSI:PEFF]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
+xref: value-type:xsd\:string "The allowed value-type for this CV term."
 
 [Term]
 id: PEFF:0001008
 name: EV
 def: "PEFF keyword for the entry version." [PSI:PEFF]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
+xref: value-type:xsd\:string "The allowed value-type for this CV term."
 
 [Term]
 id: PEFF:0001009
 name: PE
 def: "PEFF keyword for the Protein Evidence; A UniProtKB code 1-5." [PSI:PEFF]
-xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
+xref: value-type:xsd\:int "The allowed value-type for this CV term."
 
 [Term]
 id: PEFF:0001010
 name: Processed
 def: "PEFF keyword for information on how the full length original protein sequence can be processed into shorter components such as signal peptides and chains." [PSI:PEFF]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: PEFF:0000003 ! PEFF file sequence entry term
+xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: has_regexp PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0001011
 name: Variant
 def: "OBSOLETE Sequence variation (substitution, insertion, deletion)." [PSI:PEFF]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
+comment: This term was made obsolete in favor of VariantSimple and VariantComplex.
 is_a: PEFF:0000003 ! PEFF file sequence entry term
+xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: has_regexp PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
+is_obsolete: true
 
 [Term]
 id: PEFF:0001012
 name: ModResPsi
 def: "PEFF keyword for the modified residue with PSI-MOD identifier." [PSI:PEFF]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: PEFF:0000003 ! PEFF file sequence entry term
+xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: has_regexp PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0001013
 name: ModRes
 def: "PEFF keyword for the modified residue without aPSI-MOD or UniMod identifier." [PSI:PEFF]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: PEFF:0000003 ! PEFF file sequence entry term
+xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: has_regexp PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0001014
 name: AltAC
 def: "PEFF keyword for the Alternative Accession Code." [PSI:PEFF]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
+xref: value-type:xsd\:string "The allowed value-type for this CV term."
 
 [Term]
 id: PEFF:0001015
 name: SeqStatus
 def: "PEFF keyword for the sequence status. Complete or Fragment." [PSI:PEFF]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: PEFF:0000003 ! PEFF file sequence entry term
+xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: has_regexp PEFF:1002003 ! regular expression for PEFF sequence status
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0001016
 name: CC
 def: "PEFF keyword for the entry associated comment." [PSI:PEFF]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
+xref: value-type:xsd\:string "The allowed value-type for this CV term."
 
 [Term]
 id: PEFF:0001017
 name: KW
 def: "PEFF keyword for the entry associated keyword(s)." [PSI:PEFF]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
+xref: value-type:xsd\:string "The allowed value-type for this CV term."
 
 [Term]
 id: PEFF:0001018
 name: GO
 def: "PEFF keyword for the Gene Ontology code." [PSI:PEFF]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
+xref: value-type:xsd\:string "The allowed value-type for this CV term."
 
 [Term]
 id: PEFF:0001019
 name: XRef
 def: "PEFF keyword for the cross-reference to an external resource." [PSI:PEFF]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
+xref: value-type:xsd\:string "The allowed value-type for this CV term."
 
 [Term]
 id: PEFF:0001020
 name: mature protein
 def: "Portion of a newly synthesized protein that contributes to a final structure after other components such as signal peptides are removed." [PSI:PEFF]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: PEFF:0001032 ! PEFF molecule processing keyword
+xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: has_regexp PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0001021
 name: signal peptide
 def: "Short peptide present at the N-terminus of a newly synthesized protein that is cleaved off and is not part of the final mature protein." [PSI:PEFF]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: PEFF:0001032 ! PEFF molecule processing keyword
+xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: has_regexp PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0001022
 name: transit peptide
 def: "Short peptide present at the N-terminus of a newly synthesized protein that helps the protein through the membrane of its destination organelle." [PSI:PEFF]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: PEFF:0001032 ! PEFF molecule processing keyword
+xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: has_regexp PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0001023
 name: Conflict
 def: "PEFF keyword for the sequence conflict; a UniProtKB term." [PSI:PEFF]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: PEFF:0000003 ! PEFF file sequence entry term
+xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: has_regexp PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0001024
 name: Crc64
 def: "PEFF keyword for the Sequence checksum in crc64." [PSI:PEFF]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
+xref: value-type:xsd\:string "The allowed value-type for this CV term."
 
 [Term]
 id: PEFF:0001025
 name: Domain
 def: "PEFF keyword for the sequence range of a domain." [PSI:PEFF]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
+xref: value-type:xsd\:string "The allowed value-type for this CV term."
 
 [Term]
 id: PEFF:0001026
 name: ID
 def: "PEFF keyword for the UniProtKB specific Protein identifier ID; a UniProtKB term." [PSI:PEFF]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
+xref: value-type:xsd\:string "The allowed value-type for this CV term."
 
 [Term]
 id: PEFF:0001027
 name: ModResUnimod
 def: "PEFF keyword for the modified residue with UniMod identifier." [PSI:PEFF]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: PEFF:0000003 ! PEFF file sequence entry term
+xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: has_regexp PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0001028
 name: VariantSimple
 def: "PEFF keyword for the simple sequence variation of a single amino acid change. A change to a stop codon is permitted with a * symbol. More complex variations must be encoded with the VariantComplex term." [PSI:PEFF]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: PEFF:0000003 ! PEFF file sequence entry term
+xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: has_regexp PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0001029
 name: VariantComplex
 def: "PEFF keyword for a sequence variation that is more complex than a single amino acid change or change to a stop codon." [PSI:PEFF]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: PEFF:0000003 ! PEFF file sequence entry term
+xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: has_regexp PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0001030
 name: Proteoform
 def: "PEFF keyword for the proteoforms of this protein, constructed as a set of annotation identifiers." [PSI:PEFF]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
+xref: value-type:xsd\:string "The allowed value-type for this CV term."
 
 [Term]
 id: PEFF:0001031
 name: DisulfideBond
 def: "PEFF keyword for the disulfide bonds in this protein, constructed as a sets of annotation identifiers of two half-cystine modifications." [PSI:PEFF]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
+xref: value-type:xsd\:string "The allowed value-type for this CV term."
 
 [Term]
 id: PEFF:0001032
@@ -21302,27 +20939,24 @@ is_a: PEFF:0000003 ! PEFF file sequence entry term
 id: PEFF:0001033
 name: Comment
 def: "PEFF keyword for the individual protein entry comment. It is discouraged to put parsable information here. This is only for free-text commentary." [PSI:PEFF]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
+xref: value-type:xsd\:string "The allowed value-type for this CV term."
 
 [Term]
 id: PEFF:0001034
 name: propeptide
 def: "Short peptide that is cleaved off a newly synthesized protein and generally immediately degraded in the process of protein maturation, and is not a signal peptide or transit peptide." [PSI:PEFF]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: PEFF:0001032 ! PEFF molecule processing keyword
+xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: has_regexp PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0001035
 name: initiator methionine
 def: "N-terminal methionine residue of a protein that can be co-translationally cleaved." [PSI:PEFF]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: PEFF:0001032 ! PEFF molecule processing keyword
+xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: has_regexp PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:1002001
@@ -21341,4 +20975,3 @@ id: PEFF:1002003
 name: regular expression for PEFF sequence status
 def: "(Complete|Fragment|[a-z0-9A-Z]+)." [PSI:PEFF]
 is_a: MS:1002479 ! regular expression
-

--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -1,7 +1,7 @@
 format-version: 1.2
-data-version: 4.1.55
+data-version: 4.1.56
 date: 21:05:2021 00:00
-saved-by: Joshua Klei
+saved-by: Joshua Klein
 auto-generated-by: OBO-Edit 2.3.1
 import: http://ontologies.berkeleybop.org/pato.obo
 import: http://ontologies.berkeleybop.org/uo.obo
@@ -49,6 +49,11 @@ name: has_order
 id: has_domain
 name: has_domain
 
+[Typedef]
+id: has_value_type
+name: has value type
+def: "'Entity A' has value type 'Entity B', such as xsd:float." []
+
 [Term]
 id: MS:0000000
 name: Proteomics Standards Initiative Mass Spectrometry Vocabularies
@@ -60,6 +65,7 @@ name: sample number
 def: "A reference number relevant to the sample under study." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000548 ! sample attribute
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000002
@@ -67,6 +73,7 @@ name: sample name
 def: "A reference string relevant to the sample under study." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000548 ! sample attribute
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000003
@@ -81,6 +88,7 @@ def: "Total mass of sample used." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000548 ! sample attribute
 relationship: has_units UO:0000021 ! gram
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000005
@@ -89,6 +97,7 @@ def: "Total volume of solution used." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000548 ! sample attribute
 relationship: has_units UO:0000098 ! milliliter
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000006
@@ -97,6 +106,7 @@ def: "Concentration of sample in picomol/ul, femtomol/ul or attomol/ul solution 
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000548 ! sample attribute
 relationship: has_units UO:0000175 ! gram per liter
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000007
@@ -130,6 +140,7 @@ name: mass resolution
 def: "Smallest mass difference between two equal magnitude peaks so that the valley between them is a specified fraction of the peak height." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000503 ! scan attribute
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000012
@@ -152,6 +163,7 @@ xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000480 ! mass analyzer attribute
 relationship: has_units MS:1000040 ! m/z
 relationship: has_units UO:0000169 ! parts per million
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000015
@@ -160,6 +172,7 @@ def: "Rate in Th/sec for scanning analyzers." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000503 ! scan attribute
 relationship: has_units MS:1000807 ! Th/s
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000016
@@ -170,6 +183,7 @@ is_a: MS:1000503 ! scan attribute
 is_a: MS:1002345 ! PSM-level attribute
 relationship: has_units UO:0000010 ! second
 relationship: has_units UO:0000031 ! minute
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000017
@@ -211,6 +225,7 @@ def: "The length of the field free drift space in a time of flight mass spectrom
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000480 ! mass analyzer attribute
 relationship: has_units UO:0000008 ! meter
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000023
@@ -220,6 +235,7 @@ comment: This former purgatory term was made obsolete.
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 relationship: has_units MS:1000040 ! m/z
 is_obsolete: true
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000024
@@ -227,6 +243,7 @@ name: final MS exponent
 def: "Final MS level achieved when performing PFF with the ion trap (e.g. MS E10)." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1000480 ! mass analyzer attribute
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000025
@@ -237,6 +254,7 @@ synonym: "Magnetic Field" RELATED []
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000480 ! mass analyzer attribute
 relationship: has_units UO:0000228 ! tesla
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000026
@@ -256,6 +274,7 @@ name: detector resolution
 def: "The resolving power of the detector to detect the smallest difference between two ions so that the valley between them is a specified fraction of the peak height." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000481 ! detector attribute
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000029
@@ -265,6 +284,7 @@ synonym: "ADC Sampling Frequency" NARROW []
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000481 ! detector attribute
 relationship: has_units UO:0000106 ! hertz
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000030
@@ -285,6 +305,7 @@ name: customization
 def: "Free text description of a single customization made to the instrument; for several modifications, use several entries." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000496 ! instrument attribute
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000033
@@ -349,6 +370,7 @@ synonym: "z" EXACT []
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1000455 ! ion selection attribute
 is_a: MS:1000507 ! ion property
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000042
@@ -362,6 +384,7 @@ relationship: has_units MS:1000814 ! counts per second
 relationship: has_units MS:1000905 ! percent of base peak times 100
 relationship: has_units UO:0000269 ! absorbance unit
 relationship: part_of MS:1000231 ! peak
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000043
@@ -383,6 +406,7 @@ def: "Energy for an ion experiencing collision with a stationary gas particle re
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000510 ! precursor activation attribute
 relationship: has_units UO:0000266 ! electronvolt
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000046
@@ -434,6 +458,7 @@ name: sample batch
 def: "Sample batch lot identifier." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000548 ! sample attribute
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000054
@@ -955,6 +980,7 @@ name: percent of base peak
 def: "The magnitude of a peak or measurement element expressed in terms of the percentage of the magnitude of the base peak intensity." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000043 ! intensity unit
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000133
@@ -1000,6 +1026,7 @@ def: "Instrument setting, expressed in percent, for adjusting collisional energi
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000510 ! precursor activation attribute
 relationship: has_units UO:0000187 ! percent
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000139
@@ -1424,6 +1451,7 @@ xref: value-type:xsd\:float "The allowed value-type for this CV term."
 comment: This child of the former purgatory term ion attribute was made obsolete.
 relationship: has_units UO:0000002 ! mass unit
 is_obsolete: true
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000208
@@ -1433,6 +1461,7 @@ xref: value-type:xsd\:float "The allowed value-type for this CV term."
 comment: This child of the former purgatory term ion attribute was made obsolete.
 relationship: has_units UO:0000002 ! mass unit
 is_obsolete: true
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000209
@@ -1443,6 +1472,7 @@ xref: value-type:xsd\:float "The allowed value-type for this CV term."
 comment: This child of the former purgatory term ion attribute was made obsolete.
 relationship: has_units UO:0000266 ! electronvolt
 is_obsolete: true
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000210
@@ -1457,6 +1487,7 @@ name: OBSOLETE charge number
 def: "OBSOLETE The total charge on an ion divided by the electron charge e. OBSOLETED 2009-10-27 since this was viewed as a duplication of 00041 charge state." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_obsolete: true
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000212
@@ -1473,6 +1504,7 @@ comment: This child of the former purgatory term ion attribute was made obsolete
 synonym: "EA" EXACT []
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_obsolete: true
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000214
@@ -1489,6 +1521,7 @@ xref: value-type:xsd\:float "The allowed value-type for this CV term."
 comment: This child of the former purgatory term ion attribute was made obsolete.
 relationship: has_units UO:0000002 ! mass unit
 is_obsolete: true
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000216
@@ -1511,6 +1544,7 @@ def: "OBSOLETE The ratio of the number of ions formed to the number of electrons
 comment: This term was made obsolete because it was replaced by ionization efficiency (MS:1000392).
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_obsolete: true
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000219
@@ -1521,6 +1555,7 @@ comment: This child of the former purgatory term ion attribute was made obsolete
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 relationship: has_units UO:0000266 ! electronvolt
 is_obsolete: true
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000220
@@ -1544,6 +1579,7 @@ xref: value-type:xsd\:float "The allowed value-type for this CV term."
 comment: This child of the former purgatory term ion attribute was made obsolete.
 relationship: has_units UO:0000002 ! mass unit
 is_obsolete: true
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000223
@@ -1552,6 +1588,7 @@ def: "OBSOLETE The sum of the protons and neutrons in an atom, molecule or ion."
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 comment: This child of the former purgatory term ion attribute was made obsolete.
 is_obsolete: true
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000224
@@ -1560,6 +1597,7 @@ def: "Mass of a molecule measured in unified atomic mass units (u or Da)." [http
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000861 ! molecular entity property
 relationship: has_units UO:0000002 ! mass unit
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000225
@@ -1569,6 +1607,7 @@ xref: value-type:xsd\:float "The allowed value-type for this CV term."
 comment: This child of the former purgatory term ion attribute was made obsolete.
 relationship: has_units UO:0000002 ! mass unit
 is_obsolete: true
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000226
@@ -1600,6 +1639,7 @@ xref: value-type:xsd\:float "The allowed value-type for this CV term."
 comment: This child of the former purgatory term ion attribute was made obsolete.
 relationship: has_units UO:0000002 ! mass unit
 is_obsolete: true
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000230
@@ -1629,6 +1669,7 @@ synonym: "PA" EXACT [PSI:MS]
 comment: This child of the former purgatory term ion attribute was made obsolete.
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_obsolete: true
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000234
@@ -1637,6 +1678,7 @@ def: "OBSOLETE In a mass spectrum, the observed mass divided by the difference b
 comment: This term was made obsolete because it was replaced by mass resolving power (MS:1000800).
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_obsolete: true
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000235
@@ -1651,6 +1693,7 @@ name: transmission
 def: "The ratio of the number of ions leaving a region of a mass spectrometer to the number entering that region." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000496 ! instrument attribute
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000237
@@ -2017,6 +2060,7 @@ def: "The sum of all the separate ion currents carried by the ions of different 
 synonym: "TIC" EXACT []
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1003058 ! spectrum property
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000286
@@ -2150,6 +2194,7 @@ def: "The electrical potential used to impart kinetic energy to ions in a mass s
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000487 ! ion optics attribute
 relationship: has_units UO:0000218 ! volt
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000305
@@ -2178,6 +2223,7 @@ def: "The magnitude of the force per unit charge at a given point in space." [PS
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000487 ! ion optics attribute
 relationship: has_units UO:0000268 ! volt per meter
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000309
@@ -2370,6 +2416,7 @@ name: neutral loss
 def: "The loss of an uncharged species during a rearrangement process. The value slot holds the molecular formula in Hill notation of the neutral loss molecule, see PMID: 21182243. This term must be used in conjunction with a child of the term MS:1002307 (fragmentation ion type)." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001055 ! modification parameters
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000337
@@ -2748,6 +2795,7 @@ name: ionization efficiency
 def: "The ratio of the number of ions formed to the number of electrons, molecules or photons used." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000482 ! source attribute
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000393
@@ -2868,6 +2916,7 @@ name: buffer gas
 def: "An inert gas used for collisional deactivation of internally excited ions." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000510 ! precursor activation attribute
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000413
@@ -2917,6 +2966,7 @@ name: collision gas
 def: "An inert gas used for collisional excitation. The term target gas is not recommended." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000510 ! precursor activation attribute
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000420
@@ -3362,6 +3412,7 @@ def: "Potential difference at the MS source in volts." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000482 ! source attribute
 relationship: has_units UO:0000218 ! volt
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000487
@@ -3453,6 +3504,7 @@ synonym: "mzRangeStop" RELATED []
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000549 ! selection window attribute
 relationship: has_units MS:1000040 ! m/z
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000501
@@ -3462,6 +3514,7 @@ synonym: "mzRangeStart" RELATED []
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000549 ! selection window attribute
 relationship: has_units MS:1000040 ! m/z
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000502
@@ -3472,6 +3525,7 @@ xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000503 ! scan attribute
 relationship: has_units UO:0000010 ! second
 relationship: has_units UO:0000031 ! minute
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000503
@@ -3487,6 +3541,7 @@ def: "M/z value of the signal of highest intensity in the mass spectrum." [PSI:M
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1003058 ! spectrum property
 relationship: has_units MS:1000040 ! m/z
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000505
@@ -3499,6 +3554,7 @@ relationship: has_units MS:1000132 ! percent of base peak
 relationship: has_units MS:1000814 ! counts per second
 relationship: has_units MS:1000905 ! percent of base peak times 100
 relationship: has_units UO:0000269 ! absorbance unit
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000506
@@ -3527,6 +3583,7 @@ def: "Activation Energy." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000510 ! precursor activation attribute
 relationship: has_units UO:0000266 ! electronvolt
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000510
@@ -3540,6 +3597,7 @@ name: ms level
 def: "Stage number achieved in a multi stage mass spectrometry acquisition." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1000499 ! spectrum attribute
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000512
@@ -3547,6 +3605,7 @@ name: filter string
 def: "A string unique to Thermo instrument describing instrument settings for the scan." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000503 ! scan attribute
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000513
@@ -3656,6 +3715,7 @@ xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000808 ! chromatogram attribute
 is_a: MS:1003058 ! spectrum property
 relationship: has_units MS:1000040 ! m/z
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000528
@@ -3665,6 +3725,7 @@ xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000808 ! chromatogram attribute
 is_a: MS:1003058 ! spectrum property
 relationship: has_units MS:1000040 ! m/z
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000529
@@ -3672,6 +3733,7 @@ name: instrument serial number
 def: "Serial Number of the instrument." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000496 ! instrument attribute
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000530
@@ -3936,6 +3998,7 @@ name: MD5
 def: "MD5 (Message-Digest algorithm 5) is a (now deprecated) cryptographic hash function with a 128-bit hash value used to check the integrity of files." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000561 ! data file checksum type
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000569
@@ -3943,6 +4006,7 @@ name: SHA-1
 def: "SHA-1 (Secure Hash Algorithm-1) is a cryptographic hash function designed by the National Security Agency (NSA). It is also used to verify file integrity. Since 2011 it has been deprecated by the NIST as a U. S. government standard." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000561 ! data file checksum type
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000570
@@ -4063,6 +4127,7 @@ name: contact name
 def: "Name of the contact person or organization." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000585 ! contact attribute
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000587
@@ -4070,6 +4135,7 @@ name: contact address
 def: "Postal address of the contact person or organization." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000585 ! contact attribute
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000588
@@ -4077,6 +4143,7 @@ name: contact URL
 def: "Uniform Resource Locator related to the contact person or organization." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000585 ! contact attribute
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000589
@@ -4084,6 +4151,7 @@ name: contact email
 def: "Email address of the contact person or organization." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000585 ! contact attribute
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000590
@@ -4091,6 +4159,7 @@ name: contact affiliation
 def: "Home institution of the contact person." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000585 ! contact attribute
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000591
@@ -4260,6 +4329,7 @@ name: preset scan configuration
 def: "A user-defined scan configuration that specifies the instrumental settings in which a spectrum is acquired. An instrument may cycle through a list of preset scan configurations to acquire data. This is a more generic term for the Thermo \"scan event\", which is defined in the Thermo Xcalibur glossary as: a mass spectrometer scan that is defined by choosing the necessary scan parameter settings. Multiple scan events can be defined for each segment of time." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000503 ! scan attribute
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000617
@@ -4278,6 +4348,7 @@ xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1003058 ! spectrum property
 is_a: MS:1000808 ! chromatogram attribute
 relationship: has_units UO:0000018 ! nanometer
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000619
@@ -4287,6 +4358,7 @@ xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1003058 ! spectrum property
 is_a: MS:1000808 ! chromatogram attribute
 relationship: has_units UO:0000018 ! nanometer
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000620
@@ -4359,6 +4431,7 @@ relationship: has_units MS:1000132 ! percent of base peak
 relationship: has_units MS:1000814 ! counts per second
 relationship: has_units MS:1000905 ! percent of base peak times 100
 relationship: has_units UO:0000269 ! absorbance unit
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000630
@@ -4377,6 +4450,7 @@ relationship: has_units MS:1000132 ! percent of base peak
 relationship: has_units MS:1000814 ! counts per second
 relationship: has_units MS:1000905 ! percent of base peak times 100
 relationship: has_units UO:0000269 ! absorbance unit
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000632
@@ -4390,6 +4464,7 @@ name: possible charge state
 def: "A possible charge state of the ion in a situation where the charge of an ion is known to be one of several possible values rather than a completely unknown value or determined to be a specific charge with reasonable certainty." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1000455 ! ion selection attribute
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000634
@@ -5137,6 +5212,7 @@ def: "Mass-to-charge ratio of an selected ion." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000455 ! ion selection attribute
 relationship: has_units MS:1000040 ! m/z
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000745
@@ -5156,6 +5232,7 @@ name: completion time
 def: "The time that a data processing action was finished." [PSI:MS]
 xref: value-type:xsd\:dateTime "The allowed value-type for this CV term."
 is_a: MS:1000630 ! data processing parameter
+relationship: has_value_type xsd\:dateTime ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000748
@@ -5416,6 +5493,7 @@ xref: binary-data-type:MS\:1000523 "64-bit float"
 xref: binary-data-type:MS\:1001479 "null-terminated ASCII string"
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000513 ! binary data array
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000787
@@ -5428,6 +5506,7 @@ relationship: has_units MS:1000132 ! percent of base peak
 relationship: has_units MS:1000814 ! counts per second
 relationship: has_units MS:1000905 ! percent of base peak times 100
 relationship: has_units UO:0000269 ! absorbance unit
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000788
@@ -5440,6 +5519,7 @@ relationship: has_units MS:1000132 ! percent of base peak
 relationship: has_units MS:1000814 ! counts per second
 relationship: has_units MS:1000905 ! percent of base peak times 100
 relationship: has_units UO:0000269 ! absorbance unit
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000789
@@ -5476,6 +5556,7 @@ xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000792 ! isolation window attribute
 relationship: has_units MS:1000040 ! m/z
 is_obsolete: true
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000794
@@ -5486,6 +5567,7 @@ xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000792 ! isolation window attribute
 relationship: has_units MS:1000040 ! m/z
 is_obsolete: true
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000795
@@ -5501,6 +5583,7 @@ comment: This is the preferred storage place for the spectrum TITLE from an MGF 
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001405 ! spectrum identification result details
 is_a: MS:1000499 ! spectrum attribute
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000797
@@ -5510,6 +5593,7 @@ comment: This is the preferred storage place for the spectrum SCANS attribute fr
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001405 ! spectrum identification result details
 is_a: MS:1003058 ! spectrum property
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000798
@@ -5519,6 +5603,7 @@ comment: This is the preferred storage place for the spectrum RAWSCANS attribute
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001405 ! spectrum identification result details
 is_a: MS:1003058 ! spectrum property
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000799
@@ -5526,6 +5611,7 @@ name: custom unreleased software tool
 def: "A software tool that has not yet been released. The value should describe the software. Please do not use this term for publicly available software - contact the PSI-MS working group in order to have another CV term added." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000531 ! software
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000800
@@ -5533,6 +5619,7 @@ name: mass resolving power
 def: "The observed mass divided by the difference between two masses that can be separated: m/dm. The procedure by which dm was obtained and the mass at which the measurement was made should be reported." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000503 ! scan attribute
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000801
@@ -5555,6 +5642,7 @@ def: "Offset between two analyzers in a constant neutral loss or neutral gain sc
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000503 ! scan attribute
 relationship: has_units MS:1000040 ! m/z
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000804
@@ -5598,6 +5686,7 @@ def: "A free-form text title describing a chromatogram." [PSI:MS]
 comment: This is the preferred storage place for the spectrum title.
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000808 ! chromatogram attribute
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000810
@@ -5717,6 +5806,7 @@ xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000503 ! scan attribute
 relationship: has_units UO:0000010 ! second
 relationship: has_units UO:0000031 ! minute
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000827
@@ -5725,6 +5815,7 @@ def: "The primary or reference m/z about which the isolation window is defined."
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000792 ! isolation window attribute
 relationship: has_units MS:1000040 ! m/z
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000828
@@ -5733,6 +5824,7 @@ def: "The extent of the isolation window in m/z below the isolation window targe
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000792 ! isolation window attribute
 relationship: has_units MS:1000040 ! m/z
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000829
@@ -5741,6 +5833,7 @@ def: "The extent of the isolation window in m/z above the isolation window targe
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000792 ! isolation window attribute
 relationship: has_units MS:1000040 ! m/z
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000831
@@ -5767,6 +5860,7 @@ name: matrix solution
 def: "Describes the chemical solution used as matrix." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000832 ! MALDI matrix application
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000835
@@ -5775,6 +5869,7 @@ def: "Concentration of the chemical solution used as matrix." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000832 ! MALDI matrix application
 relationship: has_units UO:0000175 ! gram per liter
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000836
@@ -5828,6 +5923,7 @@ xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000841 ! laser attribute
 relationship: has_units UO:0000018 ! nanometer
 is_obsolete: true
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000844
@@ -5836,6 +5932,7 @@ def: "Describes the diameter of the laser beam in x direction." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000841 ! laser attribute
 relationship: has_units UO:0000017 ! micrometer
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000845
@@ -5844,6 +5941,7 @@ def: "Describes the diameter of the laser beam in y direction." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000841 ! laser attribute
 relationship: has_units UO:0000017 ! micrometer
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000846
@@ -5852,6 +5950,7 @@ def: "Describes output energy of the laser system. May be attenuated by filters 
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000841 ! laser attribute
 relationship: has_units UO:0000112 ! joule
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000847
@@ -5860,6 +5959,7 @@ def: "Describes how long the laser beam was emitted from the laser device." [PSI
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000841 ! laser attribute
 relationship: has_units UO:0000150 ! nanosecond
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000848
@@ -5868,6 +5968,7 @@ def: "Describes the reduction of the intensity of the laser beam energy." [PSI:M
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000841 ! laser attribute
 relationship: has_units UO:0000187 ! percent
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000849
@@ -5876,6 +5977,7 @@ def: "Describes the angle between the laser beam and the sample target." [PSI:MS
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000841 ! laser attribute
 relationship: has_units UO:0000185 ! degree
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000850
@@ -5931,6 +6033,7 @@ name: fraction identifier
 def: "Identier string that describes the sample fraction. This identifier should contain the fraction number(s) or similar information." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000857 ! run attribute
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000859
@@ -5957,6 +6060,7 @@ def: "The pH of a solution at which a charged molecule does not migrate in an el
 synonym: "pI" EXACT []
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000861 ! molecular entity property
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000863
@@ -5965,6 +6069,7 @@ def: "The pH of a solution at which a charged molecule would not migrate in an e
 synonym: "predicted pI" EXACT []
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000862 ! isoelectric point
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000864
@@ -5978,6 +6083,7 @@ name: empirical formula
 def: "A chemical formula which expresses the proportions of the elements present in a substance." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000864 ! chemical formula
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000866
@@ -5985,6 +6091,7 @@ name: molecular formula
 def: "A chemical compound formula expressing the number of atoms of each element present in a compound, without indicating how they are linked." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000864 ! chemical formula
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000867
@@ -5992,6 +6099,7 @@ name: structural formula
 def: "A chemical formula showing the number of atoms of each element in a molecule, their spatial arrangement, and their linkage to each other." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000864 ! chemical formula
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000868
@@ -5999,6 +6107,7 @@ name: SMILES formula
 def: "The simplified molecular input line entry specification or SMILES is a specification for unambiguously describing the structure of a chemical compound using a short ASCII string." [EDAM:2301]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000864 ! chemical formula
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000869
@@ -6007,6 +6116,7 @@ def: "The gas pressure of the collision gas used for collisional excitation." [P
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000510 ! precursor activation attribute
 relationship: has_units UO:0000110 ! pascal
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000870
@@ -6047,6 +6157,7 @@ def: "Potential difference between the orifice and the skimmer in volts." [PSI:M
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000482 ! source attribute
 relationship: has_units UO:0000218 ! volt
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000876
@@ -6055,6 +6166,7 @@ def: "Potential difference between the sampling cone/orifice in volts." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000482 ! source attribute
 relationship: has_units UO:0000218 ! volt
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000877
@@ -6063,6 +6175,7 @@ def: "Potential difference setting of the tube lens in volts." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000482 ! source attribute
 relationship: has_units UO:0000218 ! volt
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000878
@@ -6076,6 +6189,7 @@ name: PubMed identifier
 def: "A unique identifier for a publication in the PubMed database (MIR:00000015)." [PSI:MS]
 xref: value-type:xsd\:integer "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
+relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000880
@@ -6084,6 +6198,7 @@ def: "The duration of intervals between scanning, during which the instrument co
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000503 ! scan attribute
 relationship: has_units UO:0000010 ! second
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000881
@@ -6103,6 +6218,7 @@ name: protein short name
 def: "A short name or symbol of a protein (e.g., HSF 1 or HSF1_HUMAN)." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000884 ! protein attribute
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000884
@@ -6118,6 +6234,7 @@ def: "Identifier for a specific protein in a database." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000884 ! protein attribute
 is_a: MS:1003046 ! peptide-to-protein mapping attribute
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000886
@@ -6125,6 +6242,7 @@ name: protein name
 def: "A long name describing the function of the protein." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000884 ! protein attribute
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000887
@@ -6138,6 +6256,7 @@ name: stripped peptide sequence
 def: "Sequence of letter symbols denoting the order of amino acids that compose the peptide, with any amino acid mass modifications that might be present having been stripped away." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1003050 ! peptidoform attribute
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000889
@@ -6146,6 +6265,7 @@ def: "Sequence of letter symbols denoting the order of amino acid residues that 
 comment: Make it more general as there are actually many other ways to display a modified peptide sequence.
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1003050 ! peptidoform attribute
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000890
@@ -6172,6 +6292,7 @@ name: peptidoform group label
 def: "An arbitrary string label used to mark a set of peptides that belong together in a set, whereby the members are differentiated by different isotopic labels. For example, the heavy and light forms of the same peptide will both be assigned the same peptide group label." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1003050 ! peptidoform attribute
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000894
@@ -6181,6 +6302,7 @@ xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1003050 ! peptidoform attribute
 relationship: has_units UO:0000010 ! second
 relationship: has_units UO:0000031 ! minute
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000895
@@ -6190,6 +6312,7 @@ xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000894 ! retention time
 relationship: has_units UO:0000010 ! second
 relationship: has_units UO:0000031 ! minute
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000896
@@ -6199,6 +6322,7 @@ xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000894 ! retention time
 relationship: has_units UO:0000010 ! second
 relationship: has_units UO:0000031 ! minute
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000897
@@ -6208,6 +6332,7 @@ xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000894 ! retention time
 relationship: has_units UO:0000010 ! second
 relationship: has_units UO:0000031 ! minute
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000898
@@ -6245,6 +6370,7 @@ name: product ion series ordinal
 def: "The ordinal of the fragment within a specified ion series. (e.g. 8 for a y8 ion)." [PSI:PI]
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1001221 ! product ion attribute
+relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000904
@@ -6259,6 +6385,7 @@ name: percent of base peak times 100
 def: "The magnitude of a peak expressed in terms of the percentage of the magnitude of the base peak intensity multiplied by 100. The base peak is therefore 10000. This unit is common in normalized spectrum libraries." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000043 ! intensity unit
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000906
@@ -6267,6 +6394,7 @@ def: "Ordinal specifying the rank in intensity of a peak in a spectrum. Base pea
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1000455 ! ion selection attribute
 relationship: part_of MS:1000231 ! peak
+relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000907
@@ -6275,6 +6403,7 @@ def: "Ordinal specifying the rank of a peak in a spectrum in terms of suitabilit
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1000455 ! ion selection attribute
 relationship: part_of MS:1000231 ! peak
+relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000908
@@ -6334,6 +6463,7 @@ xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000915 ! retention time window attribute
 relationship: has_units UO:0000010 ! second
 relationship: has_units UO:0000031 ! minute
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000917
@@ -6343,6 +6473,7 @@ xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000915 ! retention time window attribute
 relationship: has_units UO:0000010 ! second
 relationship: has_units UO:0000031 ! minute
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000918
@@ -6401,6 +6532,7 @@ name: product interpretation rank
 def: "The integer rank given an interpretation of an observed product ion. For example, if y8 is selected as the most likely interpretation of a peak, then it is assigned a rank of 1." [PSI:MS]
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1001221 ! product ion attribute
+relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000927
@@ -6409,6 +6541,7 @@ def: "The length of time spent filling an ion trapping device." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000503 ! scan attribute
 relationship: has_units UO:0000028 ! millisecond
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000928
@@ -6446,6 +6579,7 @@ name: protein modifications
 def: "Encoding of modifications of the protein sequence from the specified accession, written in PEFF notation." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000884 ! protein attribute
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000934
@@ -6453,6 +6587,7 @@ name: gene name
 def: "Name of the gene from which the protein is translated." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000884 ! protein attribute
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001000
@@ -6465,6 +6600,7 @@ id: MS:1001005
 name: SEQUEST:CleavesAt
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002096 ! SEQUEST input parameter
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001006
@@ -6478,6 +6614,7 @@ name: SEQUEST:OutputLines
 def: "Number of peptide results to show." [PSI:MS]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1002096 ! SEQUEST input parameter
+relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001009
@@ -6485,6 +6622,7 @@ name: SEQUEST:DescriptionLines
 def: "Number of full protein descriptions to show for top N peptides." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002096 ! SEQUEST input parameter
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001010
@@ -6504,6 +6642,7 @@ name: database source
 def: "The organisation, project or laboratory from where the database is obtained (UniProt, NCBI, EBI, other)." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001011 ! search database details
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001013
@@ -6524,6 +6663,7 @@ name: database original uri
 def: "URI, from where the search database was originally downloaded." [PSI:PI]
 xref: value-type:xsd\:anyURI "The allowed value-type for this CV term."
 is_a: MS:1001011 ! search database details
+relationship: has_value_type xsd\:anyURI ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001016
@@ -6531,6 +6671,7 @@ name: database version
 def: "Version of the search database. In mzIdentML use the attribute instead." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001011 ! search database details
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001017
@@ -6587,12 +6728,14 @@ name: translation table
 def: "The translation table used to translate the nucleotides to amino acids." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001011 ! search database details
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001026
 name: SEQUEST:NormalizeXCorrValues
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002096 ! SEQUEST input parameter
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001027
@@ -6606,6 +6749,7 @@ name: SEQUEST:SequenceHeaderFilter
 def: "String in the header of a sequence entry for that entry to be searched." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002096 ! SEQUEST input parameter
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001029
@@ -6613,6 +6757,7 @@ name: number of sequences searched
 def: "The number of sequences (proteins / nucleotides) from the database search after filtering." [PSI:PI]
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1001011 ! search database details
+relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001030
@@ -6621,6 +6766,7 @@ def: "Number of peptide seqs compared to each spectrum." [PSI:PI]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1001011 ! search database details
 is_a: MS:1001405 ! spectrum identification result details
+relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001031
@@ -6633,6 +6779,7 @@ id: MS:1001032
 name: SEQUEST:SequencePartialFilter
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002096 ! SEQUEST input parameter
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001035
@@ -6647,6 +6794,7 @@ name: search time taken
 def: "The time taken to complete the search in seconds." [PSI:PI]
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1001184 ! search statistics
+relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001037
@@ -6654,6 +6802,7 @@ name: SEQUEST:ShowFragmentIons
 def: "Flag indicating that fragment ions should be shown." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002096 ! SEQUEST input parameter
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001038
@@ -6661,6 +6810,7 @@ name: SEQUEST:Consensus
 def: "Specify depth as value of the CVParam." [PSI:PI]
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1001006 ! SEQUEST:ViewCV
+relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001040
@@ -6680,6 +6830,7 @@ name: SEQUEST:LimitTo
 def: "Specify \"number of dtas shown\" as value of the CVParam." [PSI:PI]
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1002096 ! SEQUEST input parameter
+relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001044
@@ -6699,6 +6850,7 @@ name: SEQUEST:sort by dCn
 def: "Sort order of SEQUEST search results by the delta of the normalized correlation score." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001041 ! SEQUEST:sortCV
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001047
@@ -6706,6 +6858,7 @@ name: SEQUEST:sort by dM
 def: "Sort order of SEQUEST search results by the difference between a theoretically calculated and the corresponding experimentally measured molecular mass M." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001041 ! SEQUEST:sortCV
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001048
@@ -6713,6 +6866,7 @@ name: SEQUEST:sort by Ions
 def: "Sort order of SEQUEST search results given by the ions." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001041 ! SEQUEST:sortCV
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001049
@@ -6720,6 +6874,7 @@ name: SEQUEST:sort by MH+
 def: "Sort order of SEQUEST search results given by the mass of the protonated ion." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001041 ! SEQUEST:sortCV
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001050
@@ -6727,6 +6882,7 @@ name: SEQUEST:sort by P
 def: "Sort order of SEQUEST search results given by the probability." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001041 ! SEQUEST:sortCV
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001051
@@ -6734,6 +6890,7 @@ name: multiple enzyme combination rules
 def: "OBSOLETE: use attribute independent in mzIdentML instead. Description of multiple enzyme digestion protocol, if any." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_obsolete: true
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001052
@@ -6741,6 +6898,7 @@ name: SEQUEST:sort by PreviousAminoAcid
 def: "Sort order of SEQUEST search results given by the previous amino acid." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001041 ! SEQUEST:sortCV
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001053
@@ -6748,6 +6906,7 @@ name: SEQUEST:sort by Ref
 def: "Sort order of SEQUEST search results given by the reference." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001041 ! SEQUEST:sortCV
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001055
@@ -6780,6 +6939,7 @@ name: SEQUEST:sort by RSp
 def: "Sort order of SEQUEST search results given by the result 'Sp' of 'Rank/Sp' in the out file (peptide)." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001041 ! SEQUEST:sortCV
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001060
@@ -6822,6 +6982,7 @@ name: SEQUEST:sort by Sp
 def: "Sort order of SEQUEST search results by the Sp score." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001041 ! SEQUEST:sortCV
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001069
@@ -6829,6 +6990,7 @@ name: SEQUEST:sort by TIC
 def: "Sort order of SEQUEST search results given by the total ion current." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001041 ! SEQUEST:sortCV
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001070
@@ -6836,6 +6998,7 @@ name: SEQUEST:sort by Scan
 def: "Sort order of SEQUEST search results given by the scan number." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001041 ! SEQUEST:sortCV
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001071
@@ -6843,6 +7006,7 @@ name: SEQUEST:sort by Sequence
 def: "Sort order of SEQUEST search results given by the sequence." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001041 ! SEQUEST:sortCV
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001072
@@ -6850,6 +7014,7 @@ name: SEQUEST:sort by Sf
 def: "Sort order of SEQUEST search results given by the SEQUEST result 'Sf'." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001041 ! SEQUEST:sortCV
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001073
@@ -6905,6 +7070,7 @@ name: SEQUEST:sort by XCorr
 def: "Sort order of SEQUEST search results by the correlation score." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001041 ! SEQUEST:sortCV
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001087
@@ -6919,6 +7085,7 @@ def: "The protein description line from the sequence entry in the source databas
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001085 ! protein-level identification attribute
 is_a: MS:1001342 ! database sequence details
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001089
@@ -6928,6 +7095,7 @@ xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001085 ! protein-level identification attribute
 is_a: MS:1001342 ! database sequence details
 is_a: MS:1001512 ! Sequence database filters
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001090
@@ -6959,6 +7127,7 @@ name: sequence coverage
 def: "The percent coverage for the protein based upon the matched peptide sequences (can be calculated)." [PSI:PI]
 xref: value-type:xsd\:decimal "The allowed value-type for this CV term."
 is_a: MS:1001085 ! protein-level identification attribute
+relationship: has_value_type xsd\:decimal ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001094
@@ -6966,12 +7135,14 @@ name: SEQUEST:sort by z
 def: "Sort order of SEQUEST search results given by the charge." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001041 ! SEQUEST:sortCV
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001095
 name: SEQUEST:ProcessAll
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001087 ! SEQUEST:ProcessCV
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001096
@@ -6979,6 +7150,7 @@ name: SEQUEST:TopPercentMostIntense
 def: "Specify \"percentage\" as value of the CVParam." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001087 ! SEQUEST:ProcessCV
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001097
@@ -6986,6 +7158,7 @@ name: distinct peptide sequences
 def: "This counts distinct sequences hitting the protein without regard to a minimal confidence threshold." [PSI:PI]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1001085 ! protein-level identification attribute
+relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001098
@@ -6993,6 +7166,7 @@ name: confident distinct peptide sequences
 def: "This counts the number of distinct peptide sequences. Multiple charge states and multiple modification states do NOT count as multiple sequences. The definition of 'confident' must be qualified elsewhere." [PSI:PI]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1001085 ! protein-level identification attribute
+relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001099
@@ -7000,6 +7174,7 @@ name: confident peptide qualification
 def: "The point of this entry is to define what is meant by confident for the term Confident distinct peptide sequence and/or Confident peptides. Example 1 - metric=Paragon:Confidence value=95 sense=greater than Example 2 - metric=Mascot:Eval value=0.05 sense=less than." [PSI:PI]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1001085 ! protein-level identification attribute
+relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001100
@@ -7007,6 +7182,7 @@ name: confident peptide sequence number
 def: "This counts the number of peptide sequences without regard to whether they are distinct. Multiple charges states and multiple modification states DO count as multiple peptides. The definition of 'confident' must be qualified elsewhere." [PSI:PI]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1001085 ! protein-level identification attribute
+relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001101
@@ -7019,12 +7195,14 @@ id: MS:1001102
 name: SEQUEST:Chromatogram
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001006 ! SEQUEST:ViewCV
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001103
 name: SEQUEST:InfoAndLog
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001006 ! SEQUEST:ViewCV
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001104
@@ -7044,6 +7222,7 @@ name: SEQUEST:TopNumber
 def: "Specify \"number\" as value of the CVParam." [PSI:PI]
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1001087 ! SEQUEST:ProcessCV
+relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001107
@@ -7063,6 +7242,7 @@ name: SEQUEST:CullTo
 def: "Specify cull string as value of the CVParam." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001087 ! SEQUEST:ProcessCV
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001110
@@ -7075,6 +7255,7 @@ id: MS:1001111
 name: SEQUEST:Full
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001110 ! SEQUEST:modeCV
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001112
@@ -7083,6 +7264,7 @@ def: "Residue preceding the first amino acid in the peptide sequence as it occur
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1003046 ! peptide-to-protein mapping attribute
 is_a: MS:1001105 ! peptide sequence-level identification attribute
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001113
@@ -7091,6 +7273,7 @@ def: "Residue following the last amino acid in the peptide sequence as it occurs
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1003046 ! peptide-to-protein mapping attribute
 is_a: MS:1001105 ! peptide sequence-level identification attribute
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001114
@@ -7102,6 +7285,7 @@ is_a: MS:1001105 ! peptide sequence-level identification attribute
 relationship: has_units UO:0000010 ! second
 relationship: has_units UO:0000031 ! minute
 is_obsolete: true
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001115
@@ -7123,6 +7307,7 @@ def: "The theoretical mass of the molecule (e.g. the peptide sequence and its mo
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001105 ! peptide sequence-level identification attribute
 relationship: has_units UO:0000221 ! dalton
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001118
@@ -7141,6 +7326,7 @@ id: MS:1001120
 name: SEQUEST:FormatAndLinks
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001110 ! SEQUEST:modeCV
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001121
@@ -7148,6 +7334,7 @@ name: number of matched peaks
 def: "The number of peaks that were matched as qualified by the ion series considered field. If a peak matches multiple ions then only 1 would be added the count." [PSI:PI]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1001105 ! peptide sequence-level identification attribute
+relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001122
@@ -7161,6 +7348,7 @@ name: number of peaks used
 def: "The number of peaks from the original peak list that are used to calculate the scores for a particular search engine. All ions that have the opportunity to match or be counted even if they don't." [PSI:PI]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1001105 ! peptide sequence-level identification attribute
+relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001124
@@ -7168,6 +7356,7 @@ name: number of peaks submitted
 def: "The number of peaks from the original peaks listed that were submitted to the search engine." [PSI:PI]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1001105 ! peptide sequence-level identification attribute
+relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001125
@@ -7176,12 +7365,14 @@ def: "Result of quality estimation: decision of a manual validation." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001092 ! peptide sequence-level identification statistic
 is_a: MS:1001116 ! single protein identification statistic
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001126
 name: SEQUEST:Fast
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001110 ! SEQUEST:modeCV
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001127
@@ -7209,6 +7400,7 @@ comment: This term was made obsolete because it is replaced by 'MS1 feature area
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002737 ! peptide-level quantification datatype
 is_obsolete: true
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001131
@@ -7216,6 +7408,7 @@ name: error on peptide area
 def: "Error on peptide area." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002737 ! peptide-level quantification datatype
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001132
@@ -7223,6 +7416,7 @@ name: peptide ratio
 def: "Peptide ratio." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002737 ! peptide-level quantification datatype
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001133
@@ -7230,6 +7424,7 @@ name: error on peptide ratio
 def: "Error on peptide ratio." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002737 ! peptide-level quantification datatype
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001134
@@ -7237,6 +7432,7 @@ name: protein ratio
 def: "Protein ratio." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002738 ! protein-level quantification datatype
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001135
@@ -7244,6 +7440,7 @@ name: error on protein ratio
 def: "Error on protein ratio." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002738 ! protein-level quantification datatype
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001136
@@ -7253,6 +7450,7 @@ comment: This term was made obsolete because it is replaced by 't-test p-value' 
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002738 ! protein-level quantification datatype
 is_obsolete: true
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001137
@@ -7260,6 +7458,7 @@ name: absolute quantity
 def: "Absolute quantity in terms of real concentration or molecule copy number in sample." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001138
@@ -7267,6 +7466,7 @@ name: error on absolute quantity
 def: "Error on absolute quantity." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001139
@@ -7289,6 +7489,7 @@ name: intensity of precursor ion
 def: "The intensity of the precursor ion." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001142
@@ -7367,6 +7568,7 @@ name: SEQUEST:probability
 def: "The SEQUEST result 'Probability'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001155
@@ -7375,6 +7577,7 @@ def: "The SEQUEST result 'XCorr'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002108 ! higher score better
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001156
@@ -7382,6 +7585,7 @@ name: SEQUEST:deltacn
 def: "The SEQUEST result 'DeltaCn'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001157
@@ -7389,12 +7593,14 @@ name: SEQUEST:sp
 def: "The SEQUEST result 'Sp' (protein)." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001158
 name: SEQUEST:Uniq
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001159
@@ -7402,6 +7608,7 @@ name: SEQUEST:expectation value
 def: "The SEQUEST result 'Expectation value'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001153 ! search engine specific score
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001160
@@ -7409,6 +7616,7 @@ name: SEQUEST:sf
 def: "The SEQUEST result 'Sf'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001161
@@ -7416,6 +7624,7 @@ name: SEQUEST:matched ions
 def: "The SEQUEST result 'Matched Ions'." [PSI:PI]
 xref: value-type:xsd\:integer "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001162
@@ -7423,6 +7632,7 @@ name: SEQUEST:total ions
 def: "The SEQUEST result 'Total Ions'." [PSI:PI]
 xref: value-type:xsd\:integer "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001163
@@ -7430,6 +7640,7 @@ name: SEQUEST:consensus score
 def: "The SEQUEST result 'Consensus Score'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001153 ! search engine specific score
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001164
@@ -7438,6 +7649,7 @@ def: "The Paragon result 'Unused ProtScore'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
 is_a: MS:1002368 ! search engine specific score for protein groups
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001165
@@ -7446,6 +7658,7 @@ def: "The Paragon result 'Total ProtScore'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
 is_a: MS:1002368 ! search engine specific score for protein groups
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001166
@@ -7453,6 +7666,7 @@ name: Paragon:score
 def: "The Paragon result 'Score'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001167
@@ -7460,6 +7674,7 @@ name: Paragon:confidence
 def: "The Paragon result 'Confidence'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001168
@@ -7467,6 +7682,7 @@ name: Paragon:expression error factor
 def: "The Paragon result 'Expression Error Factor'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001169
@@ -7474,6 +7690,7 @@ name: Paragon:expression change p-value
 def: "The Paragon result 'Expression change P-value'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001170
@@ -7481,6 +7698,7 @@ name: Paragon:contrib
 def: "The Paragon result 'Contrib'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001171
@@ -7488,6 +7706,7 @@ name: Mascot:score
 def: "The Mascot result 'Score'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001172
@@ -7495,6 +7714,7 @@ name: Mascot:expectation value
 def: "The Mascot result 'expectation value'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001173
@@ -7502,6 +7722,7 @@ name: Mascot:matched ions
 def: "The Mascot result 'Matched ions'." [PSI:PI]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001174
@@ -7509,6 +7730,7 @@ name: Mascot:total ions
 def: "The Mascot result 'Total ions'." [PSI:PI]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001175
@@ -7528,6 +7750,7 @@ name: number of molecular hypothesis considered
 def: "Number of Molecular Hypothesis Considered - This is the number of molecules (e.g. peptides for proteomics) considered for a particular search." [PSI:PI]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1001184 ! search statistics
+relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001178
@@ -7569,6 +7792,7 @@ xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001092 ! peptide sequence-level identification statistic
 is_a: MS:1001198 ! protein identification confidence metric
 is_obsolete: true
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001192
@@ -7577,6 +7801,7 @@ def: "Result of quality estimation: Expect value." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001092 ! peptide sequence-level identification statistic
 is_a: MS:1001116 ! single protein identification statistic
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001193
@@ -7585,6 +7810,7 @@ def: "Result of quality estimation: confidence score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001092 ! peptide sequence-level identification statistic
 is_a: MS:1001116 ! single protein identification statistic
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001194
@@ -7592,6 +7818,7 @@ name: quality estimation with decoy database
 def: "Quality estimation by decoy database." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001060 ! quality estimation method details
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001195
@@ -7637,6 +7864,7 @@ xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001512 ! Sequence database filters
 relationship: has_units UO:0000221 ! dalton
 relationship: has_units UO:0000222 ! kilodalton
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001202
@@ -7646,6 +7874,7 @@ xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001512 ! Sequence database filters
 relationship: has_units UO:0000221 ! dalton
 relationship: has_units UO:0000222 ! kilodalton
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001203
@@ -7653,6 +7882,7 @@ name: DB PI filter maximum
 def: "Maximum value of isoelectric point filter." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001512 ! Sequence database filters
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001204
@@ -7660,6 +7890,7 @@ name: DB PI filter minimum
 def: "Minimum value of isoelectric point filter." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001512 ! Sequence database filters
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001207
@@ -7711,6 +7942,7 @@ def: "Estimation of the global false discovery rate of proteins." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002705 ! protein-level result list statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001215
@@ -7718,6 +7950,7 @@ name: SEQUEST:PeptideSp
 def: "The SEQUEST result 'Sp' in out file (peptide)." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001217
@@ -7725,6 +7958,7 @@ name: SEQUEST:PeptideRankSp
 def: "The SEQUEST result 'Sp' of 'Rank/Sp' in out file (peptide). Also called 'rsp'." [PSI:PI]
 xref: value-type:xsd\:integer "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001218
@@ -7732,6 +7966,7 @@ name: SEQUEST:PeptideNumber
 def: "The SEQUEST result '#' in out file (peptide)." [PSI:PI]
 xref: value-type:xsd\:integer "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001219
@@ -7739,6 +7974,7 @@ name: SEQUEST:PeptideIdnumber
 def: "The SEQUEST result 'Id#' in out file (peptide)." [PSI:PI]
 xref: value-type:xsd\:integer "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001220
@@ -7924,6 +8160,7 @@ def: "Result of quality estimation: the local FDR at the current position of a s
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001092 ! peptide sequence-level identification statistic
 is_a: MS:1001116 ! single protein identification statistic
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001251
@@ -8022,6 +8259,7 @@ name: programmer
 def: "Programmer role." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001266 ! role type
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001269
@@ -8029,6 +8267,7 @@ name: instrument vendor
 def: "Instrument vendor role." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001266 ! role type
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001270
@@ -8036,6 +8275,7 @@ name: lab personnel
 def: "Lab personnel role." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001266 ! role type
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001271
@@ -8079,6 +8319,7 @@ name: decoy DB accession regexp
 def: "Specify the regular expression for decoy accession numbers." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001450 ! decoy DB details
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001284
@@ -8200,6 +8441,7 @@ name: protein rank
 def: "The rank of the protein in a list sorted by the search engine." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1001085 ! protein-level identification attribute
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001302
@@ -8307,6 +8549,7 @@ name: Mascot:SigThreshold
 def: "Significance threshold below which the p-value of a peptide match must lie to be considered statistically significant (default 0.05)." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002095 ! Mascot input parameter
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001317
@@ -8314,6 +8557,7 @@ name: Mascot:MaxProteinHits
 def: "The number of protein hits to display in the report. If 'Auto', all protein hits that have a protein score exceeding the average peptide identity threshold are reported. Otherwise an integer at least 1." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002095 ! Mascot input parameter
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001318
@@ -8321,6 +8565,7 @@ name: Mascot:ProteinScoringMethod
 def: "Mascot protein scoring method; either 'Standard' or 'MudPIT'." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002095 ! Mascot input parameter
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001319
@@ -8328,6 +8573,7 @@ name: Mascot:MinMSMSThreshold
 def: "Mascot peptide match ion score threshold. If between 0 and 1, then peptide matches whose expect value exceeds the thresholds are suppressed; if at least 1, then peptide matches whose ion score is below the threshold are suppressed." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002095 ! Mascot input parameter
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001320
@@ -8335,6 +8581,7 @@ name: Mascot:ShowHomologousProteinsWithSamePeptides
 def: "If true, show (sequence or spectrum) same-set proteins. Otherwise they are suppressed." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002095 ! Mascot input parameter
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001321
@@ -8342,6 +8589,7 @@ name: Mascot:ShowHomologousProteinsWithSubsetOfPeptides
 def: "If true, show (sequence or spectrum) sub-set and subsumable proteins. Otherwise they are suppressed." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002095 ! Mascot input parameter
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001322
@@ -8349,6 +8597,7 @@ name: Mascot:RequireBoldRed
 def: "Only used in Peptide Summary and Select Summary reports. If true, a peptide match must be 'bold red' to be included in the report; bold red means the peptide is a top ranking match in a query and appears for the first time (in linear order) in the list of protein hits." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002095 ! Mascot input parameter
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001323
@@ -8356,6 +8605,7 @@ name: Mascot:UseUnigeneClustering
 def: "If true, then the search results are against a nucleic acid database and Unigene clustering is enabled. Otherwise UniGene clustering is not in use." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002095 ! Mascot input parameter
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001324
@@ -8363,6 +8613,7 @@ name: Mascot:IncludeErrorTolerantMatches
 def: "If true, then the search results are error tolerant and peptide matches from the second pass are included in search results. Otherwise no error tolerant peptide matches are included." [http://www.matrixscience.com/help/error_tolerant_help.html]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002095 ! Mascot input parameter
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001325
@@ -8370,6 +8621,7 @@ name: Mascot:ShowDecoyMatches
 def: "If true, then the search results are against an automatically generated decoy database and the reported peptide matches and protein hits come from the decoy database. Otherwise peptide matches and protein hits come from the original database." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002095 ! Mascot input parameter
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001326
@@ -8384,6 +8636,7 @@ name: OMSSA:evalue
 def: "OMSSA E-value." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001329
@@ -8391,6 +8644,7 @@ name: OMSSA:pvalue
 def: "OMSSA p-value." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001330
@@ -8398,6 +8652,7 @@ name: X\!Tandem:expect
 def: "The X!Tandem expectation value." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001331
@@ -8405,6 +8660,7 @@ name: X\!Tandem:hyperscore
 def: "The X!Tandem hyperscore." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001332
@@ -8568,6 +8824,7 @@ name: msmsEval quality
 def: "This term reports the quality of the spectrum assigned by msmsEval." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001357 ! spectrum quality descriptions
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001359
@@ -8581,6 +8838,7 @@ name: alternate single letter codes
 def: "List of standard residue one letter codes which are used to replace a non-standard." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001359 ! ambiguous residues
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001361
@@ -8589,6 +8847,7 @@ def: "List of masses a non-standard letter code is replaced with." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001359 ! ambiguous residues
 relationship: has_units UO:0000221 ! dalton
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001362
@@ -8596,6 +8855,7 @@ name: number of unmatched peaks
 def: "The number of unmatched peaks." [PSI:PI]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1002345 ! PSM-level attribute
+relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001363
@@ -8610,6 +8870,7 @@ def: "Estimation of the global false discovery rate for distinct peptides once r
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002703 ! peptide sequence-level result list statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001365
@@ -8647,6 +8908,7 @@ name: Mascot:homology threshold
 def: "The Mascot result 'homology threshold'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001371
@@ -8654,12 +8916,14 @@ name: Mascot:identity threshold
 def: "The Mascot result 'identity threshold'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001372
 name: SEQUEST:Sequences
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
+relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001373
@@ -8667,12 +8931,14 @@ name: SEQUEST:TIC
 def: "SEQUEST total ion current." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001374
 name: SEQUEST:Sum
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001375
@@ -8680,6 +8946,7 @@ name: Phenyx:Instrument Type
 def: "The instrument type parameter value in Phenyx." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002097 ! Phenyx input parameter
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001376
@@ -8687,6 +8954,7 @@ name: Phenyx:Scoring Model
 def: "The selected scoring model in Phenyx." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002097 ! Phenyx input parameter
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001377
@@ -8694,6 +8962,7 @@ name: Phenyx:Default Parent Charge
 def: "The default parent charge value in Phenyx." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002097 ! Phenyx input parameter
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001378
@@ -8701,6 +8970,7 @@ name: Phenyx:Trust Parent Charge
 def: "The parameter in Phenyx that specifies if the experimental charge state is to be considered as correct." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002097 ! Phenyx input parameter
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001379
@@ -8708,6 +8978,7 @@ name: Phenyx:Turbo
 def: "The turbo mode parameter in Phenyx." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002097 ! Phenyx input parameter
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001380
@@ -8715,6 +8986,7 @@ name: Phenyx:Turbo:ErrorTol
 def: "The maximal allowed fragment m/z error filter considered in the turbo mode of Phenyx." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002097 ! Phenyx input parameter
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001381
@@ -8722,6 +8994,7 @@ name: Phenyx:Turbo:Coverage
 def: "The minimal peptide sequence coverage value, expressed in percent, considered in the turbo mode of Phenyx." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002097 ! Phenyx input parameter
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001382
@@ -8729,6 +9002,7 @@ name: Phenyx:Turbo:Series
 def: "The list of ion series considered in the turbo mode of Phenyx." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002097 ! Phenyx input parameter
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001383
@@ -8736,6 +9010,7 @@ name: Phenyx:MinPepLength
 def: "The minimal number of residues for a peptide to be considered for a valid identification in Phenyx." [PSI:PI]
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1002097 ! Phenyx input parameter
+relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001384
@@ -8743,6 +9018,7 @@ name: Phenyx:MinPepzscore
 def: "The minimal peptide z-score for a peptide to be considered for a valid identification in Phenyx." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002097 ! Phenyx input parameter
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001385
@@ -8750,6 +9026,7 @@ name: Phenyx:MaxPepPvalue
 def: "The maximal peptide p-value for a peptide to be considered for a valid identification in Phenyx." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002097 ! Phenyx input parameter
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001386
@@ -8757,6 +9034,7 @@ name: Phenyx:AC Score
 def: "The minimal protein score required for a protein database entry to be displayed in the list of identified proteins in Phenyx." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002097 ! Phenyx input parameter
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001387
@@ -8764,6 +9042,7 @@ name: Phenyx:Conflict Resolution
 def: "The parameter in Phenyx that specifies if the conflict resolution algorithm is to be used." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002097 ! Phenyx input parameter
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001388
@@ -8771,6 +9050,7 @@ name: Phenyx:AC
 def: "The primary sequence database identifier of a protein in Phenyx." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001389
@@ -8778,6 +9058,7 @@ name: Phenyx:ID
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 def: "A secondary sequence database identifier of a protein in Phenyx." [PSI:PI]
 is_a: MS:1002363 ! search engine specific score for proteins
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001390
@@ -8785,6 +9066,7 @@ name: Phenyx:Score
 def: "The protein score of a protein match in Phenyx." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001391
@@ -8792,6 +9074,7 @@ name: Phenyx:Peptides1
 def: "First number of phenyx result \"#Peptides\"." [PSI:PI]
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
+relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001392
@@ -8799,6 +9082,7 @@ name: Phenyx:Peptides2
 def: "Second number of phenyx result \"#Peptides\"." [PSI:PI]
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
+relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001393
@@ -8806,6 +9090,7 @@ name: Phenyx:Auto
 def: "The value of the automatic peptide acceptance filter in Phenyx." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001394
@@ -8814,6 +9099,7 @@ def: "The value of the user-defined peptide acceptance filter in Phenyx." [PSI:P
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1002363 ! search engine specific score for proteins
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001395
@@ -8821,6 +9107,7 @@ name: Phenyx:Pepzscore
 def: "The z-score value of a peptide sequence match in Phenyx." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001396
@@ -8829,6 +9116,7 @@ def: "The p-value of a peptide sequence match in Phenyx." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1002358 ! search engine specific peptide sequence-level identification statistic
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001397
@@ -8836,6 +9124,7 @@ name: Phenyx:NumberOfMC
 def: "The number of missed cleavages of a peptide sequence in Phenyx." [PSI:PI]
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001398
@@ -8844,6 +9133,7 @@ def: "The expression of the nature and position(s) of modified residue(s) on a m
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1002363 ! search engine specific score for proteins
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001399
@@ -8899,6 +9189,7 @@ name: translation start codons
 def: "The translation start codons used to translate the nucleotides to amino acids." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001011 ! search database details
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001411
@@ -8915,6 +9206,7 @@ relationship: has_units UO:0000166 ! parts per notation unit
 relationship: has_units UO:0000169 ! parts per million
 relationship: has_units UO:0000187 ! percent
 relationship: has_units UO:0000221 ! dalton
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001413
@@ -8925,6 +9217,7 @@ relationship: has_units UO:0000166 ! parts per notation unit
 relationship: has_units UO:0000169 ! parts per million
 relationship: has_units UO:0000187 ! percent
 relationship: has_units UO:0000221 ! dalton
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001414
@@ -8934,6 +9227,7 @@ xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001405 ! spectrum identification result details
 is_obsolete: true
 replaced_by: MS:1000797
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001415
@@ -8943,6 +9237,7 @@ xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001405 ! spectrum identification result details
 is_obsolete: true
 replaced_by: MS:1000798
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001416
@@ -8952,6 +9247,7 @@ xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001405 ! spectrum identification result details
 is_obsolete: true
 replaced_by: MS:1000796
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001417
@@ -8959,6 +9255,7 @@ name: SpectraST:dot
 def: "SpectraST dot product of two spectra, measuring spectral similarity." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001418
@@ -8966,6 +9263,7 @@ name: SpectraST:dot_bias
 def: "SpectraST measure of how much of the dot product is dominated by a few peaks." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001419
@@ -8973,6 +9271,7 @@ name: SpectraST:discriminant score F
 def: "SpectraST spectrum score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001420
@@ -8980,6 +9279,7 @@ name: SpectraST:delta
 def: "SpectraST normalised difference between dot product of top hit and runner-up." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001421
@@ -8999,6 +9299,7 @@ name: translation table description
 def: "A URL that describes the translation table used to translate the nucleotides to amino acids." [PSI:PI]
 xref: value-type:xsd\:anyURI "The allowed value-type for this CV term."
 is_a: MS:1001011 ! search database details
+relationship: has_value_type xsd\:anyURI ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001424
@@ -9006,6 +9307,7 @@ name: ProteinExtractor:Methodname
 def: "Name of the used method in the ProteinExtractor algorithm." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001425
@@ -9013,6 +9315,7 @@ name: ProteinExtractor:GenerateNonRedundant
 def: "Flag indicating if a non redundant scoring should be generated." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001426
@@ -9020,6 +9323,7 @@ name: ProteinExtractor:IncludeIdentified
 def: "Flag indicating if identified proteins should be included." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001427
@@ -9027,6 +9331,7 @@ name: ProteinExtractor:MaxNumberOfProteins
 def: "The maximum number of proteins to consider." [PSI:PI]
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
+relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001428
@@ -9034,6 +9339,7 @@ name: ProteinExtractor:MaxProteinMass
 def: "The maximum considered mass for a protein." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001429
@@ -9041,6 +9347,7 @@ name: ProteinExtractor:MinNumberOfPeptides
 def: "The minimum number of proteins to consider." [PSI:PI]
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
+relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001430
@@ -9048,6 +9355,7 @@ name: ProteinExtractor:UseMascot
 def: "Flag indicating to include Mascot scoring for calculation of the ProteinExtractor meta score." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001431
@@ -9055,6 +9363,7 @@ name: ProteinExtractor:MascotPeptideScoreThreshold
 def: "Only peptides with scores higher than that threshold are taken into account in Mascot scoring for calculation of the ProteinExtractor meta score." [DOI:10.4172/jpb.1000056]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001432
@@ -9062,12 +9371,14 @@ name: ProteinExtractor:MascotUniqueScore
 def: "In the final result each protein must have at least one peptide above this Mascot score threshold in ProteinExtractor meta score calculation." [DOI:10.4172/jpb.1000056]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001433
 name: ProteinExtractor:MascotUseIdentityScore
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001434
@@ -9075,6 +9386,7 @@ name: ProteinExtractor:MascotWeighting
 def: "Influence of Mascot search engine in the process of merging the search engine specific protein lists into the global protein list of ProteinExtractor." [DOI:10.4172/jpb.1000056]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001435
@@ -9082,6 +9394,7 @@ name: ProteinExtractor:UseSequest
 def: "Flag indicating to include SEQUEST scoring for calculation of the ProteinExtractor meta score." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001436
@@ -9089,6 +9402,7 @@ name: ProteinExtractor:SequestPeptideScoreThreshold
 def: "Only peptides with scores higher than that threshold are taken into account in SEQUEST scoring for calculation of the ProteinExtractor meta score." [DOI:10.4172/jpb.1000056]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001437
@@ -9096,6 +9410,7 @@ name: ProteinExtractor:SequestUniqueScore
 def: "In the final result each protein must have at least one peptide above this SEQUEST score threshold in ProteinExtractor meta score calculation." [DOI:10.4172/jpb.1000056]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001438
@@ -9103,6 +9418,7 @@ name: ProteinExtractor:SequestWeighting
 def: "Influence of SEQUEST search engine in the process of merging the search engine specific protein lists into the global protein list of ProteinExtractor." [DOI:10.4172/jpb.1000056]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001439
@@ -9110,6 +9426,7 @@ name: ProteinExtractor:UseProteinSolver
 def: "Flag indicating to include ProteinSolver scoring for calculation of the ProteinExtractor meta score." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001440
@@ -9117,6 +9434,7 @@ name: ProteinExtractor:ProteinSolverPeptideScoreThreshold
 def: "Only peptides with scores higher than that threshold are taken into account in ProteinSolver scoring for calculation of the ProteinExtractor meta score." [DOI:10.4172/jpb.1000056]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001441
@@ -9124,6 +9442,7 @@ name: ProteinExtractor:ProteinSolverUniqueScore
 def: "In the final result each protein must have at least one peptide above this ProteinSolver score threshold in ProteinExtractor meta score calculation." [DOI:10.4172/jpb.1000056]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001442
@@ -9131,6 +9450,7 @@ name: ProteinExtractor:ProteinSolverWeighting
 def: "Influence of ProteinSolver search engine in the process of merging the search engine specific protein lists into the global protein list of ProteinExtractor." [DOI:10.4172/jpb.1000056]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001443
@@ -9138,6 +9458,7 @@ name: ProteinExtractor:UsePhenyx
 def: "Flag indicating to include Phenyx scoring for calculation of the ProteinExtractor meta score." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001444
@@ -9145,6 +9466,7 @@ name: ProteinExtractor:PhenyxPeptideScoreThreshold
 def: "Only peptides with scores higher than that threshold are taken into account in Phenyx scoring for calculation of the ProteinExtractor meta score." [DOI:10.4172/jpb.1000056]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001445
@@ -9152,6 +9474,7 @@ name: ProteinExtractor:PhenyxUniqueScore
 def: "In the final result each protein must have at least one peptide above this Phenyx score threshold in ProteinExtractor meta score calculation." [DOI:10.4172/jpb.1000056]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001446
@@ -9159,6 +9482,7 @@ name: ProteinExtractor:PhenyxWeighting
 def: "Influence of Phenyx search engine in the process of merging the search engine specific protein lists into the global protein list of ProteinExtractor." [DOI:10.4172/jpb.1000056]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001447
@@ -9166,6 +9490,7 @@ name: prot:FDR threshold
 def: "False-discovery rate threshold for proteins." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002485 ! protein-level statistical threshold
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001448
@@ -9173,6 +9498,7 @@ name: pep:FDR threshold
 def: "False-discovery rate threshold for peptides." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002484 ! peptide-level statistical threshold
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001449
@@ -9180,6 +9506,7 @@ name: OMSSA e-value threshold
 def: "Threshold for OMSSA e-value for quality estimation." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002099 ! OMSSA input parameter
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001450
@@ -9193,6 +9520,7 @@ name: decoy DB generation algorithm
 def: "Name of algorithm used for decoy generation." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001450 ! decoy DB details
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001452
@@ -9285,6 +9613,7 @@ name: taxonomy: NCBI TaxID
 def: "This term is used if a NCBI TaxID is specified, e.g. 9606 for Homo sapiens." [PSI:PI]
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1001089 ! molecule taxonomy
+relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001468
@@ -9292,6 +9621,7 @@ name: taxonomy: common name
 def: "This term is used if a common name is specified, e.g. human. Recommend using MS:1001467 (taxonomy: NCBI TaxID) where possible." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001089 ! molecule taxonomy
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001469
@@ -9299,6 +9629,7 @@ name: taxonomy: scientific name
 def: "This term is used if a scientific name is specified, e.g. Homo sapiens. Recommend using MS:1001467 (taxonomy: NCBI TaxID) where possible." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001089 ! molecule taxonomy
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001470
@@ -9306,6 +9637,7 @@ name: taxonomy: Swiss-Prot ID
 def: "This term is used if a swiss prot taxonomy id is specified, e.g. Human. Recommend using MS:1001467 (taxonomy: NCBI TaxID) where possible." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001089 ! molecule taxonomy
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001471
@@ -9443,6 +9775,7 @@ name: percolator:Q value
 def: "Percolator:Q value." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001492
@@ -9450,6 +9783,7 @@ name: percolator:score
 def: "Percolator:score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001493
@@ -9457,6 +9791,7 @@ name: percolator:PEP
 def: "Posterior error probability." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001494
@@ -9470,6 +9805,7 @@ name: ProteinScape:SearchResultId
 def: "The SearchResultId of this peptide as SearchResult in the ProteinScape database." [PSI:PI]
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001496
@@ -9477,6 +9813,7 @@ name: ProteinScape:SearchEventId
 def: "The SearchEventId of the SearchEvent in the ProteinScape database." [PSI:PI]
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001497
@@ -9484,6 +9821,7 @@ name: ProteinScape:ProfoundProbability
 def: "The Profound probability score stored by ProteinScape." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001498
@@ -9491,6 +9829,7 @@ name: Profound:z value
 def: "The Profound z value." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001499
@@ -9498,6 +9837,7 @@ name: Profound:Cluster
 def: "The Profound cluster score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001500
@@ -9505,6 +9845,7 @@ name: Profound:ClusterRank
 def: "The Profound cluster rank." [PSI:PI]
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001501
@@ -9512,6 +9853,7 @@ name: MSFit:Mowse score
 def: "The MSFit Mowse score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001502
@@ -9519,6 +9861,7 @@ name: Sonar:Score
 def: "The Sonar score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001503
@@ -9526,6 +9869,7 @@ name: ProteinScape:PFFSolverExp
 def: "The ProteinSolver exp value stored by ProteinScape." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001504
@@ -9533,6 +9877,7 @@ name: ProteinScape:PFFSolverScore
 def: "The ProteinSolver score stored by ProteinScape." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001505
@@ -9540,6 +9885,7 @@ name: ProteinScape:IntensityCoverage
 def: "The intensity coverage of the identified peaks in the spectrum calculated by ProteinScape." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001506
@@ -9547,6 +9893,7 @@ name: ProteinScape:SequestMetaScore
 def: "The SEQUEST meta score calculated by ProteinScape from the original SEQUEST scores." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001507
@@ -9554,6 +9901,7 @@ name: ProteinExtractor:Score
 def: "The score calculated by ProteinExtractor." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001508
@@ -9591,6 +9939,7 @@ name: DB sequence filter pattern
 def: "DB sequence filter pattern." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001512 ! Sequence database filters
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001514
@@ -9598,6 +9947,7 @@ name: DB accession filter string
 def: "DB accession filter string." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001512 ! Sequence database filters
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001515
@@ -9660,6 +10010,7 @@ def: "This term can describe a neutral loss m/z value that is lost from an ion."
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001471 ! peptide modification details
 relationship: has_units UO:0000221 ! dalton
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001525
@@ -9668,6 +10019,7 @@ def: "This term can describe a neutral loss m/z value that is lost from an ion."
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001471 ! peptide modification details
 relationship: has_units UO:0000221 ! dalton
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001526
@@ -9926,6 +10278,7 @@ name: Scaffold:Peptide Probability
 def: "Scaffold peptide probability score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001569
@@ -9933,6 +10286,7 @@ name: IdentityE Score
 def: "Waters IdentityE peptide score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001570
@@ -9940,6 +10294,7 @@ name: ProteinLynx:Log Likelihood
 def: "ProteinLynx log likelihood score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001571
@@ -9947,6 +10302,7 @@ name: ProteinLynx:Ladder Score
 def: "Waters ProteinLynx Ladder score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001572
@@ -9954,6 +10310,7 @@ name: SpectrumMill:Score
 def: "Spectrum mill peptide score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001573
@@ -9961,6 +10318,7 @@ name: SpectrumMill:SPI
 def: "SpectrumMill SPI score (%)." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001574
@@ -9974,6 +10332,7 @@ name: Scaffold: Minimum Peptide Count
 def: "Minimum number of peptides a protein must have to be accepted." [PSI:PI]
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1002106 ! Scaffold input parameter
+relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001576
@@ -9981,6 +10340,7 @@ name: Scaffold: Minimum Protein Probability
 def: "Minimum protein probability a protein must have to be accepted." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002106 ! Scaffold input parameter
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001577
@@ -9988,6 +10348,7 @@ name: Scaffold: Minimum Peptide Probability
 def: "Minimum probability a peptide must have to be accepted for protein scoring." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002106 ! Scaffold input parameter
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001578
@@ -9995,6 +10356,7 @@ name: minimum number of enzymatic termini
 def: "Minimum number of enzymatic termini a peptide must have to be accepted." [PSI:PI]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1002094 ! common search engine input parameter
+relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001579
@@ -10002,6 +10364,7 @@ name: Scaffold:Protein Probability
 def: "Scaffold protein probability score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001580
@@ -10009,6 +10372,7 @@ name: SpectrumMill:Discriminant Score
 def: "Discriminant score from Agilent SpectrumMill software." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001581
@@ -10018,6 +10382,7 @@ xref: value-type:xsd\:double "The allowed value-type for this CV term."
 synonym: "FAIMS CV" EXACT []
 is_a: MS:1002892 ! ion mobility attribute
 relationship: has_units UO:0000218 ! volt
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001582
@@ -10085,6 +10450,7 @@ name: anchor protein
 def: "A representative protein selected from a set of sequence same-set or spectrum same-set proteins." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001101 ! protein group or subset relationship
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001592
@@ -10092,6 +10458,7 @@ name: family member protein
 def: "A protein with significant homology to another protein, but some distinguishing peptide matches." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001101 ! protein group or subset relationship
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001593
@@ -10105,6 +10472,7 @@ name: sequence same-set protein
 def: "A protein which is indistinguishable or equivalent to another protein, having matches to an identical set of peptide sequences." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001101 ! protein group or subset relationship
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001595
@@ -10112,6 +10480,7 @@ name: spectrum same-set protein
 def: "A protein which is indistinguishable or equivalent to another protein, having matches to a set of peptide sequences that cannot be distinguished using the evidence in the mass spectra." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001101 ! protein group or subset relationship
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001596
@@ -10119,6 +10488,7 @@ name: sequence sub-set protein
 def: "A protein with a sub-set of the peptide sequence matches for another protein, and no distinguishing peptide matches." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001101 ! protein group or subset relationship
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001597
@@ -10126,6 +10496,7 @@ name: spectrum sub-set protein
 def: "A protein with a sub-set of the matched spectra for another protein, where the matches cannot be distinguished using the evidence in the mass spectra, and no distinguishing peptide matches." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001101 ! protein group or subset relationship
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001598
@@ -10133,6 +10504,7 @@ name: sequence subsumable protein
 def: "A sequence same-set or sequence sub-set protein where the matches are distributed across two or more proteins." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001101 ! protein group or subset relationship
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001599
@@ -10140,6 +10512,7 @@ name: spectrum subsumable protein
 def: "A spectrum same-set or spectrum sub-set protein where the matches are distributed across two or more proteins." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001101 ! protein group or subset relationship
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001600
@@ -10147,6 +10520,7 @@ name: protein inference confidence category
 def: "Confidence category of inferred protein (conclusive, non conclusive, ambiguous group or indistinguishable)." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001101 ! protein group or subset relationship
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001601
@@ -10156,6 +10530,7 @@ comment: This term was made obsolete because it's recommended to use one of the 
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001602
@@ -10165,6 +10540,7 @@ comment: This term was made obsolete. Use attribute in mzIdentML / mzQuantML ins
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001603
@@ -10174,6 +10550,7 @@ comment: This term was made obsolete because it's recommended to use one of the 
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001604
@@ -10183,6 +10560,7 @@ comment: This term was made obsolete because it's recommended to use one of the 
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001605
@@ -10190,6 +10568,7 @@ name: ProteomeDiscoverer:Spectrum Selector:Lower RT Limit
 def: "Lower retention-time limit." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001606
@@ -10199,6 +10578,7 @@ comment: This term was made obsolete because it's recommended to use mass analyz
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001607
@@ -10206,6 +10586,7 @@ name: ProteomeDiscoverer:Max Precursor Mass
 def: "Maximum mass limit of a singly charged precursor ion." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001608
@@ -10213,6 +10594,7 @@ name: ProteomeDiscoverer:Min Precursor Mass
 def: "Minimum mass limit of a singly charged precursor ion." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001609
@@ -10220,6 +10602,7 @@ name: ProteomeDiscoverer:Spectrum Selector:Minimum Peak Count
 def: "Minimum number of peaks in a tandem mass spectrum that is allowed to pass the filter and to be subjected to further processing in the workflow." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001610
@@ -10229,6 +10612,7 @@ comment: This term was made obsolete because it's recommended to use MS1 spectru
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001611
@@ -10238,6 +10622,7 @@ comment: This term was made obsolete because it's recommended to use scan polari
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001612
@@ -10245,6 +10630,7 @@ name: ProteomeDiscoverer:Spectrum Selector:Precursor Selection
 def: "Determines which precursor mass to use for a given MSn scan. This option applies only to higher-order MSn scans (n >= 3)." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001613
@@ -10252,6 +10638,7 @@ name: ProteomeDiscoverer:SN Threshold
 def: "Signal-to-Noise ratio below which peaks are removed." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001614
@@ -10261,6 +10648,7 @@ comment: This term was made obsolete because it's recommended to use MS1 spectru
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001615
@@ -10268,6 +10656,7 @@ name: ProteomeDiscoverer:Spectrum Selector:Total Intensity Threshold
 def: "Used to filter out tandem mass spectra that have a total intensity current(sum of the intensities of all peaks in a spectrum) below the specified value." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001616
@@ -10275,6 +10664,7 @@ name: ProteomeDiscoverer:Spectrum Selector:Unrecognized Activation Type Replacem
 def: "Specifies the fragmentation method to use in the search algorithm if it is not included in the scan header." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001617
@@ -10282,6 +10672,7 @@ name: ProteomeDiscoverer:Spectrum Selector:Unrecognized Charge Replacements
 def: "Specifies the charge state of the precursor ions, if it is not defined in the scan header." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001618
@@ -10289,6 +10680,7 @@ name: ProteomeDiscoverer:Spectrum Selector:Unrecognized Mass Analyzer Replacemen
 def: "Specifies the mass spectrometer to use to produce the spectra, if it is not included in the scan header." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001619
@@ -10296,6 +10688,7 @@ name: ProteomeDiscoverer:Spectrum Selector:Unrecognized MS Order Replacements
 def: "Specifies the MS scan order used to produce the product spectra, if it is not included in the scan header." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001620
@@ -10303,6 +10696,7 @@ name: ProteomeDiscoverer:Spectrum Selector:Unrecognized Polarity Replacements
 def: "Specifies the polarity of the ions monitored if it is not included in the scan header." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001621
@@ -10310,6 +10704,7 @@ name: ProteomeDiscoverer:Spectrum Selector:Upper RT Limit
 def: "Upper retention-time limit." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001622
@@ -10317,6 +10712,7 @@ name: ProteomeDiscoverer:Non-Fragment Filter:Mass Window Offset
 def: "Specifies the size of the mass-to-charge ratio (m/z) window in daltons used to remove precursors." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001623
@@ -10324,6 +10720,7 @@ name: ProteomeDiscoverer:Non-Fragment Filter:Maximum Neutral Loss Mass
 def: "Maximum allowed mass of a neutral loss." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001624
@@ -10331,6 +10728,7 @@ name: ProteomeDiscoverer:Non-Fragment Filter:Remove Charge Reduced Precursor
 def: "Determines whether the charge-reduced precursor peaks found in an ETD or ECD spectrum are removed." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001625
@@ -10338,6 +10736,7 @@ name: ProteomeDiscoverer:Non-Fragment Filter:Remove Neutral Loss Peaks
 def: "Determines whether neutral loss peaks are removed from ETD and ECD spectra." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001626
@@ -10345,6 +10744,7 @@ name: ProteomeDiscoverer:Non-Fragment Filter:Remove Only Known Masses
 def: "Determines whether overtone peaks are removed from LTQ FT or LTQ FT Ultra ECD spectra." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001627
@@ -10352,6 +10752,7 @@ name: ProteomeDiscoverer:Non-Fragment Filter:Remove Precursor Overtones
 def: "Determines whether precursor overtone peaks in the spectrum are removed from the input spectrum." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001628
@@ -10359,6 +10760,7 @@ name: ProteomeDiscoverer:Non-Fragment Filter:Remove Precursor Peak
 def: "Determines whether precursor artifact peaks from the MS2 input spectra are removed." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001629
@@ -10366,6 +10768,7 @@ name: ProteomeDiscoverer:Spectrum Grouper:Allow Mass Analyzer Mismatch
 def: "Determines whether the fragment spectrum for scans with the same precursor mass is grouped, regardless of mass analyzer and activation type." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001630
@@ -10373,6 +10776,7 @@ name: ProteomeDiscoverer:Spectrum Grouper:Allow MS Order Mismatch
 def: "Determines whether spectra from different MS order scans can be grouped together." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001631
@@ -10382,6 +10786,7 @@ comment: This term was made obsolete because it's recommended to use retention t
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001632
@@ -10389,6 +10794,7 @@ name: ProteomeDiscoverer:Spectrum Grouper:Precursor Mass Criterion
 def: "Groups spectra measured within the given mass and retention-time tolerances into a single spectrum for analysis." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001633
@@ -10396,6 +10802,7 @@ name: ProteomeDiscoverer:Xtract:Highest Charge
 def: "Highest charge state that is allowed for the deconvolution of multiply charged data." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001634
@@ -10405,6 +10812,7 @@ comment: This term was made obsolete because it's recommended to use scan window
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001635
@@ -10412,6 +10820,7 @@ name: ProteomeDiscoverer:Xtract:Lowest Charge
 def: "Lowest charge state that is allowed for the deconvolution of multiply charged data." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001636
@@ -10421,6 +10830,7 @@ comment: This term was made obsolete because it's recommended to use scan window
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001637
@@ -10428,6 +10838,7 @@ name: ProteomeDiscoverer:Xtract:Monoisotopic Mass Only
 def: "Determines whether the isotopic pattern, i.e. all isotopes of a mass are removed from the spectrum." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001638
@@ -10435,6 +10846,7 @@ name: ProteomeDiscoverer:Xtract:Overlapping Remainder
 def: "Fraction of the more abundant peak that an overlapping multiplet must exceed in order to be processed (deconvoluted)." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001639
@@ -10442,6 +10854,7 @@ name: ProteomeDiscoverer:Xtract:Required Fitting Accuracy
 def: "Accuracy required for a pattern fit to be considered valid." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001640
@@ -10449,6 +10862,7 @@ name: ProteomeDiscoverer:Xtract:Resolution At 400
 def: "Resolution at mass 400." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001641
@@ -10456,6 +10870,7 @@ name: ProteomeDiscoverer:Lowest Charge State
 def: "Minimum charge state below which peptides are filtered out." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001642
@@ -10463,6 +10878,7 @@ name: ProteomeDiscoverer:Highest Charge State
 def: "Maximum charge above which peptides are filtered out." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001643
@@ -10470,6 +10886,7 @@ name: ProteomeDiscoverer:Spectrum Score Filter:Let Pass Above Scores
 def: "Determines whether spectra with scores above the threshold score are retained rather than filtered out." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001644
@@ -10477,6 +10894,7 @@ name: ProteomeDiscoverer:Dynamic Modification
 def: "Determine dynamic post-translational modifications (PTMs)." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001645
@@ -10484,6 +10902,7 @@ name: ProteomeDiscoverer:Static Modification
 def: "Static Modification to all occurrences of a named amino acid." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001646
@@ -10493,6 +10912,7 @@ comment: This term was made obsolete because it's recommended to use quality est
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001647
@@ -10500,6 +10920,7 @@ name: ProteomeDiscoverer:Mascot:Error tolerant Search
 def: "Determines whether to search error-tolerant." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001648
@@ -10507,6 +10928,7 @@ name: ProteomeDiscoverer:Mascot:Max MGF File Size
 def: "Maximum size of the .mgf (Mascot Generic Format) file in MByte." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001649
@@ -10514,6 +10936,7 @@ name: ProteomeDiscoverer:Mascot:Mascot Server URL
 def: "URL (Uniform resource Locator) of the Mascot server." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001650
@@ -10521,6 +10944,7 @@ name: ProteomeDiscoverer:Mascot:Number of attempts to submit the search
 def: "Number of attempts to submit the Mascot search." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001651
@@ -10528,6 +10952,7 @@ name: ProteomeDiscoverer:Mascot:X Static Modification
 def: "Number of attempts to submit the Mascot search." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001652
@@ -10537,6 +10962,7 @@ comment: This term was made obsolete because it's recommended to use researcher 
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001653
@@ -10544,6 +10970,7 @@ name: ProteomeDiscoverer:Mascot:Time interval between attempts to submit a searc
 def: "Time interval between attempts to submit a search in seconds." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001654
@@ -10553,6 +10980,7 @@ comment: This term was made obsolete because it's recommended to use cleavage ag
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001655
@@ -10562,6 +10990,7 @@ comment: This term was made obsolete because it's recommended to use search tole
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001656
@@ -10569,6 +10998,7 @@ name: Mascot:Instrument
 def: "Type of instrument used to acquire the data in the raw file." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002095 ! Mascot input parameter
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001657
@@ -10576,6 +11006,7 @@ name: ProteomeDiscoverer:Maximum Missed Cleavage Sites
 def: "Maximum number of missed cleavage sites to consider during the digest." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001658
@@ -10583,6 +11014,7 @@ name: ProteomeDiscoverer:Mascot:Peptide CutOff Score
 def: "Minimum score in the IonScore column that each peptide must exceed in order to be reported." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001659
@@ -10592,6 +11024,7 @@ comment: This term was made obsolete because it's recommended to use search tole
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001660
@@ -10599,6 +11032,7 @@ name: ProteomeDiscoverer:Mascot:Protein CutOff Score
 def: "Minimum protein score in the IonScore column that each protein must exceed in order to be reported." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001661
@@ -10608,6 +11042,7 @@ comment: This term was made obsolete because it's recommended to use database na
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001662
@@ -10615,6 +11050,7 @@ name: ProteomeDiscoverer:Mascot:Protein Relevance Factor
 def: "Specifies a factor that is used in calculating a threshold that determines whether a protein appears in the results report." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001663
@@ -10622,6 +11058,7 @@ name: ProteomeDiscoverer:Target FDR Relaxed
 def: "Specifies the relaxed target false discovery rate (FDR, 0.0 - 1.0) for peptide hits with moderate confidence." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001664
@@ -10629,6 +11066,7 @@ name: ProteomeDiscoverer:Target FDR Strict
 def: "Specifies the strict target false discovery rate (FDR, 0.0 - 1.0) for peptide hits with high confidence." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001665
@@ -10638,6 +11076,7 @@ comment: This term was made obsolete because it's recommended to use taxonomy: s
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001666
@@ -10647,6 +11086,7 @@ comment: This term was made obsolete because it's recommended to use parent mass
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001667
@@ -10656,6 +11096,7 @@ comment: This term was made obsolete because it's recommended to use Mascot:Prot
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002095 ! Mascot input parameter
 is_obsolete: true
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001668
@@ -10663,6 +11104,7 @@ name: ProteomeDiscoverer:Absolute XCorr Threshold
 def: "Minimum cross-correlation threshold that determines whether peptides in an .srf file are imported." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001669
@@ -10670,6 +11112,7 @@ name: ProteomeDiscoverer:SEQUEST:Calculate Probability Score
 def: "Determines whether to calculate a probability score for every peptide match." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001670
@@ -10677,6 +11120,7 @@ name: ProteomeDiscoverer:SEQUEST:CTerminal Modification
 def: "Dynamic C-terminal modification that is used during the search." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001671
@@ -10684,6 +11128,7 @@ name: ProteomeDiscoverer:SEQUEST:Fragment Ion Cutoff Percentage
 def: "Percentage of the theoretical ions that must be found in order for a peptide to be scored and retained." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001672
@@ -10691,6 +11136,7 @@ name: ProteomeDiscoverer:SEQUEST:Max Identical Modifications Per Peptide
 def: "Maximum number of identical modifications that a single peptide can have." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001673
@@ -10698,6 +11144,7 @@ name: ProteomeDiscoverer:Max Modifications Per Peptide
 def: "Maximum number of different modifications that a peptide can have, e.g. because of steric hindrance." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001674
@@ -10705,6 +11152,7 @@ name: ProteomeDiscoverer:SEQUEST:Maximum Peptides Considered
 def: "Maximum number of peptides that are searched and scored per spectrum." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001675
@@ -10712,6 +11160,7 @@ name: ProteomeDiscoverer:Maximum Peptides Output
 def: "Maximum number of peptide matches reported per spectrum." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001676
@@ -10719,6 +11168,7 @@ name: ProteomeDiscoverer:Maximum Protein References Per Peptide
 def: "Maximum number of proteins that a single identified peptide can be associated with during protein assembly." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001677
@@ -10726,6 +11176,7 @@ name: ProteomeDiscoverer:SEQUEST:NTerminal Modification
 def: "Dynamic N-terminal modification that is used during the search." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001678
@@ -10733,6 +11184,7 @@ name: ProteomeDiscoverer:Peptide CTerminus
 def: "Static modification for the C terminal of the peptide used during the search." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001679
@@ -10740,6 +11192,7 @@ name: ProteomeDiscoverer:Peptide NTerminus
 def: "Static modification for the N terminal of the peptide used during the search." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001680
@@ -10747,6 +11200,7 @@ name: ProteomeDiscoverer:SEQUEST:Peptide Relevance Factor
 def: "Specifies a factor to apply to the protein score." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001681
@@ -10754,6 +11208,7 @@ name: ProteomeDiscoverer:Protein Relevance Threshold
 def: "Specifies a peptide threshold that determines whether the protein that it is a part of is scored and retained in the report." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001682
@@ -10763,6 +11218,7 @@ comment: This term was made obsolete because it's recommended to use quality est
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001683
@@ -10770,6 +11226,7 @@ name: ProteomeDiscoverer:SEQUEST:Use Average Fragment Masses
 def: "Use average masses for the fragments." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001684
@@ -10777,6 +11234,7 @@ name: ProteomeDiscoverer:Use Neutral Loss a Ions
 def: "Determines whether a ions with neutral loss are used for spectrum matching." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001685
@@ -10784,6 +11242,7 @@ name: ProteomeDiscoverer:Use Neutral Loss b Ions
 def: "Determines whether b ions with neutral loss are used for spectrum matching." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001686
@@ -10791,6 +11250,7 @@ name: ProteomeDiscoverer:Use Neutral Loss y Ions
 def: "Determines whether y ions with neutral loss are used for spectrum matching." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001687
@@ -10798,6 +11258,7 @@ name: ProteomeDiscoverer:Use Neutral Loss z Ions
 def: "Determines whether z ions with neutral loss are used for spectrum matching." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001688
@@ -10805,6 +11266,7 @@ name: ProteomeDiscoverer:SEQUEST:Weight of a Ions
 def: "Uses a ions for spectrum matching with this relative factor." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001689
@@ -10812,6 +11274,7 @@ name: ProteomeDiscoverer:SEQUEST:Weight of b Ions
 def: "Uses b ions for spectrum matching with this relative factor." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001690
@@ -10819,6 +11282,7 @@ name: ProteomeDiscoverer:SEQUEST:Weight of c Ions
 def: "Uses c ions for spectrum matching with this relative factor." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001691
@@ -10826,6 +11290,7 @@ name: ProteomeDiscoverer:SEQUEST:Weight of d Ions
 def: "Uses c ions for spectrum matching with this relative factor." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001692
@@ -10833,6 +11298,7 @@ name: ProteomeDiscoverer:SEQUEST:Weight of v Ions
 def: "Uses c ions for spectrum matching with this relative factor." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001693
@@ -10840,6 +11306,7 @@ name: ProteomeDiscoverer:SEQUEST:Weight of w Ions
 def: "Uses c ions for spectrum matching with this relative factor." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001694
@@ -10847,6 +11314,7 @@ name: ProteomeDiscoverer:SEQUEST:Weight of x Ions
 def: "Uses x ions for spectrum matching with this relative factor." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001695
@@ -10854,6 +11322,7 @@ name: ProteomeDiscoverer:SEQUEST:Weight of y Ions
 def: "Uses y ions for spectrum matching with this relative factor." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001696
@@ -10861,6 +11330,7 @@ name: ProteomeDiscoverer:SEQUEST:Weight of z Ions
 def: "Uses z ions for spectrum matching with this relative factor." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001697
@@ -10868,6 +11338,7 @@ name: ProteomeDiscoverer:ZCore:Protein Score Cutoff
 def: "Sets a minimum protein score that each protein must exceed in order to be reported." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001698
@@ -10875,6 +11346,7 @@ name: ProteomeDiscoverer:Reporter Ions Quantizer:Integration Method
 def: "Specifies which peak to select if more than one peak is found inside the integration window." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001699
@@ -10882,6 +11354,7 @@ name: ProteomeDiscoverer:Reporter Ions Quantizer:Integration Window Tolerance
 def: "Specifies the mass-to-charge window that enables one to look for the reporter peaks." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001700
@@ -10889,6 +11362,7 @@ name: ProteomeDiscoverer:Reporter Ions Quantizer:Quantitation Method
 def: "Quantitation method for isobarically labeled quantitation." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001701
@@ -10898,6 +11372,7 @@ comment: This term was made obsolete because it's recommended to use one of the 
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001702
@@ -10905,6 +11380,7 @@ name: ProteomeDiscoverer:Spectrum Exporter:File name
 def: "Name of the output file that contains the exported data." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001703
@@ -10912,6 +11388,7 @@ name: ProteomeDiscoverer:Search Modifications Only For Identified Proteins
 def: "Influences the modifications search." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001704
@@ -10919,6 +11396,7 @@ name: ProteomeDiscoverer:SEQUEST:Std High Confidence XCorr Charge1
 def: "Standard high confidence XCorr parameter for charge = 1." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001705
@@ -10926,6 +11404,7 @@ name: ProteomeDiscoverer:SEQUEST:Std High Confidence XCorr Charge2
 def: "Standard high confidence XCorr parameter for charge = 2." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001706
@@ -10933,6 +11412,7 @@ name: ProteomeDiscoverer:SEQUEST:Std High Confidence XCorr Charge3
 def: "Standard high confidence XCorr parameter for charge = 3." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001707
@@ -10940,6 +11420,7 @@ name: ProteomeDiscoverer:SEQUEST:Std High Confidence XCorr Charge4
 def: "Standard high confidence XCorr parameter for charge >= 4." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001708
@@ -10947,6 +11428,7 @@ name: ProteomeDiscoverer:SEQUEST:Std Medium Confidence XCorr Charge1
 def: "Standard medium confidence XCorr parameter for charge = 1." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001709
@@ -10954,6 +11436,7 @@ name: ProteomeDiscoverer:SEQUEST:Std Medium Confidence XCorr Charge2
 def: "Standard medium confidence XCorr parameter for charge = 2." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001710
@@ -10961,6 +11444,7 @@ name: ProteomeDiscoverer:SEQUEST:Std Medium Confidence XCorr Charge3
 def: "Standard medium confidence XCorr parameter for charge = 3." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001711
@@ -10968,6 +11452,7 @@ name: ProteomeDiscoverer:SEQUEST:Std Medium Confidence XCorr Charge4
 def: "Standard medium confidence XCorr parameter for charge >= 4." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001712
@@ -10975,6 +11460,7 @@ name: ProteomeDiscoverer:SEQUEST:FT High Confidence XCorr Charge1
 def: "FT high confidence XCorr parameter for charge = 1." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001713
@@ -10982,6 +11468,7 @@ name: ProteomeDiscoverer:SEQUEST:FT High Confidence XCorr Charge2
 def: "FT high confidence XCorr parameter for charge = 2." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001714
@@ -10989,6 +11476,7 @@ name: ProteomeDiscoverer:SEQUEST:FT High Confidence XCorr Charge3
 def: "FT high confidence XCorr parameter for charge = 3." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001715
@@ -10996,6 +11484,7 @@ name: ProteomeDiscoverer:SEQUEST:FT High Confidence XCorr Charge4
 def: "FT high confidence XCorr parameter for charge >= 4." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001716
@@ -11003,6 +11492,7 @@ name: ProteomeDiscoverer:SEQUEST:FT Medium Confidence XCorr Charge1
 def: "FT medium confidence XCorr parameter for charge = 1." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001717
@@ -11010,6 +11500,7 @@ name: ProteomeDiscoverer:SEQUEST:FT Medium Confidence XCorr Charge2
 def: "FT medium confidence XCorr parameter for charge = 2." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001718
@@ -11017,6 +11508,7 @@ name: ProteomeDiscoverer:SEQUEST:FT Medium Confidence XCorr Charge3
 def: "FT medium confidence XCorr parameter for charge = 3." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001719
@@ -11024,6 +11516,7 @@ name: ProteomeDiscoverer:SEQUEST:FT Medium Confidence XCorr Charge4
 def: "FT medium confidence XCorr parameter for charge >= 4." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001720
@@ -11033,6 +11526,7 @@ comment: This term was made obsolete because it's recommended to use ProteomeDis
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001721
@@ -11042,6 +11536,7 @@ comment: This term was made obsolete because it's recommended to use ProteomeDis
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001722
@@ -11051,6 +11546,7 @@ comment: This term was made obsolete because it's recommended to use ProteomeDis
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001723
@@ -11060,6 +11556,7 @@ comment: This term was made obsolete because it's recommended to use ProteomeDis
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001724
@@ -11067,6 +11564,7 @@ name: ProteomeDiscoverer:Static Modification for X
 def: "Static Modification for X." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001725
@@ -11074,6 +11572,7 @@ name: ProteomeDiscoverer:Initial minimal peptide probability
 def: "Minimal initial peptide probability to contribute to analysis." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001726
@@ -11081,6 +11580,7 @@ name: ProteomeDiscoverer:Minimal peptide probability
 def: "Minimum adjusted peptide probability contributing to protein probability." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001727
@@ -11088,6 +11588,7 @@ name: ProteomeDiscoverer:Minimal peptide weight
 def: "Minimum peptide weight contributing to protein probability." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001728
@@ -11095,6 +11596,7 @@ name: ProteomeDiscoverer:Number of input1 spectra
 def: "Number of spectra from 1+ precursor ions." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001729
@@ -11102,6 +11604,7 @@ name: ProteomeDiscoverer:Number of input2 spectra
 def: "Number of spectra from 2+ precursor ions." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001730
@@ -11109,6 +11612,7 @@ name: ProteomeDiscoverer:Number of input3 spectra
 def: "Number of spectra from 3+ precursor ions." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001731
@@ -11116,6 +11620,7 @@ name: ProteomeDiscoverer:Number of input4 spectra
 def: "Number of spectra from 4+ precursor ions." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001732
@@ -11123,6 +11628,7 @@ name: ProteomeDiscoverer:Number of input5 spectra
 def: "Number of spectra from 5+ precursor ions." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001733
@@ -11130,6 +11636,7 @@ name: ProteomeDiscoverer:Number of predicted correct proteins
 def: "Total number of predicted correct protein ids (sum of probabilities)." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001734
@@ -11139,6 +11646,7 @@ comment: This term was made obsolete because it's recommended to use taxonomy: s
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001735
@@ -11148,6 +11656,7 @@ comment: This term was made obsolete. Use attribute in mzIdentML / mzQuantML ins
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001736
@@ -11155,6 +11664,7 @@ name: ProteomeDiscoverer:Residue substitution list
 def: "Residues considered equivalent when comparing peptides." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001737
@@ -11164,6 +11674,7 @@ comment: This term was made obsolete because it's recommended to use mass spectr
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001738
@@ -11173,6 +11684,7 @@ comment: This term was made obsolete because it's recommended to use pepXML file
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001739
@@ -11182,6 +11694,7 @@ comment: This term was made obsolete because it's recommended to use pepXML file
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001740
@@ -11189,6 +11702,7 @@ name: ProteomeDiscoverer:WinCyg reference database
 def: "Windows full path for database." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001741
@@ -11196,6 +11710,7 @@ name: ProteomeDiscoverer:WinCyg source files
 def: "Windows pepXML file names." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001742
@@ -11209,6 +11724,7 @@ name: ProteomeDiscoverer:Mascot:Weight of A Ions
 def: "Determines if to use A ions for spectrum matching." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001744
@@ -11216,6 +11732,7 @@ name: ProteomeDiscoverer:Mascot:Weight of B Ions
 def: "Determines if to use B ions for spectrum matching." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001745
@@ -11223,6 +11740,7 @@ name: ProteomeDiscoverer:Mascot:Weight of C Ions
 def: "Determines if to use C ions for spectrum matching." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001746
@@ -11230,6 +11748,7 @@ name: ProteomeDiscoverer:Mascot:Weight of D Ions
 def: "Determines if to use D ions for spectrum matching." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001747
@@ -11237,6 +11756,7 @@ name: ProteomeDiscoverer:Mascot:Weight of V Ions
 def: "Determines if to use V ions for spectrum matching." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001748
@@ -11244,6 +11764,7 @@ name: ProteomeDiscoverer:Mascot:Weight of W Ions
 def: "Determines if to use W ions for spectrum matching." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001749
@@ -11251,6 +11772,7 @@ name: ProteomeDiscoverer:Mascot:Weight of X Ions
 def: "Determines if to use X ions for spectrum matching." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001750
@@ -11258,6 +11780,7 @@ name: ProteomeDiscoverer:Mascot:Weight of Y Ions
 def: "Determines if to use Y ions for spectrum matching." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001751
@@ -11265,6 +11788,7 @@ name: ProteomeDiscoverer:Mascot:Weight of Z Ions
 def: "Determines if to use z ions for spectrum matching." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001752
@@ -11272,6 +11796,7 @@ name: ProteomeDiscoverer:Spectrum Selector:Use New Precursor Reevaluation
 def: "Determines if to use precursor reevaluation." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001753
@@ -11279,6 +11804,7 @@ name: ProteomeDiscoverer:Spectrum Selector:SN Threshold FTonly
 def: "Signal-to-Noise ratio below which peaks are removed (in FT mode only)." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001754
@@ -11286,6 +11812,7 @@ name: ProteomeDiscoverer:Mascot:Please Do not Touch this
 def: "Unknown Mascot parameter which ProteomeDiscoverer uses for mascot searches." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001755
@@ -11293,6 +11820,7 @@ name: contact phone number
 def: "Phone number of the contact person or organization." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000585 ! contact attribute
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001756
@@ -11300,6 +11828,7 @@ name: contact fax number
 def: "Fax number for the contact person or organization." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000585 ! contact attribute
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001757
@@ -11307,6 +11836,7 @@ name: contact toll-free phone number
 def: "Toll-free phone number of the contact person or organization." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000585 ! contact attribute
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001758
@@ -11314,6 +11844,7 @@ name: Mascot:SigThresholdType
 def: "Significance threshold type used in Mascot reporting (either 'identity' or 'homology')." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002095 ! Mascot input parameter
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001759
@@ -11321,6 +11852,7 @@ name: Mascot:ProteinGrouping
 def: "Strategy used by Mascot to group proteins with same peptide matches (one of 'none', 'Occam's razor' or 'family clustering')." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002095 ! Mascot input parameter
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001760
@@ -11328,6 +11860,7 @@ name: Percolator:features
 def: "List of Percolator features that were used in processing the peptide matches. Typical Percolator features are 'retentionTime', 'dM', 'mScore', 'lgDScore', 'mrCalc', 'charge' and 'dMppm'." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002107 ! Percolator input parameter
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001761
@@ -11527,6 +12060,7 @@ name: Mascot:PreferredTaxonomy
 def: "NCBI TaxID taxonomy ID to prefer when two or more proteins match the same set of peptides or when protein entry in database represents multiple sequences." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002095 ! Mascot input parameter
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001795
@@ -11621,6 +12155,7 @@ name: technical replicate
 def: "The study variable is 'technical replicate'. The string value denotes the category of technical replicate, e.g. 'run generated from same sample'." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001807 ! study variable attribute
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001809
@@ -11658,6 +12193,7 @@ name: generic experimental condition
 def: "The experimental condition is given in the value of this term." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001807 ! study variable attribute
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001815
@@ -11665,6 +12201,7 @@ name: time series, time point X
 def: "The experimental design followed a time series design. The time point of this run is given in the value of this term." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1001807 ! study variable attribute
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001816
@@ -11672,6 +12209,7 @@ name: dilution series, concentration X
 def: "The experimental design followed a dilution series design. The concentration of this run is given in the value of this term." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001807 ! study variable attribute
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001817
@@ -11751,6 +12289,7 @@ name: SRM transition ID
 def: "Identifier for an SRM transition in an external document describing additional information about the transition." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001828 ! feature attribute
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001830
@@ -11771,6 +12310,7 @@ name: quantitation software comment or customizations
 def: "Quantitation software comment or any customizations to the default setup of the software." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001129 ! quantification information
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001833
@@ -11820,6 +12360,7 @@ name: LC-MS feature intensity
 def: "Maximum peak intensity of the LC-MS feature." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002735 ! feature-level quantification datatype
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001841
@@ -11827,6 +12368,7 @@ name: LC-MS feature volume
 def: "Real (intensity times area) volume of the LC-MS feature." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002735 ! feature-level quantification datatype
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001842
@@ -11834,6 +12376,7 @@ name: sequence-level spectral count
 def: "The number of MS2 spectra identified for a raw peptide sequence without PTMs and charge state in spectral counting." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002737 ! peptide-level quantification datatype
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001843
@@ -11841,6 +12384,7 @@ name: MS1 feature maximum intensity
 def: "Maximum intensity of MS1 feature." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002735 ! feature-level quantification datatype
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001844
@@ -11848,6 +12392,7 @@ name: MS1 feature area
 def: "Area of MS1 feature." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002735 ! feature-level quantification datatype
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001845
@@ -11857,6 +12402,7 @@ comment: This term was made obsolete because it was a duplication of MS:1001844.
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
 is_obsolete: true
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001846
@@ -11864,6 +12410,7 @@ name: isotopic pattern area
 def: "Area of all peaks belonging to the isotopic pattern of light or heavy peak (e.g. 15N)." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001847
@@ -11871,6 +12418,7 @@ name: reporter ion intensity
 def: "Intensity of MS2 reporter ion (e.g. iTraq)." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001848
@@ -11886,6 +12434,7 @@ comment: This term was made obsolete because the concept MatchedFeature was drop
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002735 ! feature-level quantification datatype
 is_obsolete: true
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001850
@@ -11893,6 +12442,7 @@ name: normalized peptide value
 def: "Normalized peptide value." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002737 ! peptide-level quantification datatype
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001851
@@ -11900,6 +12450,7 @@ name: protein value: sum of peptide values
 def: "Protein quantification value calculated as sum of peptide values." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002738 ! protein-level quantification datatype
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001852
@@ -11907,6 +12458,7 @@ name: normalized protein value
 def: "Normalized protein value." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002738 ! protein-level quantification datatype
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001853
@@ -11914,6 +12466,7 @@ name: max fold change
 def: "Global datatype: Maximum of all pair-wise fold changes of group means (e.g. Progenesis)." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001854
@@ -11921,6 +12474,7 @@ name: ANOVA p-value
 def: "Global datatype: p-value of ANOVA of group means (e.g. Progenesis)." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002072 ! p-value
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001855
@@ -11928,6 +12482,7 @@ name: t-test p-value
 def: "P-value of t-Test of two groups." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002072 ! p-value
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001856
@@ -11935,6 +12490,7 @@ name: reporter ion raw value
 def: "Intensity (or area) of MS2 reporter ion (e.g. iTraq)." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001857
@@ -11942,6 +12498,7 @@ name: reporter ion normalized value
 def: "Normalized value of MS2 reporter ion (e.g. iTraq)." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001858
@@ -11949,6 +12506,7 @@ name: XIC area
 def: "Area of the extracted ion chromatogram (e.g. of a transition in SRM)." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001859
@@ -11956,6 +12514,7 @@ name: normalized XIC area
 def: "Normalized area of the extracted ion chromatogram (e.g. of a transition in SRM)." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001860
@@ -11963,6 +12522,7 @@ name: protein value: mean of peptide ratios
 def: "Protein quantification value calculated as mean of peptide ratios." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002738 ! protein-level quantification datatype
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001861
@@ -12013,6 +12573,7 @@ def: "Estimation of the q-value for distinct peptides once redundant identificat
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002484 ! peptide-level statistical threshold
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001869
@@ -12021,6 +12582,7 @@ def: "Estimation of the q-value for proteins." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001116 ! single protein identification statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001870
@@ -12029,6 +12591,7 @@ def: "Estimation of the p-value for distinct peptides once redundant identificat
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001092 ! peptide sequence-level identification statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001871
@@ -12037,6 +12600,7 @@ def: "Estimation of the p-value for proteins." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001116 ! single protein identification statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001872
@@ -12045,6 +12609,7 @@ def: "Estimation of the e-value for distinct peptides once redundant identificat
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001092 ! peptide sequence-level identification statistic
 relationship: has_domain MS:1002306 ! value greater than zero
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001873
@@ -12053,6 +12618,7 @@ def: "Estimation of the e-value for proteins." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001116 ! single protein identification statistic
 relationship: has_domain MS:1002306 ! value greater than zero
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001874
@@ -12063,6 +12629,7 @@ xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1001153 ! search engine specific score
 is_obsolete: true
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001875
@@ -12070,6 +12637,7 @@ name: modification motif
 def: "The regular expression describing the sequence motif for a modification." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001056 ! modification specificity rule
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001876
@@ -12099,6 +12667,7 @@ def: "The potential difference between two adjacent interface voltages affecting
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000482 ! source attribute
 relationship: has_units UO:0000218 ! volt
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001880
@@ -12124,6 +12693,7 @@ name: coefficient of variation
 def: "Variation of a set of signal measurements calculated as the standard deviation relative to the mean." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1001882 ! transition validation attribute
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001884
@@ -12131,6 +12701,7 @@ name: signal-to-noise ratio
 def: "Unitless number providing the ratio of the total measured intensity of a signal relative to the estimated noise level for that signal." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1001882 ! transition validation attribute
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001885
@@ -12138,6 +12709,7 @@ name: command-line parameters
 def: "Parameters string passed to a command-line interface software application, omitting the executable name." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000630 ! data processing parameter
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001886
@@ -12170,6 +12742,7 @@ name: Progenesis:protein normalised abundance
 def: "The data type normalised abundance for proteins produced by Progenesis LC-MS." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002738 ! protein-level quantification datatype
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001891
@@ -12177,6 +12750,7 @@ name: Progenesis:peptide normalised abundance
 def: "The data type normalised abundance for peptides produced by Progenesis LC-MS." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002737 ! peptide-level quantification datatype
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001892
@@ -12184,6 +12758,7 @@ name: Progenesis:protein raw abundance
 def: "The data type raw abundance for proteins produced by Progenesis LC-MS." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002738 ! protein-level quantification datatype
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001893
@@ -12191,6 +12766,7 @@ name: Progenesis:peptide raw abundance
 def: "The data type raw abundance for peptide produced by Progenesis LC-MS." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002737 ! peptide-level quantification datatype
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001894
@@ -12198,6 +12774,7 @@ name: Progenesis:confidence score
 def: "The data type confidence score produced by Progenesis LC-MS." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001895
@@ -12205,6 +12782,7 @@ name: Progenesis:peptide count
 def: "The data type peptide count produced by Progenesis LC-MS." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002737 ! peptide-level quantification datatype
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001896
@@ -12212,6 +12790,7 @@ name: Progenesis:feature intensity
 def: "The data type feature intensity produced by Progenesis LC-MS." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002735 ! feature-level quantification datatype
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001897
@@ -12219,6 +12798,7 @@ name: MaxQuant:peptide counts (unique)
 def: "The data type peptide counts (unique) produced by MaxQuant." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002737 ! peptide-level quantification datatype
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001898
@@ -12226,6 +12806,7 @@ name: MaxQuant:peptide counts (all)
 def: "The data type peptide counts (all) produced by MaxQuant." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002737 ! peptide-level quantification datatype
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001899
@@ -12233,6 +12814,7 @@ name: MaxQuant:peptide counts (razor+unique)
 def: "The data type peptide counts (razor+unique) produced by MaxQuant." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002737 ! peptide-level quantification datatype
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001900
@@ -12240,6 +12822,7 @@ name: MaxQuant:sequence length
 def: "The data type sequence length produced by MaxQuant." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002737 ! peptide-level quantification datatype
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001901
@@ -12247,6 +12830,7 @@ name: MaxQuant:PEP
 def: "The data type PEP (posterior error probability) produced by MaxQuant." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001902
@@ -12254,6 +12838,7 @@ name: MaxQuant:LFQ intensity
 def: "The data type LFQ intensity produced by MaxQuant." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001903
@@ -12261,6 +12846,7 @@ name: MaxQuant:feature intensity
 def: "The data type feature intensity produced by MaxQuant." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002735 ! feature-level quantification datatype
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001904
@@ -12268,6 +12854,7 @@ name: MaxQuant:MS/MS count
 def: "The data type MS2 count produced by MaxQuant." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001905
@@ -12275,6 +12862,7 @@ name: emPAI value
 def: "The emPAI value of protein abundance, produced from the emPAI algorithm." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002738 ! protein-level quantification datatype
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001906
@@ -12282,6 +12870,7 @@ name: APEX value
 def: "The APEX value of protein abundance, produced from the APEX software." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002738 ! protein-level quantification datatype
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001907
@@ -12291,6 +12880,7 @@ xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000915 ! retention time window attribute
 relationship: has_units UO:0000010 ! second
 relationship: has_units UO:0000031 ! minute
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001908
@@ -12331,6 +12921,7 @@ def: "Potential difference setting of the Thermo Scientific S-lens stacked-ring 
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000482 ! source attribute
 relationship: has_units UO:0000218 ! volt
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001914
@@ -12374,6 +12965,7 @@ name: ProteomeXchange accession number
 def: "Main identifier of a ProteomeXchange dataset." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001921
@@ -12381,6 +12973,7 @@ name: ProteomeXchange accession number version number
 def: "Version number of a ProteomeXchange accession number." [PSI:PI]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
+relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001922
@@ -12390,6 +12983,7 @@ xref: value-type:xsd\:string "The allowed value-type for this CV term."
 synonym: "doi" EXACT []
 is_a: MS:1000878 ! external reference identifier
 relationship: has_regexp MS:1002480 ! (10[.][0-9]\{4,\}(?:[.][0-9]+)*/(?:(?![\"&\'<>])[^ \t\\r\n\\v\\f])+)
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001923
@@ -12397,6 +12991,7 @@ name: external reference keyword
 def: "Free text attribute that can enrich the information about an entity." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002840 ! external reference data
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001924
@@ -12404,6 +12999,7 @@ name: journal article keyword
 def: "Keyword present in a scientific publication." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001923 ! external reference keyword
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001925
@@ -12411,6 +13007,7 @@ name: submitter keyword
 def: "Keyword assigned by the data submitter." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001923 ! external reference keyword
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001926
@@ -12418,6 +13015,7 @@ name: curator keyword
 def: "Keyword assigned by a data curator." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001923 ! external reference keyword
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001927
@@ -12425,6 +13023,7 @@ name: Tranche file hash
 def: "Hash assigned by the Tranche resource to an individual file." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001928
@@ -12432,6 +13031,7 @@ name: Tranche project hash
 def: "Hash assigned by the Tranche resource to a whole project." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001929
@@ -12439,6 +13039,7 @@ name: PRIDE experiment URI
 def: "URI that allows the access to one experiment in the PRIDE database." [PSI:PI]
 xref: value-type:xsd\:anyURI "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
+relationship: has_value_type xsd\:anyURI ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001930
@@ -12446,6 +13047,7 @@ name: PRIDE project URI
 def: "URI that allows the access to one project in the PRIDE database." [PSI:PI]
 xref: value-type:xsd\:anyURI "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
+relationship: has_value_type xsd\:anyURI ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001931
@@ -12459,6 +13061,7 @@ name: source interface model
 def: "The source interface model." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: part_of MS:1001931 ! source interface
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001933
@@ -12466,6 +13069,7 @@ name: source sprayer
 def: "The source sprayer." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: part_of MS:1000458 ! source
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001934
@@ -12479,6 +13083,7 @@ name: source sprayer manufacturer
 def: "The source sprayer manufacturer." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: part_of MS:1001933 ! source sprayer
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001936
@@ -12486,6 +13091,7 @@ name: source sprayer model
 def: "The source sprayer model." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: part_of MS:1001933 ! source sprayer
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001937
@@ -12537,6 +13143,7 @@ xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000510 ! precursor activation attribute
 relationship: has_units UO:0000218 ! volt
 synonym: "CXP" EXACT []
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001945
@@ -12580,6 +13187,7 @@ name: PEAKS:peptideScore
 def: "The PEAKS peptide '-10lgP Score'." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001951
@@ -12587,6 +13195,7 @@ name: PEAKS:proteinScore
 def: "The PEAKS protein '-10lgP Score'." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001952
@@ -12594,6 +13203,7 @@ name: ZCore:probScore
 def: "The ZCore probability score." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001953
@@ -12601,6 +13211,7 @@ name: source interface manufacturer
 def: "The source interface manufacturer." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: part_of MS:1001931 ! source interface
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001954
@@ -12608,6 +13219,7 @@ name: acquisition parameter
 def: "Parameters used in the mass spectrometry acquisition." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: part_of MS:1001458 ! spectrum generation information
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001955
@@ -12651,6 +13263,7 @@ name: peptide spectrum match scoring algorithm
 def: "Algorithm used to score the match between a spectrum and a peptide ion." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: part_of MS:1001458 ! spectrum generation information
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001962
@@ -12658,6 +13271,7 @@ name: Mascot:C13 counts
 def: "C13 peaks to use in peak detection." [PSI:MS]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1002095 ! Mascot input parameter
+relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001963
@@ -12665,6 +13279,7 @@ name: ProteinExtractor:Weighting
 def: "Weighting factor for protein list compilation by ProteinExtractor." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001964
@@ -12672,6 +13287,7 @@ name: ProteinScape:second round Mascot
 def: "Flag indicating a second round search with Mascot." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002100 ! ProteinScape input parameter
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001965
@@ -12679,6 +13295,7 @@ name: ProteinScape:second round Phenyx
 def: "Flag indicating a second round search with Phenyx." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002100 ! ProteinScape input parameter
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001966
@@ -12695,6 +13312,7 @@ is_a: MS:1002222 ! SRM transition attribute
 relationship: has_units UO:0000028 ! millisecond
 comment: This term was made obsolete because it was replaced by ion mobility drift time (MS:1002476).
 is_obsolete: true
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001968
@@ -12709,6 +13327,7 @@ def: "phosphoRS score for PTM site location at the PSM-level." [DOI:10.1021/pr20
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001968 ! PTM localization PSM-level statistic
 relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001970
@@ -12717,6 +13336,7 @@ def: "Probability that the respective isoform is correct." [DOI:10.1021/pr200611
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001968 ! PTM localization PSM-level statistic
 relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001971
@@ -12725,6 +13345,7 @@ def: "Estimate of the probability that the respective site is truly phosphorylat
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001968 ! PTM localization PSM-level statistic
 relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001972
@@ -12732,6 +13353,7 @@ name: PTM scoring algorithm version
 def: "Version of the post-translational modification scoring algorithm." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001471 ! peptide modification details
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001973
@@ -12747,6 +13369,7 @@ xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001968 ! PTM localization PSM-level statistic
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001975
@@ -12758,6 +13381,7 @@ is_a: MS:1001405 ! spectrum identification result details
 relationship: has_units UO:0000166 ! parts per notation unit
 relationship: has_units UO:0000187 ! percent
 relationship: has_units UO:0000221 ! dalton
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001976
@@ -12769,6 +13393,7 @@ is_a: MS:1001405 ! spectrum identification result details
 relationship: has_units UO:0000166 ! parts per notation unit
 relationship: has_units UO:0000187 ! percent
 relationship: has_units UO:0000221 ! dalton
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001977
@@ -12783,6 +13408,7 @@ def: "The PTM score from MSQuant software." [DOI:10.1021/pr900721e, PMID:1988874
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001968 ! PTM localization PSM-level statistic
 relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001979
@@ -12791,6 +13417,7 @@ def: "The PTM score from MaxQuant software." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001968 ! PTM localization PSM-level statistic
 relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001980
@@ -12799,6 +13426,7 @@ def: "The Phospho (STY) Probabilities from MaxQuant software." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001968 ! PTM localization PSM-level statistic
 relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001981
@@ -12806,6 +13434,7 @@ name: MaxQuant:Phospho (STY) Score Diffs
 def: "The Phospho (STY) Score Diffs from MaxQuant software." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001968 ! PTM localization PSM-level statistic
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001982
@@ -12814,6 +13443,7 @@ def: "The P-site localization probability value from MaxQuant software." [PSI:MS
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001968 ! PTM localization PSM-level statistic
 relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001983
@@ -12822,6 +13452,7 @@ def: "The PTM Delta Score value from MaxQuant software (Difference between highe
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001968 ! PTM localization PSM-level statistic
 relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001984
@@ -12836,6 +13467,7 @@ def: "A-score for PTM site location at the PSM-level." [DOI:10.1038/nbt1240, PMI
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001968 ! PTM localization PSM-level statistic
 relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001986
@@ -12844,6 +13476,7 @@ def: "H-Score for peptide phosphorylation site location." [DOI:10.1021/pr1006813
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001968 ! PTM localization PSM-level statistic
 relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001987
@@ -12936,6 +13569,7 @@ name: MS1 label-based raw feature quantitation
 def: "MS1 label-based raw feature quantitation." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002018 ! MS1 label-based analysis
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002002
@@ -12943,6 +13577,7 @@ name: MS1 label-based peptide level quantitation
 def: "MS1 label-based peptide level quantitation." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002018 ! MS1 label-based analysis
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002003
@@ -12950,6 +13585,7 @@ name: MS1 label-based protein level quantitation
 def: "MS1 label-based protein level quantitation." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002018 ! MS1 label-based analysis
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002004
@@ -12957,6 +13593,7 @@ name: MS1 label-based proteingroup level quantitation
 def: "MS1 label-based proteingroup level quantitation." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002018 ! MS1 label-based analysis
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002005
@@ -13011,6 +13648,7 @@ def: "Relative probability that PTM site assignment is correct, derived from the
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001968 ! PTM localization PSM-level statistic
 relationship: has_units UO:0000187 ! percent
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002013
@@ -13019,6 +13657,7 @@ def: "Collision energy at the start of the collision energy ramp." [PSI:PI]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000045 ! collision energy
 relationship: has_units UO:0000266 ! electronvolt
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002014
@@ -13027,6 +13666,7 @@ def: "Collision energy at the end of the collision energy ramp." [PSI:PI]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000045 ! collision energy
 relationship: has_units UO:0000266 ! electronvolt
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002015
@@ -13034,6 +13674,7 @@ name: spectral count peptide level quantitation
 def: "Spectral count peptide level quantitation." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001836 ! spectral counting quantitation analysis
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002016
@@ -13041,6 +13682,7 @@ name: spectral count protein level quantitation
 def: "Spectral count protein level quantitation." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001836 ! spectral counting quantitation analysis
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002017
@@ -13048,6 +13690,7 @@ name: spectral count proteingroup level quantitation
 def: "Spectral count proteingroup level quantitation." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001836 ! spectral counting quantitation analysis
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002018
@@ -13061,6 +13704,7 @@ name: label-free raw feature quantitation
 def: "Label-free raw feature quantitation." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001834 ! LC-MS label-free quantitation analysis
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002020
@@ -13068,6 +13712,7 @@ name: label-free peptide level quantitation
 def: "Label-free peptide level quantitation." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001834 ! LC-MS label-free quantitation analysis
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002021
@@ -13075,6 +13720,7 @@ name: label-free protein level quantitation
 def: "Label-free protein level quantitation." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001834 ! LC-MS label-free quantitation analysis
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002022
@@ -13082,6 +13728,7 @@ name: label-free proteingroup level quantitation
 def: "Label-free proteingroup level quantitation." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001834 ! LC-MS label-free quantitation analysis
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002023
@@ -13095,6 +13742,7 @@ name: MS2 tag-based feature level quantitation
 def: "MS2 tag-based feature level quantitation." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002023 ! MS2 tag-based analysis
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002025
@@ -13102,6 +13750,7 @@ name: MS2 tag-based peptide level quantitation
 def: "MS2 tag-based peptide level quantitation." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002023 ! MS2 tag-based analysis
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002026
@@ -13109,6 +13758,7 @@ name: MS2 tag-based protein level quantitation
 def: "MS2 tag-based protein level quantitation." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002023 ! MS2 tag-based analysis
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002027
@@ -13116,6 +13766,7 @@ name: MS2 tag-based proteingroup level quantitation
 def: "MS2 tag-based proteingroup level quantitation." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002023 ! MS2 tag-based analysis
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002028
@@ -13123,6 +13774,7 @@ name: nucleic acid base modification
 def: "Nucleic acid base modification (substitution, insertion or deletion)." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001471 ! peptide modification details
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002029
@@ -13130,6 +13782,7 @@ name: original nucleic acid sequence
 def: "Specification of the original nucleic acid sequence, prior to a modification. The value slot should hold the DNA or RNA sequence." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001471 ! peptide modification details
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002030
@@ -13137,6 +13790,7 @@ name: modified nucleic acid sequence
 def: "Specification of the modified nucleic acid sequence. The value slot should hold the DNA or RNA sequence." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001471 ! peptide modification details
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002031
@@ -13144,6 +13798,7 @@ name: PASSEL transition group browser URI
 def: "URI to retrieve transition group data for a PASSEL (PeptideAtlas SRM Experiment Library) experiment." [PSI:PI]
 xref: value-type:xsd\:anyURI "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
+relationship: has_value_type xsd\:anyURI ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002032
@@ -13151,6 +13806,7 @@ name: PeptideAtlas dataset URI
 def: "URI that allows access to a PeptideAtlas dataset." [PSI:PI]
 xref: value-type:xsd\:anyURI "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
+relationship: has_value_type xsd\:anyURI ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002033
@@ -13205,6 +13861,7 @@ is_a: MS:1000482 ! source attribute
 is_a: MS:1002039 ! inlet attribute
 relationship: has_units UO:0000012 ! kelvin
 relationship: has_units UO:0000027 ! degree Celsius
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002041
@@ -13214,6 +13871,7 @@ xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000482 ! source attribute
 relationship: has_units UO:0000012 ! kelvin
 relationship: has_units UO:0000027 ! degree Celsius
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002042
@@ -13223,6 +13881,7 @@ xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000857 ! run attribute
 relationship: has_units UO:0000010 ! second
 relationship: has_units UO:0000031 ! minute
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002043
@@ -13236,6 +13895,7 @@ name: ProteinProspector:score
 def: "The ProteinProspector result 'Score'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002045
@@ -13243,6 +13903,7 @@ name: ProteinProspector:expectation value
 def: "The ProteinProspector result 'Expectation value'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002046
@@ -13250,6 +13911,7 @@ name: native source path
 def: "The original source path used for directory-based sources." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001458 ! spectrum generation information
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002047
@@ -13270,6 +13932,7 @@ name: MS-GF:RawScore
 def: "MS-GF raw score." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002050
@@ -13277,6 +13940,7 @@ name: MS-GF:DeNovoScore
 def: "MS-GF de novo score." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002051
@@ -13284,6 +13948,7 @@ name: MS-GF:Energy
 def: "MS-GF energy score." [PSI:PI]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002052
@@ -13293,6 +13958,7 @@ xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002353 ! PSM-level e-value
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002109 ! lower score better
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002053
@@ -13302,6 +13968,7 @@ xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002353 ! PSM-level e-value
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002109 ! lower score better
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002054
@@ -13310,6 +13977,7 @@ def: "MS-GF Q-value." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002354 ! PSM-level q-value
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002055
@@ -13317,6 +13985,7 @@ name: MS-GF:PepQValue
 def: "MS-GF peptide-level Q-value." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002056
@@ -13324,6 +13993,7 @@ name: MS-GF:PEP
 def: "MS-GF posterior error probability." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002057
@@ -13374,6 +14044,7 @@ name: peptide consensus RT
 def: "Peptide consensus retention time." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002737 ! peptide-level quantification datatype
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002065
@@ -13381,6 +14052,7 @@ name: peptide consensus m/z
 def: "Peptide consensus mass/charge ratio." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002737 ! peptide-level quantification datatype
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002066
@@ -13388,6 +14060,7 @@ name: ratio calculation method
 def: "Method used to calculate the ratio." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002067
@@ -13395,6 +14068,7 @@ name: protein value: median of peptide ratios
 def: "Protein quantification value calculated as median of peptide ratios." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002738 ! protein-level quantification datatype
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002068
@@ -13408,6 +14082,7 @@ name: metabolic labelling purity
 def: "Metabolic labelling: Description of labelling purity. Usually the purity of feeding material (e.g. 95%), or the inclusion rate derived from isotopic peak pattern shape." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001055 ! modification parameters
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002070
@@ -13415,6 +14090,7 @@ name: t-test
 def: "Perform a t-test (two groups). Specify in string value, whether paired / unpaired, variance equal / different, one- / two-sided version is performed." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001861 ! quantification data processing
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002071
@@ -13422,6 +14098,7 @@ name: ANOVA-test
 def: "Perform an ANOVA-test (more than two groups). Specify in string value, which version is performed." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001861 ! quantification data processing
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002072
@@ -13430,6 +14107,7 @@ def: "P-value as result of one of the processing steps described. Specify in the
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002073
@@ -13469,6 +14147,7 @@ comment: This term was made obsolete because it's recommended to use ProteomeDis
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002079
@@ -13478,6 +14157,7 @@ comment: This term was made obsolete because it's recommended to use ProteomeDis
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002080
@@ -13486,6 +14166,7 @@ def: "Precursor clipping range before." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_units UO:0000221 ! dalton
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002081
@@ -13494,6 +14175,7 @@ def: "Precursor clipping range after." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_units UO:0000221 ! dalton
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002082
@@ -13503,6 +14185,7 @@ xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000503 ! scan attribute
 relationship: has_units UO:0000010 ! second
 relationship: has_units UO:0000031 ! minute
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002083
@@ -13512,6 +14195,7 @@ xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000503 ! scan attribute
 relationship: has_units UO:0000010 ! second
 relationship: has_units UO:0000031 ! minute
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002084
@@ -13549,6 +14233,7 @@ name: ProteomeDiscoverer:Peptide Without Protein XCorr Threshold
 def: "XCorr threshold for storing peptides that do not belong to a protein." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002090
@@ -13556,6 +14241,7 @@ name: Calculate Probability Scores
 def: "Flag indicating that a probability score for the assessment that a reported peptide match is a random occurrence is calculated." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002094 ! common search engine input parameter
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002091
@@ -13563,6 +14249,7 @@ name: ProteomeDiscoverer:Maximum Delta Cn
 def: "Delta Cn threshold for filtering out PSM's." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002092
@@ -13570,6 +14257,7 @@ name: Percolator:Validation based on
 def: "Algorithm (e.g. q-value or PEP) used for calculation of the validation score using Percolator." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002107 ! Percolator input parameter
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002093
@@ -13766,6 +14454,7 @@ xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1001153 ! search engine specific score
 is_obsolete: true
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002126
@@ -13936,6 +14625,7 @@ name: protein level PSM counts
 def: "The number of spectra identified for this protein in spectral counting." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002738 ! protein-level quantification datatype
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002154
@@ -14298,6 +14988,7 @@ name: PAnalyzer:conclusive protein
 def: "A protein identified by at least one unique (distinct, discrete) peptide (peptides are considered different only if they can be distinguished by evidence in mass spectrum)." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001600 ! protein inference confidence category
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002214
@@ -14305,6 +14996,7 @@ name: PAnalyzer:indistinguishable protein
 def: "A member of a group of proteins sharing all peptides that are exclusive to the group (peptides are considered different only if they can be distinguished by evidence in mass spectrum)." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001600 ! protein inference confidence category
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002215
@@ -14312,6 +15004,7 @@ name: PAnalyzer:non-conclusive protein
 def: "A protein sharing all its matched peptides with either conclusive or indistinguishable proteins (peptides are considered different only if they can be distinguished by evidence in mass spectrum)." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001600 ! protein inference confidence category
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002216
@@ -14319,6 +15012,7 @@ name: PAnalyzer:ambiguous group member
 def: "A protein sharing at least one peptide not matched to either conclusive or indistinguishable proteins (peptides are considered different only if they can be distinguished by evidence in mass spectrum)." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001600 ! protein inference confidence category
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002217
@@ -14326,6 +15020,7 @@ name: decoy peptide
 def: "A putative identified peptide issued from a decoy sequence database." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001105 ! peptide sequence-level identification attribute
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002218
@@ -14334,6 +15029,7 @@ def: "Collision energy at the start of the collision energy ramp in percent, nor
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000138 ! normalized collision energy
 relationship: has_units UO:0000187 ! percent
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002219
@@ -14342,6 +15038,7 @@ def: "Collision energy at the end of the collision energy ramp in percent, norma
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000138 ! normalized collision energy
 relationship: has_units UO:0000187 ! percent
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002220
@@ -14369,6 +15066,7 @@ name: precursor ion detection probability
 def: "Probability of detecting precursor when parent protein is present." [PSI:PI]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002222 ! SRM transition attribute
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002224
@@ -14376,6 +15074,7 @@ name: product ion detection probability
 def: "Probability of detecting product ion when precursor ion is present." [PSI:PI]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002222 ! SRM transition attribute
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002225
@@ -14403,6 +15102,7 @@ name: number of product ion observations
 def: "The number of times the specific product ion has been observed in a series of SRM experiments." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002222 ! SRM transition attribute
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002228
@@ -14410,6 +15110,7 @@ name: number of precursor ion observations
 def: "The number of times the specific precursor ion has been observed in a series of SRM experiments." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002222 ! SRM transition attribute
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002229
@@ -14417,6 +15118,7 @@ name: ProteomeDiscoverer:Mascot:Significance Middle
 def: "Calculated relaxed significance when performing a decoy search for high-confidence peptides." [PSI:PI]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002230
@@ -14424,6 +15126,7 @@ name: ProteomeDiscoverer:Mascot:Significance High
 def: "Calculated relaxed significance when performing a decoy search for medium-confidence peptides." [PSI:PI]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002231
@@ -14444,6 +15147,7 @@ name: ProteomeDiscoverer:SEQUEST:Low resolution spectra contained
 def: "Flag indicating if low-resolution spectra are taken into consideration." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002234
@@ -14453,6 +15157,7 @@ synonym: "selected ion m/z" RELATED []
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000455 ! ion selection attribute
 relationship: has_units MS:1000040 ! m/z
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002235
@@ -14460,6 +15165,7 @@ name: ProteoGrouper:PDH score
 def: "A score assigned to a single protein accession (modelled as ProteinDetectionHypothesis in mzIdentML), based on summed peptide level scores." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002236
@@ -14467,6 +15173,7 @@ name: ProteoGrouper:PAG score
 def: "A score assigned to a protein group (modelled as ProteinAmbiguityGroup in mzIdentML), based on all summed peptide level scores that have been assigned to the group as unique or razor peptides." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002368 ! search engine specific score for protein groups
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002237
@@ -14540,6 +15247,7 @@ name: SEQUEST:spscore
 def: "The SEQUEST result 'SpScore'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002249
@@ -14547,6 +15255,7 @@ name: SEQUEST:sprank
 def: "The SEQUEST result 'SpRank'." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002250
@@ -14554,6 +15263,7 @@ name: SEQUEST:deltacnstar
 def: "The SEQUEST result 'DeltaCnStar'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002251
@@ -14568,6 +15278,7 @@ def: "The Comet result 'XCorr'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002108 ! higher score better
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002253
@@ -14575,6 +15286,7 @@ name: Comet:deltacn
 def: "The Comet result 'DeltaCn'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002254
@@ -14582,6 +15294,7 @@ name: Comet:deltacnstar
 def: "The Comet result 'DeltaCnStar'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002255
@@ -14589,6 +15302,7 @@ name: Comet:spscore
 def: "The Comet result 'SpScore'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002256
@@ -14596,6 +15310,7 @@ name: Comet:sprank
 def: "The Comet result 'SpRank'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002257
@@ -14603,6 +15318,7 @@ name: Comet:expectation value
 def: "The Comet result 'Expectation value'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001153 ! search engine specific score
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002258
@@ -14610,6 +15326,7 @@ name: Comet:matched ions
 def: "The Comet result 'Matched Ions'." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002259
@@ -14617,6 +15334,7 @@ name: Comet:total ions
 def: "The Comet result 'Total Ions'." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002260
@@ -14624,6 +15342,7 @@ name: PSM:FDR threshold
 def: "False-discovery rate threshold for peptide-spectrum matches." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002483 ! PSM-level statistical threshold
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002261
@@ -14638,6 +15357,7 @@ def: "The Byonic score is the primary indicator of PSM correctness. The Byonic s
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002108 ! higher score better
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002263
@@ -14646,6 +15366,7 @@ def: "The drop in Byonic score from the top-scoring peptide to the next peptide 
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002108 ! higher score better
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002264
@@ -14654,6 +15375,7 @@ def: "The drop in Byonic score from the top-scoring peptide to the next peptide 
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002108 ! higher score better
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002265
@@ -14662,6 +15384,7 @@ def: "Byonic posterior error probability." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002109 ! lower score better
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002266
@@ -14670,6 +15393,7 @@ def: "The log p-value of the PSM. This is the log of the probability that the PS
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002109 ! lower score better
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002267
@@ -14679,6 +15403,7 @@ xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
 is_a: MS:1002363 ! search engine specific score for proteins
 relationship: has_order MS:1002109 ! lower score better
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002268
@@ -14688,6 +15413,7 @@ xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001116 ! single protein identification statistic
 is_a: MS:1001153 ! search engine specific score
 relationship: has_order MS:1002109 ! lower score better
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002269
@@ -14696,6 +15422,7 @@ def: "Best (largest) Byonic score of a PSM." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
 relationship: has_order MS:1002108 ! higher score better
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002270
@@ -14722,6 +15449,7 @@ def: "Detector potential difference in volts." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000481 ! detector attribute
 relationship: has_units UO:0000218 ! volt
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002274
@@ -14906,6 +15634,7 @@ name: Bruker Container nativeID format
 def: "Native identifier (UUID)." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000767 ! native spectrum identifier format
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002304
@@ -14944,6 +15673,7 @@ def: "The absolute value of the log-base10 of the Byonic posterior error probabi
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002108 ! higher score better
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002310
@@ -14952,6 +15682,7 @@ def: "The absolute value of the log-base10 of the Byonic posterior error probabi
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
 relationship: has_order MS:1002108 ! higher score better
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002311
@@ -14960,6 +15691,7 @@ def: "The absolute value of the log-base10 Byonic two-dimensional posterior erro
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002108 ! higher score better
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002312
@@ -14991,6 +15723,7 @@ name: ProteomeDiscoverer:Amanda:high confidence threshold
 def: "Strict confidence probability score." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002317
@@ -14998,6 +15731,7 @@ name: ProteomeDiscoverer:Amanda:middle confidence threshold
 def: "Relaxed confidence probability score." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002318
@@ -15005,6 +15739,7 @@ name: ProteomeDiscoverer:automatic workload
 def: "Flag indicating automatic estimation of the workload level." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002319
@@ -15012,6 +15747,7 @@ name: Amanda:AmandaScore
 def: "The Amanda score of the scoring function for a PSM." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002320
@@ -15019,6 +15755,7 @@ name: ProteomeDiscoverer:max differential modifications
 def: "Maximum dynamic modifications per PSM." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002321
@@ -15026,6 +15763,7 @@ name: ProteomeDiscoverer:max equal modifications
 def: "Maximum equal modifications per PSM." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002322
@@ -15033,6 +15771,7 @@ name: ProteomeDiscoverer:min peptide length
 def: "Minimum peptide length." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002323
@@ -15040,6 +15779,7 @@ name: ProteomeDiscoverer:max peptide length
 def: "Maximum peptide length." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002324
@@ -15047,6 +15787,7 @@ name: ProteomeDiscoverer:max number neutral loss
 def: "Maximum number of same neutral losses." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002325
@@ -15054,6 +15795,7 @@ name: ProteomeDiscoverer:max number neutral loss modifications
 def: "Max number of same neutral losses of modifications." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002326
@@ -15061,6 +15803,7 @@ name: ProteomeDiscoverer:use flanking ions
 def: "Flag for usage of flanking ions." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002327
@@ -15068,6 +15811,7 @@ name: ProteomeDiscoverer:max number of same modifs
 def: "The maximum number of possible equal modifications per PSM." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002328
@@ -15075,6 +15819,7 @@ name: ProteomeDiscoverer:perform deisotoping
 def: "Defines whether a simple deisotoping shall be performed." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002329
@@ -15082,6 +15827,7 @@ name: ProteomeDiscoverer:ion settings
 def: "Specifies the fragment ions and neutral losses that are calculated." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002330
@@ -15091,6 +15837,7 @@ comment: This term was made obsolete because it's recommended to use ProteomeDis
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002331
@@ -15100,6 +15847,7 @@ comment: This term was made obsolete because it's recommended to use ProteomeDis
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002332
@@ -15144,6 +15892,7 @@ def: "The probability based score of the Andromeda search engine." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002108 ! higher score better
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002339
@@ -15151,6 +15900,7 @@ name: site:global FDR
 def: "Estimation of global false discovery rate of peptides with a post-translational modification." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001405 ! spectrum identification result details
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002340
@@ -15158,6 +15908,7 @@ name: ProteomeXchange project tag
 def: "Tag that can be added to a ProteomeXchange dataset, to enable the grouping of datasets. One tag can be used for indicating that a given dataset is part of a bigger project, like e.g. the Human Proteome Project." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002341
@@ -15165,6 +15916,7 @@ name: second-pass peptide identification
 def: "A putative identified peptide found in a second-pass search of protein sequences selected from a first-pass search." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001105 ! peptide sequence-level identification attribute
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002342
@@ -15224,6 +15976,7 @@ def: "Estimation of the global false discovery rate of peptide spectrum matches.
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002701 ! PSM-level result list statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002351
@@ -15232,6 +15985,7 @@ def: "Estimation of the local false discovery rate of peptide spectrum matches."
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002347 ! PSM-level identification statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002352
@@ -15240,6 +15994,7 @@ def: "Estimation of the p-value for peptide spectrum matches." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002347 ! PSM-level identification statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002353
@@ -15248,6 +16003,7 @@ def: "Estimation of the e-value for peptide spectrum matches." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002347 ! PSM-level identification statistic
 relationship: has_domain MS:1002306 ! value greater than zero
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002354
@@ -15256,6 +16012,7 @@ def: "Estimation of the q-value for peptide spectrum matches." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002347 ! PSM-level identification statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002355
@@ -15265,6 +16022,7 @@ xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1002363 ! search engine specific score for proteins
 relationship: has_domain MS:1002349 ! value greater than zero but less than or equal to 1
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002356
@@ -15274,6 +16032,7 @@ xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1002363 ! search engine specific score for proteins
 relationship: has_domain MS:1002349 ! value greater than zero but less than or equal to 1
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002357
@@ -15282,6 +16041,7 @@ def: "Probability that the reported peptide ion is truly responsible for some or
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002347 ! PSM-level identification statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002358
@@ -15296,6 +16056,7 @@ def: "Estimation of the local false discovery rate for distinct peptides once re
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001092 ! peptide sequence-level identification statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002360
@@ -15305,6 +16066,7 @@ xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002358 ! search engine specific peptide sequence-level identification statistic
 is_a: MS:1002363 ! search engine specific score for proteins
 relationship: has_domain MS:1002349 ! value greater than zero but less than or equal to one
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002361
@@ -15314,6 +16076,7 @@ xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002358 ! search engine specific peptide sequence-level identification statistic
 is_a: MS:1002363 ! search engine specific score for proteins
 relationship: has_domain MS:1002349 ! value greater than zero but less than or equal to one
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002362
@@ -15322,6 +16085,7 @@ def: "Probability that the reported distinct peptide sequence (irrespective of m
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001092 ! peptide sequence-level identification statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002363
@@ -15335,6 +16099,7 @@ name: protein-level local FDR
 def: "Estimation of the local false discovery rate of proteins." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001116 ! single protein identification statistic
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002365
@@ -15343,6 +16108,7 @@ def: "MzidLibrary FDRScore for proteins specifically obtained for distinct combi
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
 relationship: has_domain MS:1002349 ! value greater than zero but less than or equal to one
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002366
@@ -15351,6 +16117,7 @@ def: "MzidLibrary Combined FDRScore for proteins." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
 relationship: has_domain MS:1002349 ! value greater than zero but less than or equal to one
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002367
@@ -15359,6 +16126,7 @@ def: "Probability that a specific protein sequence has been correctly identified
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001116 ! single protein identification statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002368
@@ -15372,6 +16140,7 @@ name: protein group-level global FDR
 def: "Estimation of the global false discovery rate of protein groups." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002706 ! protein group-level result list statistic
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002370
@@ -15379,6 +16148,7 @@ name: protein group-level local FDR
 def: "Estimation of the local false discovery rate of protein groups." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002348 ! protein group-level identification statistic
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002371
@@ -15387,6 +16157,7 @@ def: "Estimation of the p-value for protein groups." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002348 ! protein group-level identification statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002372
@@ -15395,6 +16166,7 @@ def: "Estimation of the e-value for protein groups." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002348 ! protein group-level identification statistic
 relationship: has_domain MS:1002306 ! value greater than zero
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002373
@@ -15403,6 +16175,7 @@ def: "Estimation of the q-value for protein groups." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002348 ! protein group-level identification statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002374
@@ -15411,6 +16184,7 @@ def: "mzidLibrary FDRScore for protein groups." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002368 ! search engine specific score for protein groups
 relationship: has_domain MS:1002349 ! value greater than zero but less than or equal to one
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002375
@@ -15419,6 +16193,7 @@ def: "mzidLibrary Combined FDRScore for proteins specifically obtained for disti
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002368 ! search engine specific score for protein groups
 relationship: has_domain MS:1002349 ! value greater than zero but less than or equal to one
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002376
@@ -15427,6 +16202,7 @@ def: "Probability that at least one of the members of a group of protein sequenc
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002348 ! protein group-level identification statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002377
@@ -15434,6 +16210,7 @@ name: ProteomeDiscoverer:Relaxed Score Threshold
 def: "Specifies the threshold value for relaxed scoring." [PSI:PI]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002378
@@ -15441,6 +16218,7 @@ name: ProteomeDiscoverer:Strict Score Threshold
 def: "Specifies the threshold value for strict scoring." [PSI:PI]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002379
@@ -15448,6 +16226,7 @@ name: ProteomeDiscoverer:Peptide Without Protein Cut Off Score
 def: "Cut off score for storing peptides that do not belong to a protein." [PSI:PI]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002380
@@ -15455,6 +16234,7 @@ name: false localization rate
 def: "Estimation of the false localization rate for modification site assignment." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001405 ! spectrum identification result details
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002381
@@ -15523,6 +16303,7 @@ name: PIA:FDRScore calculated
 def: "Indicates whether the FDR score was calculated for the input file." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002389 ! PIA workflow parameter
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002391
@@ -15530,6 +16311,7 @@ name: PIA:Combined FDRScore calculated
 def: "Indicates whether the combined FDR score was calculated for the PIA compilation." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002389 ! PIA workflow parameter
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002392
@@ -15537,6 +16319,7 @@ name: PIA:PSM sets created
 def: "Indicates whether PSM sets were created." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002389 ! PIA workflow parameter
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002393
@@ -15544,6 +16327,7 @@ name: PIA:used top identifications for FDR
 def: "The number of top identifications per spectrum used for the FDR calculation, 0 means all." [PSI:PI]
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1002389 ! PIA workflow parameter
+relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002394
@@ -15552,6 +16336,7 @@ def: "The score given to a protein by any protein inference." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
 relationship: has_order MS:1002108 ! higher score better
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002395
@@ -15559,6 +16344,7 @@ name: PIA:protein inference
 def: "The used algorithm for the protein inference using PIA." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002389 ! PIA workflow parameter
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002396
@@ -15566,6 +16352,7 @@ name: PIA:protein inference filter
 def: "A filter used by PIA for the protein inference." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002389 ! PIA workflow parameter
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002397
@@ -15573,6 +16360,7 @@ name: PIA:protein inference scoring
 def: "The used scoring method for the protein inference using PIA." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002389 ! PIA workflow parameter
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002398
@@ -15580,6 +16368,7 @@ name: PIA:protein inference used score
 def: "The used base score for the protein inference using PIA." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002389 ! PIA workflow parameter
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002399
@@ -15587,6 +16376,7 @@ name: PIA:protein inference used PSMs
 def: "The method to determine the PSMs used for scoring by the protein inference." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002389 ! PIA workflow parameter
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002400
@@ -15594,6 +16384,7 @@ name: PIA:filter
 def: "A filter used for the report generation." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002389 ! PIA workflow parameter
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002401
@@ -15619,6 +16410,7 @@ name: count of identified proteins
 def: "The number of proteins that have been identified, which must match the number of groups that pass the threshold in the file." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002704 ! protein-level result list attribute
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002405
@@ -15632,6 +16424,7 @@ name: count of identified clusters
 def: "The number of protein clusters that have been identified, which must match the number of clusters that pass the threshold in the file." [DOI:10.1002/pmic.201400080, PMID:25092112]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002405 ! protein group-level result list attribute
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002407
@@ -15639,6 +16432,7 @@ name: cluster identifier
 def: "An identifier applied to protein groups to indicate that they are linked by shared peptides." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002698 ! protein cluster identification attribute
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002408
@@ -15646,6 +16440,7 @@ name: number of distinct protein sequences
 def: "The number of protein clusters that have been identified, which must match the number of clusters that pass the threshold in the file." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002405 ! protein group-level result list attribute
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002409
@@ -15672,6 +16467,7 @@ name: total XIC area
 def: "Summed area of all the extracted ion chromatogram for the peptide (e.g. of all the transitions in SRM)." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002737 ! peptide-level quantification datatype
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002413
@@ -15679,6 +16475,7 @@ name: product background
 def: "The background area for the quantified transition." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002414
@@ -15692,6 +16489,7 @@ name: protein group passes threshold
 def: "A Boolean attribute to determine whether the protein group has passed the threshold indicated in the file." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002346 ! protein group-level identification attribute
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002416
@@ -15723,6 +16521,7 @@ name: PASSEL experiment URI
 def: "URI that allows access to a PASSEL experiment." [PSI:PI]
 xref: value-type:xsd\:anyURI "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
+relationship: has_value_type xsd\:anyURI ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002421
@@ -15736,6 +16535,7 @@ name: Paragon: sample type
 def: "The Paragon method setting indicating the type of sample at the high level, generally meaning the type of quantitation labelling or lack thereof. 'Identification' is indicated for samples without any labels for quantitation." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002421 ! Paragon input parameter
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002423
@@ -15743,6 +16543,7 @@ name: Paragon: cysteine alkylation
 def: "The Paragon method setting indicating the actual cysteine alkylation agent; 'None' is indicated if there was no cysteine alkylation." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002421 ! Paragon input parameter
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002424
@@ -15750,6 +16551,7 @@ name: Paragon: instrument setting
 def: "The Paragon method setting (translating to a large number of lower level settings) indicating the instrument used or a category of instrument." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002421 ! Paragon input parameter
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002425
@@ -15757,6 +16559,7 @@ name: Paragon: search effort
 def: "The Paragon method setting that controls the two major modes of search effort of the Paragon algorithm: the Rapid mode uses a conventional database search, while the Thorough mode uses a hybrid search, starting with the same approach as the Rapid mode but then follows it with a separate tag-based approach enabling a more extensive search." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002421 ! Paragon input parameter
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002426
@@ -15764,6 +16567,7 @@ name: Paragon: ID focus
 def: "A Paragon method setting that allows the inclusion of large sets of features such as biological modification or substitutions." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002421 ! Paragon input parameter
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002427
@@ -15771,6 +16575,7 @@ name: Paragon: FDR analysis
 def: "The Paragon method setting that controls whether FDR analysis is conducted." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002421 ! Paragon input parameter
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002428
@@ -15778,6 +16583,7 @@ name: Paragon: quantitation
 def: "The Paragon method setting that controls whether quantitation analysis is conducted." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002421 ! Paragon input parameter
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002429
@@ -15785,6 +16591,7 @@ name: Paragon: background correction
 def: "The Paragon method setting that controls whether the 'Background Correction' analysis is conducted; this processing estimates a correction to the attenuation in extremity ratios that can occur in isobaric quantatitation workflows on complex samples." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002421 ! Paragon input parameter
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002430
@@ -15792,6 +16599,7 @@ name: Paragon: bias correction
 def: "The Paragon method setting that controls whether 'Bias Correction' is invoked in quantitation analysis; this correction is a normalization to set the central tendency of protein ratios to unity." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002421 ! Paragon input parameter
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002431
@@ -15799,6 +16607,7 @@ name: Paragon: channel to use as denominator in ratios
 def: "The Paragon method setting that controls which label channel is used as the denominator in calculating relative expression ratios." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002421 ! Paragon input parameter
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002432
@@ -15812,6 +16621,7 @@ name: Paragon: modified data dictionary or parameter translation
 def: "This metric detects if any changes have been made to the originally installed key control files for the software; if no changes have been made, then the software version and settings are sufficient to enable exact reproduction; if changes have been made, then the modified ParameterTranslation- and ProteinPilot DataDictionary-XML files much also be provided in order to exactly reproduce a result." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002432 ! search engine specific input metadata
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002434
@@ -15819,6 +16629,7 @@ name: number of spectra searched
 def: "Number of spectra in a search." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1001249 ! search input details
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002435
@@ -15826,6 +16637,7 @@ name: data processing start time
 def: "The time that a data processing action was started." [PSI:MS]
 xref: value-type:xsd\:dateTime "The allowed value-type for this CV term."
 is_a: MS:1000630 ! data processing parameter
+relationship: has_value_type xsd\:dateTime ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002436
@@ -15833,6 +16645,7 @@ name: Paragon: digestion
 def: "The Paragon method setting indicating the actual digestion agent - unlike other search tools, this setting does not include options that control partial specificity like 'semitrypsin'; if trypsin is used, trypsin is set, and partially conforming peptides are found in the Thorough mode of search; 'None' should be indicated only if there was really no digestion done." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001249 ! search input details
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002437
@@ -15840,6 +16653,7 @@ name: number of decoy sequences
 def: "The number of decoy sequences, if the concatenated target-decoy approach is used." [PSI:PI]
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1001011 ! search database details
+relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002438
@@ -15901,6 +16715,7 @@ name: Paragon:special factor
 def: "The Paragon method setting indicating a list of one or more 'special factors', which generally capture secondary effects (relative to other settings) as a set of probabilities of modification features that override the assumed levels. For example the 'gel-based ID' special factor causes an increase probability of oxidation on several resides because of the air exposure impact on a gel, in addition to other effects." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002421 ! Paragon input parameter
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002448
@@ -15908,6 +16723,7 @@ name: PEAKS:inChorusPeptideScore
 def: "The PEAKS inChorus peptide score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002449
@@ -15915,6 +16731,7 @@ name: PEAKS:inChorusProteinScore
 def: "The PEAKS inChorus protein score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002450
@@ -16032,6 +16849,7 @@ def: "The probability based PeptideShaker PSM score." [PSI:PI]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002108 ! higher score better
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002467
@@ -16040,6 +16858,7 @@ def: "The probability based PeptideShaker PSM confidence." [PSI:PI]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002108 ! higher score better
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002468
@@ -16049,6 +16868,7 @@ xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002358 ! search engine specific peptide sequence-level identification statistic
 is_a: MS:1002363 ! search engine specific score for proteins
 relationship: has_order MS:1002108 ! higher score better
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002469
@@ -16057,6 +16877,7 @@ def: "The probability based PeptideShaker peptide confidence." [PSI:PI]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
 relationship: has_order MS:1002108 ! higher score better
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002470
@@ -16066,6 +16887,7 @@ xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
 is_a: MS:1002368 ! search engine specific score for protein groups
 relationship: has_order MS:1002108 ! higher score better
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002471
@@ -16074,6 +16896,7 @@ def: "The probability based PeptideShaker protein group confidence." [PSI:PI]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
 relationship: has_order MS:1002108 ! higher score better
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002472
@@ -16094,6 +16917,7 @@ def: "The sum of peptide-level scores for peptides mapped only to non-canonical 
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002368 ! search engine specific score for protein groups
 relationship: has_order MS:1002108 ! higher score better
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002475
@@ -16101,6 +16925,7 @@ name: ProteoAnnotator:count alternative peptides
 def: "The count of the number of peptide sequences mapped to non-canonical gene models only within the group." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002368 ! search engine specific score for protein groups
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002476
@@ -16110,6 +16935,7 @@ xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000455 ! ion selection attribute
 is_a: MS:1002892 ! ion mobility attribute
 relationship: has_units UO:0000028 ! millisecond
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002477
@@ -16119,6 +16945,7 @@ xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002893 ! ion mobility array
 relationship: has_units UO:0000028 ! millisecond
 relationship: has_units UO:0000010 ! second
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002478
@@ -16181,6 +17008,7 @@ name: MassIVE dataset identifier
 def: "Dataset identifier issued by the MassIVE repository. A dataset can refer to either a single sample as part of a study, or all samples that are part of the study corresponding to a publication." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002488
@@ -16188,6 +17016,7 @@ name: MassIVE dataset URI
 def: "URI that allows the access to one dataset in the MassIVE repository. A dataset can refer to either a single sample as part of a study, or all samples that are part of the study corresponding to a publication." [PSI:PI]
 xref: value-type:xsd\:anyURI "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
+relationship: has_value_type xsd\:anyURI ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002489
@@ -16264,6 +17093,7 @@ name: peptide passes threshold
 def: "A Boolean attribute to determine whether the peptide has passed the threshold indicated in the file." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001105 ! peptide sequence-level identification attribute
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002501
@@ -16289,6 +17119,7 @@ name: modification index
 def: "The order of modifications to be referenced elsewhere in the document." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1001055 ! modification parameters
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002505
@@ -16309,6 +17140,7 @@ def: "Mod position score: false localization rate." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002506 ! modification position score
 relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002508
@@ -16322,6 +17154,7 @@ name: cross-link donor
 def: "The Cross-linking donor, assigned according to the following rules: the export software SHOULD use the following rules to choose the cross-link donor as the: longer peptide, then higher peptide neutral mass, then alphabetical order." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002508 ! cross-linking attribute
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002510
@@ -16329,6 +17162,7 @@ name: cross-link acceptor
 def: "Cross-linking acceptor, assigned according to the following rules: the export software SHOULD use the following rules to choose the cross-link donor as the: longer peptide, then higher peptide neutral mass, then alphabetical order." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002508 ! cross-linking attribute
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002511
@@ -16336,6 +17170,7 @@ name: cross-link spectrum identification item
 def: "Cross-linked spectrum identification item." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002508 ! cross-linking attribute
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002512
@@ -16343,6 +17178,7 @@ name: cross-linking score
 def: "Cross-linking scoring value." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002513
@@ -16350,6 +17186,7 @@ name: molecules per cell
 def: "The absolute abundance of protein in a cell." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002514
@@ -16363,6 +17200,7 @@ name: internal peptide reference used
 def: "States whether an internal peptide reference is used or not in absolute quantitation analysis." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001832 ! quantitation software comment or customizations
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002516
@@ -16370,6 +17208,7 @@ name: internal protein reference used
 def: "States whether an internal protein reference is used or not in absolute quantitation analysis." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001832 ! quantitation software comment or customizations
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002517
@@ -16377,6 +17216,7 @@ name: internal reference abundance
 def: "The absolute abundance of the spiked in reference peptide or protein used for absolute quantitation analysis." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002518
@@ -16384,6 +17224,7 @@ name: Progenesis:protein group normalised abundance
 def: "The data type normalised abundance for protein groups produced by Progenesis LC-MS." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002739 ! protein group-level quantification datatype
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002519
@@ -16391,6 +17232,7 @@ name: Progenesis:protein group raw abundance
 def: "The data type raw abundance for protein groups produced by Progenesis LC-MS." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002739 ! protein group-level quantification datatype
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002520
@@ -16398,6 +17240,7 @@ name: peptide group ID
 def: "Peptide group identifier for peptide-level stats." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001105 ! peptide sequence-level identification attribute
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002521
@@ -16411,6 +17254,7 @@ name: ProteomeDiscoverer:1. Static Terminal Modification
 def: "Determine 1st static terminal post-translational modifications (PTMs)." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002523
@@ -16490,6 +17334,7 @@ def: "The ProLuCID result 'XCorr'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002108 ! higher score better
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002535
@@ -16497,6 +17342,7 @@ name: ProLuCID:deltacn
 def: "The ProLuCID result 'DeltaCn'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002536
@@ -16505,6 +17351,7 @@ def: "D-Score for PTM site location at the PSM-level." [PMID:23307401]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001968 ! PTM localization PSM-level statistic
 relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002537
@@ -16513,6 +17360,7 @@ def: "MD-Score for PTM site location at the PSM-level." [PMID:21057138]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001968 ! PTM localization PSM-level statistic
 relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002538
@@ -16520,6 +17368,7 @@ name: PTM localization confidence metric
 def: "Localization confidence metric for a post translational modification (PTM)." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001405 ! spectrum identification result details
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002539
@@ -16527,6 +17376,7 @@ name: PeptideShaker PTM confidence type
 def: "PeptideShaker quality criteria for the confidence of PTM localizations." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002538 ! PTM localization confidence metric
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002540
@@ -16534,6 +17384,7 @@ name: PeptideShaker PSM confidence type
 def: "PeptideShaker quality criteria for the confidence of PSM's." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002347 ! PSM-level identification statistic
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002541
@@ -16541,6 +17392,7 @@ name: PeptideShaker peptide confidence type
 def: "PeptideShaker quality criteria for the confidence of peptide identifications." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002358 ! search engine specific peptide sequence-level identification statistic
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002542
@@ -16548,6 +17400,7 @@ name: PeptideShaker protein confidence type
 def: "PeptideShaker quality criteria for the confidence of protein identifications." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001116 ! single protein identification statistic
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002543
@@ -16568,6 +17421,7 @@ def: "The xi result 'Score'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002108 ! higher score better
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002546
@@ -16601,6 +17455,7 @@ def: "phosphoRS score for PTM site location at the peptide-level." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002549 ! PTM localization distinct peptide-level statistic
 relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002551
@@ -16609,6 +17464,7 @@ def: "A-score for PTM site location at the peptide-level." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002549 ! PTM localization distinct peptide-level statistic
 relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002552
@@ -16617,6 +17473,7 @@ def: "H-Score for peptide phosphorylation site location at the peptide-level." [
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002549 ! PTM localization distinct peptide-level statistic
 relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002553
@@ -16625,6 +17482,7 @@ def: "D-Score for PTM site location at the peptide-level." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002549 ! PTM localization distinct peptide-level statistic
 relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002554
@@ -16633,6 +17491,7 @@ def: "MD-Score for PTM site location at the peptide-level." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002549 ! PTM localization distinct peptide-level statistic
 relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002555
@@ -16646,6 +17505,7 @@ name: Ascore threshold
 def: "Threshold for Ascore PTM site location score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002555 ! PTM localization score threshold
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002557
@@ -16653,6 +17513,7 @@ name: D-Score threshold
 def: "Threshold for D-score PTM site location score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002555 ! PTM localization score threshold
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002558
@@ -16660,6 +17521,7 @@ name: MD-Score threshold
 def: "Threshold for MD-score PTM site location score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002555 ! PTM localization score threshold
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002559
@@ -16667,6 +17529,7 @@ name: H-Score threshold
 def: "Threshold for H-score PTM site location score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002555 ! PTM localization score threshold
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002560
@@ -16674,6 +17537,7 @@ name: DeBunker:score threshold
 def: "Threshold for DeBunker PTM site location score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002555 ! PTM localization score threshold
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002561
@@ -16681,6 +17545,7 @@ name: Mascot:PTM site assignment confidence threshold
 def: "Threshold for Mascot PTM site assignment confidence." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002555 ! PTM localization score threshold
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002562
@@ -16688,6 +17553,7 @@ name: MSQuant:PTM-score threshold
 def: "Threshold for MSQuant:PTM-score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002555 ! PTM localization score threshold
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002563
@@ -16695,6 +17561,7 @@ name: MaxQuant:PTM Score threshold
 def: "Threshold for MaxQuant:PTM Score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002555 ! PTM localization score threshold
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002564
@@ -16702,6 +17569,7 @@ name: MaxQuant:P-site localization probability threshold
 def: "Threshold for MaxQuant:P-site localization probability." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002555 ! PTM localization score threshold
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002565
@@ -16709,6 +17577,7 @@ name: MaxQuant:PTM Delta Score threshold
 def: "Threshold for MaxQuant:PTM Delta Score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002555 ! PTM localization score threshold
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002566
@@ -16716,6 +17585,7 @@ name: MaxQuant:Phospho (STY) Probabilities threshold
 def: "Threshold for MaxQuant:Phospho (STY) Probabilities." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002555 ! PTM localization score threshold
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002567
@@ -16723,6 +17593,7 @@ name: phosphoRS score threshold
 def: "Threshold for phosphoRS score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002555 ! PTM localization score threshold
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002568
@@ -16730,6 +17601,7 @@ name: phosphoRS site probability threshold
 def: "Threshold for phosphoRS site probability." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002555 ! PTM localization score threshold
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002569
@@ -16737,6 +17609,7 @@ name: ProteomeDiscoverer:Number of Spectra Processed At Once
 def: "Number of spectra processed at once in a ProteomeDiscoverer search." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002570
@@ -16744,6 +17617,7 @@ name: sequence multiply subsumable protein
 def: "A protein for which the matched peptide sequences are the same, or a subset of, the matched peptide sequences for two or more other proteins combined. These other proteins need not all be in the same group." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001101 ! protein group or subset relationship
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002571
@@ -16751,6 +17625,7 @@ name: spectrum multiply subsumable protein
 def: "A protein for which the matched spectra are the same, or a subset of, the matched spectra for two or more other proteins combined. These other proteins need not all be in the same group." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001101 ! protein group or subset relationship
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002572
@@ -16920,6 +17795,7 @@ name: splash key
 def: "Spectral Hash key, an unique identifier for spectra." [PMID:27824832]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001405 ! spectrum identification result details
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002600
@@ -17122,6 +17998,7 @@ name: jPOST dataset identifier
 def: "Dataset identifier issued by the jPOST repository. A dataset can refer to either a single sample as part of a study, or all samples that are part of the study corresponding to a publication." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002633
@@ -17129,6 +18006,7 @@ name: jPOST dataset URI
 def: "URI that allows the access to one dataset in the jPOST repository. A dataset can refer to either a single sample as part of a study, or all samples that are part of the study corresponding to a publication." [PSI:PI]
 xref: value-type:xsd\:anyURI "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
+relationship: has_value_type xsd\:anyURI ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002634
@@ -17154,6 +18032,7 @@ name: chromosome name
 def: "The name or number of the chromosome to which a given peptide has been mapped." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002636 ! proteogenomics attribute
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002638
@@ -17161,6 +18040,7 @@ name: chromosome strand
 def: "The strand (+ or -) to which the peptide has been mapped." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002636 ! proteogenomics attribute
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002639
@@ -17170,6 +18050,7 @@ comment: This term was obsoleted because it contains redundant info contained in
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002636 ! proteogenomics attribute
 is_obsolete: true
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002640
@@ -17177,6 +18058,7 @@ name: peptide end on chromosome
 def: "The overall end position on the chromosome to which a peptide has been mapped i.e. the position of the third base of the last codon, using a zero-based counting system." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002636 ! proteogenomics attribute
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002641
@@ -17184,6 +18066,7 @@ name: peptide exon count
 def: "The number of exons to which the peptide has been mapped." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002636 ! proteogenomics attribute
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002642
@@ -17191,6 +18074,7 @@ name: peptide exon nucleotide sizes
 def: "A comma separated list of the number of DNA bases within each exon to which a peptide has been mapped. Assuming standard operation of a search engine, the peptide exon sizes should sum to exactly three times the peptide length." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002636 ! proteogenomics attribute
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002643
@@ -17198,6 +18082,7 @@ name: peptide start positions on chromosome
 def: "A comma separated list of start positions within exons to which the peptide has been mapped, relative to peptide-chromosome start, assuming a zero-based counting system. The first value MUST match the value in peptide start on chromosome." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002636 ! proteogenomics attribute
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002644
@@ -17205,6 +18090,7 @@ name: genome reference version
 def: "The reference genome and versioning string as used for mapping. All coordinates are within this frame of reference." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002636 ! proteogenomics attribute
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002645
@@ -17226,6 +18112,7 @@ name: Thermo nativeID format, combined spectra
 def: "Thermo comma separated list of spectra that have been combined prior to searching or interpretation." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002646 ! native spectrum identifier format, combined spectra
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002648
@@ -17233,6 +18120,7 @@ name: Waters nativeID format, combined spectra
 def: "Waters comma separated list of spectra that have been combined prior to searching or interpretation." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002646 ! native spectrum identifier format, combined spectra
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002649
@@ -17240,6 +18128,7 @@ name: WIFF nativeID format, combined spectra
 def: "WIFF comma separated list of spectra that have been combined prior to searching or interpretation." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002646 ! native spectrum identifier format, combined spectra
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002650
@@ -17247,6 +18136,7 @@ name: Bruker/Agilent YEP nativeID format, combined spectra
 def: "Bruker/Agilent comma separated list of spectra that have been combined prior to searching or interpretation." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002646 ! native spectrum identifier format, combined spectra
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002651
@@ -17254,6 +18144,7 @@ name: Bruker BAF nativeID format, combined spectra
 def: "Bruker BAF comma separated list of spectra that have been combined prior to searching or interpretation." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002646 ! native spectrum identifier format, combined spectra
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002652
@@ -17262,6 +18153,7 @@ def: "Bruker FID comma separated list of spectra that have been combined prior t
 comment: The nativeID must be the same as the source file ID.
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002646 ! native spectrum identifier format, combined spectra
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002653
@@ -17270,6 +18162,7 @@ def: "Comma separated list of spectra that have been combined prior to searching
 comment: Used for conversion of peak list files with multiple spectra, i.e. MGF, PKL, merged DTA files. Index is the spectrum number in the file, starting from 0.
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002646 ! native spectrum identifier format, combined spectra
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002654
@@ -17278,6 +18171,7 @@ def: "Comma separated list of spectra that have been combined prior to searching
 comment: The nativeID must be the same as the source file ID. Used for conversion of peak list files with one spectrum per file, typically folder of PKL or DTAs, each sourceFileRef is different.
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002646 ! native spectrum identifier format, combined spectra
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002655
@@ -17286,6 +18180,7 @@ def: "Comma separated list of spectra that have been combined prior to searching
 comment: Used for conversion from mzXML, or DTA folder where native scan numbers can be derived.
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002646 ! native spectrum identifier format, combined spectra
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002656
@@ -17294,6 +18189,7 @@ def: "Comma separated list of spectra that have been combined prior to searching
 comment: Used for conversion from mzData. The spectrum id attribute is referenced.
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002646 ! native spectrum identifier format, combined spectra
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002657
@@ -17302,6 +18198,7 @@ def: "Comma separated list of spectra that have been combined prior to searching
 comment: A unique identifier of a spectrum stored in an mzML file.
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002646 ! native spectrum identifier format, combined spectra
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002658
@@ -17335,6 +18232,7 @@ def: "Morpheus score for PSMs." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002108 ! higher score better
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002663
@@ -17343,6 +18241,7 @@ def: "Summed Morpheus score for protein groups." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002368 ! search engine specific score for protein groups
 relationship: has_order MS:1002108 ! higher score better
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002664
@@ -17351,6 +18250,7 @@ def: "Parent term for interaction scores derived from cross-linking." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002675 ! cross-linking result details
 relationship: has_regexp MS:1002665 ! ([:digit:]+[.][a|b]:[:digit:]+:[:digit:]+[.][:digit:]+([Ee][+-][0-9]+)*:(true|false]\{1\}))
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002665
@@ -17376,6 +18276,7 @@ name: frag: iTRAQ 4plex reporter ion
 def: "Standard reporter ion for iTRAQ 4Plex. The value slot holds the integer mass of the iTRAQ 4Plex reporter ion, e.g. 114." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002307 ! fragmentation ion type
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002669
@@ -17383,6 +18284,7 @@ name: frag: iTRAQ 8plex reporter ion
 def: "Standard reporter ion for iTRAQ 8Plex. The value slot holds the integer mass of the iTRAQ 8Plex reporter ion, e.g. 113." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002307 ! fragmentation ion type
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002670
@@ -17390,6 +18292,7 @@ name: frag: TMT reporter ion
 def: "Standard reporter ion for TMT. The value slot holds the integer mass of the TMT reporter ion and can be suffixed with either N or C, indicating whether the mass difference is encoded at a Nitrogen or Carbon atom, e.g. 127N." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002307 ! fragmentation ion type
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002671
@@ -17397,6 +18300,7 @@ name: frag: TMT ETD reporter ion
 def: "Standard reporter ion for TMT with ETD fragmentation. The value slot holds the integer mass of the TMT ETD reporter ion and can be suffixed with either N or C, indicating whether the mass difference is encoded at a Nitrogen or Carbon atom, e.g. 127C." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002307 ! fragmentation ion type
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002672
@@ -17430,6 +18334,7 @@ xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002664 ! interaction score derived from cross-linking
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
 relationship: has_regexp MS:1002665 ! ([:digit:]+[.][a|b]:[:digit:]+:[:digit:]+[.][:digit:]+([Ee][+-][0-9]+)*:(true|false]\{1\}))
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002677
@@ -17439,6 +18344,7 @@ xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002664 ! interaction score derived from cross-linking
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
 relationship: has_regexp MS:1002665 ! ([:digit:]+[.][a|b]:[:digit:]+:[:digit:]+[.][:digit:]+([Ee][+-][0-9]+)*:(true|false]\{1\}))
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002678
@@ -17459,6 +18365,7 @@ def: "Energy for an ion experiencing supplemental collision with a stationary ga
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000510 ! precursor activation attribute
 relationship: has_units UO:0000266 ! electronvolt
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002681
@@ -17468,6 +18375,7 @@ xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1001153 ! search engine specific score
 relationship: has_order MS:1002108 ! higher score better
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002682
@@ -17477,6 +18385,7 @@ xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1001153 ! search engine specific score
 relationship: has_order MS:1002108 ! higher score better
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002683
@@ -17486,6 +18395,7 @@ xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1001153 ! search engine specific score
 relationship: has_order MS:1002108 ! higher score better
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002684
@@ -17496,6 +18406,7 @@ is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1001153 ! search engine specific score
 relationship: has_order MS:1002108 ! higher score better
 relationship: has_domain MS:1002306 ! value greater than zero
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002685
@@ -17506,6 +18417,7 @@ is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1001153 ! search engine specific score
 relationship: has_order MS:1002108 ! higher score better
 relationship: has_domain MS:1002306 ! value greater than zero
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002686
@@ -17516,6 +18428,7 @@ is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1001153 ! search engine specific score
 relationship: has_order MS:1002108 ! higher score better
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002687
@@ -17665,6 +18578,7 @@ xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002353 ! PSM-level e-value
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002109 ! lower score better
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002722
@@ -17674,6 +18588,7 @@ xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002353 ! PSM-level e-value
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002109 ! lower score better
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002723
@@ -17682,6 +18597,7 @@ def: "MSPathFinder Q-value." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002354 ! PSM-level q-value
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002724
@@ -17689,6 +18605,7 @@ name: MSPathFinder:PepQValue
 def: "MSPathFinder peptide-level Q-value." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002725
@@ -17696,6 +18613,7 @@ name: MSPathFinder:RawScore
 def: "MSPathFinder raw score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002726
@@ -17745,6 +18663,7 @@ name: peptide-level spectral count
 def: "The number of MS2 spectra identified for a peptide sequence specified by the amino acid one-letter codes plus optional PTMs in spectral counting." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002737 ! peptide-level quantification datatype
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002734
@@ -17752,6 +18671,7 @@ name: peptide ion-level spectral count
 def: "The number of MS2 spectra identified for a molecular ion defined by the peptide sequence represented by the amino acid one-letter codes, plus optional PTMs plus optional charged aducts plus the charge state, in spectral counting." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002737 ! peptide-level quantification datatype
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002735
@@ -17853,6 +18773,7 @@ name: Mascot:IntegratedSpectralLibrarySearch
 def: "Means that Mascot has integrated the search results of database and spectral library search into a single data set." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002095 ! Mascot input parameter
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002750
@@ -18222,6 +19143,7 @@ name: adduct ion X m/z
 def: "Theoretical m/z of the X component in the adduct M+X or M-X. This term was formerly called 'adduct ion mass', but it is not really a mass. It corresponds to the column mislabelled as 'mass' at https://fiehnlab.ucdavis.edu/staff/kind/Metabolomics/MS-Adduct-Calculator." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1003056 ! adduct ion property
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002811
@@ -18229,6 +19151,7 @@ name: adduct ion isotope
 def: "Isotope of the matrix molecule M of an adduct formation." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1003056 ! adduct ion property
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002812
@@ -18243,6 +19166,7 @@ def: "Adduct formation formula of the form M+X or M-X, as constrained by the pro
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002809 ! adduct ion attribute
 relationship: has_regexp MS:1002812 ! (\[[:digit:]{0,1}M([+][:digit:]{0,1}(H|K|(Na)|(Li)|(Cl)|(Br)|(NH3)|(NH4)|(CH3OH)|(IsoProp)|(DMSO)|(FA)|(Hac)|(TFA)|(NaCOOH)|(HCOOH)|(CF3COOH)|(ACN))){0,}([-][:digit:]{0,1}(H|(H2O)|(CH2)|(CH4)|(NH3)|(CO)|(CO2)|(COCH2)|(HCOOH)|(C2H4)|(C4H8)|(C3H2O3)|(C5H8O4)|(C6H10O4)|(C6H10O5)|(C6H8O6))){0,}\][:digit:]{0,1}[+-])
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002814
@@ -18259,6 +19183,7 @@ xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000455 ! ion selection attribute
 is_a: MS:1002892 ! ion mobility attribute
 relationship: has_units MS:1002814 ! volt-second per square centimeter
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002816
@@ -18268,6 +19193,7 @@ xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002893 ! ion mobility array
 relationship: has_units UO:0000028 ! millisecond
 relationship: has_units UO:0000010 ! second
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002817
@@ -18287,6 +19213,7 @@ name: Bruker TDF nativeID format, combined spectra
 def: "Bruker TDF comma separated list of spectra that have been combined prior to searching or interpretation." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002646 ! native spectrum identifier format, combined spectra
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002820
@@ -18339,6 +19266,7 @@ def: "MetaMorpheus score for PSMs." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002108 ! higher score better
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002828
@@ -18347,6 +19275,7 @@ def: "MetaMorpheus score for protein groups." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002368 ! search engine specific score for protein groups
 relationship: has_order MS:1002108 ! higher score better
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002829
@@ -18354,6 +19283,7 @@ name: XCMS:into
 def: "Feature intensity produced by XCMS findPeaks() from integrated peak intensity." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002735 ! feature-level quantification datatype
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002830
@@ -18361,6 +19291,7 @@ name: XCMS:intf
 def: "Feature intensity produced by XCMS findPeaks() from baseline corrected integrated peak intensity." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002735 ! feature-level quantification datatype
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002831
@@ -18368,6 +19299,7 @@ name: XCMS:maxo
 def: "Feature intensity produced by XCMS findPeaks() from maximum peak intensity." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002735 ! feature-level quantification datatype
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002832
@@ -18375,6 +19307,7 @@ name: XCMS:area
 def: "Feature intensity produced by XCMS findPeaks() from feature area that is not normalized by the scan rate." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002735 ! feature-level quantification datatype
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002833
@@ -18388,6 +19321,7 @@ name: ProteomeDiscoverer:Delta Score
 def: "The Delta Score reported by Proteome Discoverer version 2." [PSI:PI]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002835
@@ -18401,6 +19335,7 @@ name: iProX dataset identifier
 def: "Dataset identifier issued by the iProX repository. A dataset can refer to either a single sample as part of a study, or all samples that are part of the study corresponding to a publication." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002837
@@ -18408,6 +19343,7 @@ name: iProX dataset URI
 def: "URI that allows the access to one dataset in the iProX repository. A dataset can refer to either a single sample as part of a study, or all samples that are part of the study corresponding to a publication." [PSI:PI]
 xref: value-type:xsd\:anyURI "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
+relationship: has_value_type xsd\:anyURI ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002838
@@ -18433,6 +19369,7 @@ name: external HDF5 dataset
 def: "The HDF5 dataset location containing the binary data, relative to the dataset containing the mzML. Also indicates that there is no data in the <binary> section of the BinaryDataArray." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002840 ! external reference data
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002842
@@ -18441,6 +19378,7 @@ def: "The position in the external data where the array begins." [PSI:PI]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 relationship: has_units UO:0000189 ! Count
 is_a: MS:1002840 ! external reference data
+relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002843
@@ -18449,6 +19387,7 @@ def: "Describes how many fields an array contains." [PSI:PI]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 relationship: has_units UO:0000189 ! Count
 is_a: MS:1002840 ! external reference data
+relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002844
@@ -18462,6 +19401,7 @@ name: Associated file URI
 def: "URI of one external file associated to the PRIDE experiment (maybe through a PX submission)." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002844 ! Experiment additional parameter
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002846
@@ -18469,6 +19409,7 @@ name: Associated raw file URI
 def: "URI of one raw data file associated to the PRIDE experiment (maybe through a PX submission)." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002845 ! Associated file URI
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002847
@@ -18476,6 +19417,7 @@ name: ProteomeCentral dataset URI
 def: "URI associated to one PX submission in ProteomeCentral." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002844 ! Experiment additional parameter
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002848
@@ -18483,6 +19425,7 @@ name: Result file URI
 def: "URI of one file labeled as 'Result', associated to one PX submission." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002845 ! Associated file URI
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002849
@@ -18490,6 +19433,7 @@ name: Search engine output file URI
 def: "URI of one search engine output file associated to one PX submission." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002845 ! Associated file URI
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002850
@@ -18497,6 +19441,7 @@ name: Peak list file URI
 def: "URI of one of one search engine output file associated to one PX submission." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002845 ! Associated file URI
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002851
@@ -18504,6 +19449,7 @@ name: Other type file URI
 def: "URI of one file labeled as 'Other', associated to one PX submission." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002845 ! Associated file URI
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002852
@@ -18511,6 +19457,7 @@ name: Dataset FTP location
 def: "FTP location of one entire PX data set." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002844 ! Experiment additional parameter
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002853
@@ -18554,6 +19501,7 @@ name: Additional associated raw file URI
 def: "Additional URI of one raw data file associated to the PRIDE experiment (maybe through a PX submission). The URI is provided via an additional resource to PRIDE." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002845 ! Associated file URI
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002860
@@ -18561,6 +19509,7 @@ name: Gel image file URI
 def: "URI of one gel image file associated to one PX submission." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002845 ! Associated file URI
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002861
@@ -18568,6 +19517,7 @@ name: Reprocessed complete dataset
 def: "All the raw files included in the original dataset (or group of original datasets) have been reanalysed." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002844 ! Experiment additional parameter
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002862
@@ -18575,6 +19525,7 @@ name: Reprocessed subset dataset
 def: "A subset of the raw files included in the original dataset (or group of original datasets) has been reanalysed." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002844 ! Experiment additional parameter
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002863
@@ -18600,6 +19551,7 @@ name: Reference
 def: "Literature reference associated with one dataset (including the authors, title, year and journal details). The value field can be used for the PubMedID, or to specify if one manuscript is just submitted or accepted, but it does not have a PubMedID yet." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002844 ! Experiment additional parameter
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002867
@@ -18640,6 +19592,7 @@ name: Panorama Public dataset identifier
 def: "Dataset identifier issued by the Panorama Public repository. A dataset can refer to either a single sample as part of a study, or all samples that are part of the study corresponding to a publication." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002873
@@ -18647,6 +19600,7 @@ name: Panorama Public dataset URI
 def: "URI that allows the access to one dataset in the Panorama Public repository. A dataset can refer to either a single sample as part of a study, or all samples that are part of the study corresponding to a publication." [PSI:PI]
 xref: value-type:xsd\:anyURI "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
+relationship: has_value_type xsd\:anyURI ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002874
@@ -18732,6 +19686,7 @@ name: Progenesis QI normalised abundance
 def: "The normalised abundance produced by Progenesis QI LC-MS." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002886 ! small molecule quantification datatype
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002888
@@ -18745,6 +19700,7 @@ name: Progenesis MetaScope score
 def: "The confidence score produced by Progenesis QI." [PSI:PI]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002888 ! small molecule confidence measure
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002890
@@ -18752,6 +19708,7 @@ name: fragmentation score
 def: "The fragmentation confidence score." [PSI:PI]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002888 ! small molecule confidence measure
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002891
@@ -18759,6 +19716,7 @@ name: isotopic fit score
 def: "The isotopic fit confidence score." [PSI:PI]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002888 ! small molecule confidence measure
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002892
@@ -18779,6 +19737,7 @@ name: InChIKey
 def: "Unique chemical structure identifier for chemical compounds." [PMID:273343401]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001405 ! spectrum identification result details
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002895
@@ -18792,6 +19751,7 @@ name: compound identification confidence level
 def: "Confidence level for annotation of identified compounds as defined by the Metabolomics Standards Initiative (MSI). The value slot can have the values 'Level 0' until 'Level 4'." [PMID:29748461]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002895 ! small molecule identification attribute
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002897
@@ -18801,6 +19761,7 @@ comment: This term was obsoleted because it was replaced by the more exact terms
 xref: value-type:xsd:string "The allowed value-type for this CV term."
 is_a: MS:1000231 ! peak
 is_obsolete: true
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002898
@@ -18863,6 +19824,7 @@ def: "Estimation of the global false discovery rate of proteoforms." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002905 ! proteoform-level identification statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002908
@@ -18871,6 +19833,7 @@ def: "Estimation of the local false discovery rate of proteoforms." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002905 ! proteoform-level identification statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002909
@@ -18884,6 +19847,7 @@ name: proteoform-level global FDR threshold
 def: "Threshold for the global false discovery rate of proteoforms." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002909 ! proteoform-level statistical threshold
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002911
@@ -18891,6 +19855,7 @@ name: proteoform-level local FDR threshold
 def: "Threshold for the local false discovery rate of proteoforms." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002909 ! proteoform-level statistical threshold
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002912
@@ -18916,6 +19881,7 @@ name: TopPIC:error tolerance
 def: "Error tolerance for precursor and fragment masses in PPM." [PSI:PI]
 xref: value-type:xsd\:integer "The allowed value-type for this CV term."
 is_a: MS:1002912 ! TopPIC input parameter
+relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002916
@@ -18923,6 +19889,7 @@ name: TopPIC:max shift
 def: "Maximum value of the mass shift (in Dalton) of an unexpected modification." [PSI:PI]
 xref: value-type:xsd\:integer "The allowed value-type for this CV term."
 is_a: MS:1002912 ! TopPIC input parameter
+relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002917
@@ -18930,6 +19897,7 @@ name: TopPIC:min shift
 def: "Minimum value of the mass shift (in Dalton) of an unexpected modification." [PSI:PI]
 xref: value-type:xsd\:integer "The allowed value-type for this CV term."
 is_a: MS:1002912 ! TopPIC input parameter
+relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002918
@@ -18937,6 +19905,7 @@ name: TopPIC:shift num
 def: "Maximum number of unexpected modifications in a proteoform spectrum match." [PSI:PI]
 xref: value-type:xsd\:integer "The allowed value-type for this CV term."
 is_a: MS:1002912 ! TopPIC input parameter
+relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002919
@@ -18944,6 +19913,7 @@ name: TopPIC:spectral cutoff type
 def: "Spectrum-level cutoff type for filtering identified proteoform spectrum matches." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002912 ! TopPIC input parameter
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002920
@@ -18951,6 +19921,7 @@ name: TopPIC:spectral cutoff value
 def: "Spectrum-level cutoff value for filtering identified proteoform spectrum matches." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002912 ! TopPIC input parameter
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002921
@@ -18958,6 +19929,7 @@ name: TopPIC:proteoform-level cutoff type
 def: "Proteoform-level cutoff type for filtering identified proteoform spectrum matches." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002912 ! TopPIC input parameter
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002922
@@ -18965,6 +19937,7 @@ name: TopPIC:proteoform-level cutoff value
 def: "Proteoform-level cutoff value for filtering identified proteoform spectrum matches." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002912 ! TopPIC input parameter
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002923
@@ -18972,6 +19945,7 @@ name: TopPIC:generating function
 def: "P-value and E-value estimation using generating function." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002912 ! TopPIC input parameter
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002924
@@ -18979,6 +19953,7 @@ name: TopPIC:combined spectrum number
 def: "Number of combined spectra." [PSI:PI]
 xref: value-type:xsd\:integer "The allowed value-type for this CV term."
 is_a: MS:1002912 ! TopPIC input parameter
+relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002925
@@ -18992,6 +19967,7 @@ name: TopPIC:thread number
 def: "Number of threads used in TopPIC." [PSI:PI]
 xref: value-type:xsd\:integer "The allowed value-type for this CV term."
 is_a: MS:1002912 ! TopPIC input parameter
+relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002927
@@ -18999,6 +19975,7 @@ name: TopPIC:use TopFD feature
 def: "Proteoform identification using TopFD feature file." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002912 ! TopPIC input parameter
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002928
@@ -19008,6 +19985,7 @@ xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1002353 ! PSM-level e-value
 relationship: has_order MS:1002109 ! lower score better
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002929
@@ -19016,6 +19994,7 @@ def: "TopPIC spectrum-level FDR." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1002351 ! PSM-level local FDR
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002930
@@ -19024,6 +20003,7 @@ def: "TopPIC proteoform-level FDR." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002908 ! proteoform-level local FDR
 is_a: MS:1002906 ! search engine specific score for proteoforms
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002931
@@ -19032,6 +20012,7 @@ def: "TopPIC spectrum-level p-value." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1002352 ! PSM-level p-value
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002932
@@ -19039,6 +20020,7 @@ name: TopPIC:MIScore
 def: "Modification identification score." [PMID:27291504]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001968 ! PTM localization PSM-level statistic
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002933
@@ -19046,6 +20028,7 @@ name: TopPIC:MIScore threshold
 def: "TopPIC:MIScore threshold." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002555 ! PTM localization score threshold
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002934
@@ -19071,6 +20054,7 @@ name: TopMG:error tolerance
 def: "Error tolerance for precursor and fragment masses in PPM." [PSI:PI]
 xref: value-type:xsd\:integer "The allowed value-type for this CV term."
 is_a: MS:1002934 ! TopMG input parameter
+relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002938
@@ -19078,6 +20062,7 @@ name: TopMG:max shift
 def: "Maximum value of the mass shift (in Dalton)." [PSI:PI]
 xref: value-type:xsd\:integer "The allowed value-type for this CV term."
 is_a: MS:1002934 ! TopMG input parameter
+relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002939
@@ -19085,6 +20070,7 @@ name: TopMG:spectral cutoff type
 def: "Spectrum-level cutoff type for filtering identified proteoform spectrum matches." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002934 ! TopMG input parameter
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002940
@@ -19092,6 +20078,7 @@ name: TopMG:spectral cutoff value
 def: "Spectrum-level cutoff value for filtering identified proteoform spectrum matches." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002934 ! TopMG input parameter
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002941
@@ -19099,6 +20086,7 @@ name: TopMG:proteoform-level cutoff type
 def: "Proteoform-level cutoff type for filtering identified proteoform spectrum matches." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002934 ! TopMG input parameter
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002942
@@ -19106,6 +20094,7 @@ name: TopMG:proteoform-level cutoff value
 def: "Proteoform-level cutoff value for filtering identified proteoform spectrum matches." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002934 ! TopMG input parameter
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002943
@@ -19119,6 +20108,7 @@ name: TopMG:thread number
 def: "Number of threads used in TopMG." [PSI:PI]
 xref: value-type:xsd\:integer "The allowed value-type for this CV term."
 is_a: MS:1002934 ! TopMG input parameter
+relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002945
@@ -19126,6 +20116,7 @@ name: TopMG:use TopFD feature
 def: "Proteoform identification using TopFD feature file." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002934 ! TopMG input parameter
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002946
@@ -19133,6 +20124,7 @@ name: TopMG:proteoform graph gap size
 def: "Gap size in constructing proteoform graph." [PSI:PI]
 xref: value-type:xsd\:integer "The allowed value-type for this CV term."
 is_a: MS:1002934 ! TopMG input parameter
+relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002947
@@ -19140,6 +20132,7 @@ name: TopMG:variable PTM number
 def: "Maximum number of variable PTMs." [PSI:PI]
 xref: value-type:xsd\:integer "The allowed value-type for this CV term."
 is_a: MS:1002934 ! TopMG input parameter
+relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002948
@@ -19147,6 +20140,7 @@ name: TopMG:variable PTM number in proteoform graph gap
 def: "Maximum number of variable PTMs in a proteoform graph gap." [PSI:PI]
 xref: value-type:xsd\:integer "The allowed value-type for this CV term."
 is_a: MS:1002934 ! TopMG input parameter
+relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002949
@@ -19154,6 +20148,7 @@ name: TopMG:use ASF-DIAGONAL
 def: "Protein filtering using ASF-DIAGONAL method." [PMID:29327814]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002934 ! TopMG input parameter
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002950
@@ -19163,6 +20158,7 @@ xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002353 ! PSM-level e-value
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002109 ! lower score better
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002951
@@ -19171,6 +20167,7 @@ def: "TopMG spectrum-level FDR." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002351 ! PSM-level local FDR
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002952
@@ -19179,6 +20176,7 @@ def: "TopMG proteoform-level FDR." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002908 ! proteoform-level local FDR
 is_a: MS:1002906 ! search engine specific score for proteoforms
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002953
@@ -19187,6 +20185,7 @@ def: "TopMG spectrum-level p-value." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002352 ! PSM-level p-value
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002954
@@ -19195,6 +20194,7 @@ def: "Structural molecular descriptor for the effective interaction area between
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1000861 ! molecular entity property
 relationship: has_units UO:0000324 ! square angstrom
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002955
@@ -19202,6 +20202,7 @@ name: hr-ms compound identification confidence level
 def: "Refined High Resolution mass spectrometry confidence level for annotation of identified compounds as proposed by Schymanski et al. The value slot can have the values 'Level 1', 'Level 2', 'Level 2a', 'Level 2b', 'Level 3', 'Level 4', and 'Level 5'." [PMID:24476540]
 xref: value-type:xsd:string "The allowed value-type for this CV term."
 is_a: MS:1002895 ! small molecule identification attribute
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002956
@@ -19209,6 +20210,7 @@ name: isotopic ion MS peak
 def: "A mass spectrometry peak that represents one or more isotopic ions. The value slot contains a description of the represented isotope set, e.g. 'M+1 peak'." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000231 ! peak
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002957
@@ -19216,6 +20218,7 @@ name: isotopomer MS peak
 def: "The described isotopomer mass spectrometric signal. The value slot contains a description of the represented isotopomer, e.g. '13C peak', '15N peak', '2H peak', '18O peak' or '31P peak'." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002956 ! isotopic ion MS peak
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002958
@@ -19223,6 +20226,7 @@ name: isotopologue MS peak
 def: "The described isotopologue mass spectrometric signal. The value slot contains a description of the represented isotopologue, e.g. '13C1 peak' or '15N1 peak'." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002956 ! isotopic ion MS peak
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002959
@@ -19230,6 +20234,7 @@ name: isomer
 def: "One of several species (or molecular entities) that have the same atomic composition (molecular formula) but different line formulae or different stereochemical formulae." [https://goldbook.iupac.org/html/I/I03289.html]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000859 ! molecule
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002960
@@ -19237,6 +20242,7 @@ name: isotopomer
 def: "An isomer that differs from another only in the spatial distribution of the constitutive isotopic atoms." [https://goldbook.iupac.org/html/I/I03352.html]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002959 ! isomer
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002961
@@ -19244,6 +20250,7 @@ name: isotopologue
 def: "A molecular entity that differs only in isotopic composition (number of isotopic substitutions)." [https://goldbook.iupac.org/html/I/I03351.html]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002959 ! isomer
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002962
@@ -19423,6 +20430,7 @@ def: "The IdentiPy result 'RHNS'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001153 ! search engine specific score
 relationship: has_order MS:1002108 ! higher score better
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002989
@@ -19431,6 +20439,7 @@ def: "The IdentiPy result 'hyperscore'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001153 ! search engine specific score
 relationship: has_order MS:1002108 ! higher score better
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002990
@@ -19452,6 +20461,7 @@ xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
 relationship: has_order MS:1002108 ! higher score better
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002996
@@ -19465,6 +20475,7 @@ name: ProteomeXchange dataset identifier reanalysis number
 def: "Index number of a reanalysis within a ProteomeXchange reprocessed dataset identifier container (RPXD)." [PSI:PI]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
+relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002998
@@ -19521,6 +20532,7 @@ def: "Array of population mean ion mobility values based on ion separation in ga
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002893 ! ion mobility array
 relationship: has_units MS:1002814 ! volt-second per square centimeter
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003007
@@ -19530,6 +20542,7 @@ xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002893 ! ion mobility array
 relationship: has_units UO:0000028 ! millisecond
 relationship: has_units UO:0000010 ! second
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003008
@@ -19538,6 +20551,7 @@ def: "Array of raw ion mobility values based on ion separation in gaseous phase 
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002893 ! ion mobility array
 relationship: has_units MS:1002814 ! volt-second per square centimeter
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003009
@@ -19592,6 +20606,7 @@ is_a: MS:1002490 ! peptide-level scoring
 is_a: MS:1001153 ! search engine specific score
 relationship: has_order MS:1002108 ! higher score better
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003017
@@ -19602,6 +20617,7 @@ is_a: MS:1002490 ! peptide-level scoring
 is_a: MS:1001153 ! search engine specific score
 relationship: has_order MS:1002108 ! higher score better
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003018
@@ -19649,6 +20665,7 @@ xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1001153 ! search engine specific score
 relationship: has_order MS:1002108 ! higher score better
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003025
@@ -19686,6 +20703,7 @@ name: Mascot:MinNumSigUniqueSeqs
 def: "Minimum number of significant unique sequences required in a protein hit. The setting is only relevant if the protein grouping strategy is 'family clustering'." [PSI:PI]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1002095 ! Mascot input parameter
+relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003031
@@ -19693,6 +20711,7 @@ name: CPTAC accession number
 def: "Main identifier of a CPTAC dataset." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003032
@@ -19700,6 +20719,7 @@ name: compound identification confidence code in MS-DIAL
 def: "The confidence code to describe the confidence of annotated compounds as defined by the MS-DIAL program." [PMID:25938372, http://prime.psc.riken.jp/Metabolomics_Software/MS-DIAL]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002895 ! small molecule identification attribute
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003033
@@ -19999,6 +21019,7 @@ def: "Monoisotopic mass delta in Daltons of an amino acid residue modification w
 is_a: MS:1001471 ! peptide modification details
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 relationship: has_units UO:0000221 ! dalton
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003082
@@ -20019,6 +21040,7 @@ name: processed data file
 def: "File that contains data that has been substantially processed or transformed from what was originally acquired by an instrument." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000577 ! source data file
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003085
@@ -20027,6 +21049,7 @@ def: "Intensity of the precursor ion in the previous MSn-1 scan (prior in time t
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001141 ! intensity of precursor ion
 is_a: MS:1000499 ! spectrum attribute
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003086
@@ -20035,6 +21058,7 @@ def: "Intensity of the precursor ion current as measured by its apex point over 
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001141 ! intensity of precursor ion
 is_a: MS:1000499 ! spectrum attribute
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003087
@@ -20073,6 +21097,7 @@ name: number of mantissa bits truncated
 def: "Number of extraneous mantissa bits truncated to improve subsequent compression." [PSI:MS]
 xref: value-type:xsd\:positiveInteger "Number of mantissa bits truncated."
 is_a: MS:1003091 ! binary data compression parameter
+relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003093
@@ -20105,6 +21130,7 @@ name: MaxQuant protein group-level score
 def: "The probability based MaxQuant protein group score." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002368 ! search engine specific score for protein groups
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003098
@@ -20112,6 +21138,7 @@ name: Andromeda peptide PEP
 def: "Peptide probability from Andromeda." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002358 ! search engine specific peptide sequence-level identification statistic
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003099
@@ -20119,6 +21146,7 @@ name: MaxQuant-DIA peptide PEP
 def: "Peptide probability from MaxQuant-DIA algorithm." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002358 ! search engine specific peptide sequence-level identification statistic
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003100
@@ -20126,6 +21154,7 @@ name: MaxQuant-DIA score
 def: "PSM evidence score from MaxQuant-DIA algorithm." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003101
@@ -20133,6 +21162,7 @@ name: MaxQuant-DIA PEP
 def: "PSM evidence PEP probability from MaxQuant-DIA algorithm." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003102
@@ -20140,6 +21170,7 @@ name: NIST msp comment
 def: "Term for a comment field withing the NIST msp file format" [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000499 ! spectrum attribute
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003103
@@ -20191,6 +21222,7 @@ def: "SIM-XL identification search engine score" [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002108 ! higher score better
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003111
@@ -20210,6 +21242,7 @@ name: OpenMS:ConsensusID PEP
 def: "The OpenMS ConsesusID tool posterior error probability" [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003114
@@ -20217,6 +21250,7 @@ name: OpenMS:Best PSM Score
 def: "The score of the best PSM selected by the underlying identification tool" [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002358 ! search engine specific peptide sequence-level identification statistic
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003115
@@ -20224,6 +21258,7 @@ name: OpenMS:Target-decoy PSM q-value
 def: "The OpenMS Target-decoy q-values at PSM level" [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003116
@@ -20231,6 +21266,7 @@ name: OpenMS:Target-decoy peptide q-value
 def: "The OpenMS Target-decoy q-values at peptide sequence level" [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002358 ! search engine specific peptide sequence-level identification statistic
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003117
@@ -20238,6 +21274,7 @@ name: OpenMS:Target-decoy protein q-value
 def: "The OpenMS Target-decoy q-values at protein level" [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003118
@@ -20252,6 +21289,7 @@ name: EPIFANY:Protein posterior probability
 def: "Protein Posterior probability calculated by EPIFANY protein inference algorithm" [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003120
@@ -20259,6 +21297,7 @@ name: OpenMS:LFQ intensity
 def: "The data type LFQ intensity produced by OpenMS." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003121
@@ -20266,6 +21305,7 @@ name: OpenMS:LFQ spectral count
 def: "The data type LFQ spectral count produced by OpenMS." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003122
@@ -20293,6 +21333,7 @@ xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002354 ! PSM-level q-value
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002109 ! lower score better
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003126
@@ -20301,6 +21342,7 @@ def: "ProSight spectrum-level P-score." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002109 ! lower score better
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003127
@@ -20310,6 +21352,7 @@ xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002353 ! PSM-level e-value
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002109 ! lower score better
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003128
@@ -20318,6 +21361,7 @@ def: "ProSight spectrum-level C-score." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002108 ! higher score better
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003129
@@ -20327,6 +21371,7 @@ xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002905 ! proteoform-level identification statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
 relationship: has_order MS:1002109 ! lower score better
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003130
@@ -20335,6 +21380,7 @@ def: "ProSight proteoform-level Q-value." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1003129 ! proteoform-level Q-value
 relationship: has_order MS:1002109 ! lower score better
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003131
@@ -20355,6 +21401,7 @@ def: "Estimation of the Q-value for isoforms." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1003132 ! isoform-level identification statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003134
@@ -20363,6 +21410,7 @@ def: "ProSight isoform-level Q-value." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1003133 ! isoform-level Q-value
 relationship: has_order MS:1002109 ! lower score better
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003135
@@ -20371,6 +21419,7 @@ def: "ProSight protein-level Q-value." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001869 ! protein-level q-value
 relationship: has_order MS:1002109 ! lower score better
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003136
@@ -20391,6 +21440,7 @@ def: "If true, runs delta m mode in ProSight." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1003136 ! ProSight input parameter
 is_a: MS:1003137 ! TDPortal input parameter
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003139
@@ -20399,6 +21449,7 @@ def: "If true, runs Subsequence Search mode in ProSight." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1003136 ! ProSight input parameter
 is_a: MS:1003137 ! TDPortal input parameter
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003140
@@ -20407,6 +21458,7 @@ def: "If true, runs Annotated Proteoform Search mode in ProSight." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1003136 ! ProSight input parameter
 is_a: MS:1003137 ! TDPortal input parameter
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003141
@@ -20481,6 +21533,7 @@ name: SHA-256
 def: "SHA-256 (member of Secure Hash Algorithm-2 family) is a cryptographic hash function designed by the National Security Agency (NSA) and published by the NIST as a U. S. government standard. It is also used to verify file integrity." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000561 ! data file checksum type
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003152
@@ -20496,6 +21549,7 @@ xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002893 ! ion mobility array
 relationship: has_units UO:0000028 ! millisecond
 relationship: has_units UO:0000010 ! second
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003154
@@ -20505,6 +21559,7 @@ xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002893 ! ion mobility array
 relationship: has_units UO:0000028 ! millisecond
 relationship: has_units UO:0000010 ! second
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003155
@@ -20513,6 +21568,7 @@ def: "Array of ion mobility values based on ion separation in gaseous phase due 
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002893 ! ion mobility array
 relationship: has_units MS:1002814 ! volt-second per square centimeter
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003156
@@ -20522,6 +21578,7 @@ xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002893 ! ion mobility array
 relationship: has_units UO:0000028 ! millisecond
 relationship: has_units UO:0000010 ! second
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003157
@@ -20530,6 +21587,7 @@ def: "Array of m/z values representing the lower bound m/z of the quadrupole pos
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000513 ! binary data array
 relationship: has_units MS:1000040 ! m/z
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003158
@@ -20538,6 +21596,7 @@ def: "Array of m/z values representing the upper bound m/z of the quadrupole pos
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000513 ! binary data array
 relationship: has_units MS:1000040 ! m/z
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003159
@@ -20581,6 +21640,7 @@ name: DbName
 def: "PEFF keyword for the sequence database name." [PSI:PEFF]
 is_a: PEFF:0000002 ! PEFF file header section term
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0000009
@@ -20588,6 +21648,7 @@ name: Prefix
 def: "PEFF keyword for the sequence database prefix." [PSI:PEFF]
 is_a: PEFF:0000002 ! PEFF file header section term
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0000010
@@ -20595,6 +21656,7 @@ name: DbDescription
 def: "PEFF keyword for the sequence database short description." [PSI:PEFF]
 is_a: PEFF:0000002 ! PEFF file header section term
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0000011
@@ -20602,6 +21664,7 @@ name: Decoy
 def: "PEFF keyword for the specifying whether the sequence database is a decoy database." [PSI:PEFF]
 is_a: PEFF:0000002 ! PEFF file header section term
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0000012
@@ -20609,6 +21672,7 @@ name: DbSource
 def: "PEFF keyword for the source of the database file." [PSI:PEFF]
 is_a: PEFF:0000002 ! PEFF file header section term
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0000013
@@ -20616,6 +21680,7 @@ name: DbVersion
 def: "PEFF keyword for the database version (release date) according to database provider." [PSI:PEFF]
 is_a: PEFF:0000002 ! PEFF file header section term
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0000014
@@ -20631,6 +21696,7 @@ name: NumberOfEntries
 def: "PEFF keyword for the sumber of sequence entries in the database." [PSI:PEFF]
 is_a: PEFF:0000002 ! PEFF file header section term
 xref: value-type:xsd\:integer "The allowed value-type for this CV term."
+relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0000016
@@ -20638,6 +21704,7 @@ name: Conversion
 def: "PEFF keyword for the description of the conversion from original format to this current one." [PSI:PEFF]
 is_a: PEFF:0000002 ! PEFF file header section term
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0000017
@@ -20646,6 +21713,7 @@ def: "PEFF keyword for the molecular type of the sequences." [PSI:PEFF]
 is_a: PEFF:0000002 ! PEFF file header section term
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: has_regexp PEFF:1002002 ! regular expression for PEFF molecular sequence type
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0000018
@@ -20653,6 +21721,7 @@ name: SpecificKey
 def: "PEFF keyword for database specific keywords not included in the current controlled vocabulary." [PSI:PEFF]
 is_a: PEFF:0000002 ! PEFF file header section term
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0000019
@@ -20660,6 +21729,7 @@ name: SpecificValue
 def: "PEFF keyword for the specific values for a custom key." [PSI:PEFF]
 is_a: PEFF:0000002 ! PEFF file header section term
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0000020
@@ -20667,6 +21737,7 @@ name: DatabaseDescription
 def: "PEFF keyword for the short description of the PEFF file." [PSI:PEFF]
 is_a: PEFF:0000002 ! PEFF file header section term
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0000021
@@ -20674,6 +21745,7 @@ name: GeneralComment
 def: "PEFF keyword for a general comment." [PSI:PEFF]
 is_a: PEFF:0000002 ! PEFF file header section term
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0000022
@@ -20681,6 +21753,7 @@ name: ProteoformDb
 def: "PEFF keyword that when set to 'true' indicates that the database contains complete proteoforms." [PSI:PEFF]
 is_a: PEFF:0000002 ! PEFF file header section term
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0000023
@@ -20688,6 +21761,7 @@ name: OptionalTagDef
 def: "PEFF keyword for the short tag (abbreviation) and longer definition used to annotate a sequence annotation (such as variant or modification) in the OptionalTag location." [PSI:PEFF]
 is_a: PEFF:0000002 ! PEFF file header section term
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0000024
@@ -20695,6 +21769,7 @@ name: HasAnnotationIdentifiers
 def: "PEFF keyword that when set to 'true' indicates that entries in the database have identifiers for each annotation." [PSI:PEFF]
 is_a: PEFF:0000002 ! PEFF file header section term
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0001001
@@ -20704,6 +21779,7 @@ comment: This term was made obsolete because decided in Heidelberg 2018-04 that 
 is_a: PEFF:0000003 ! PEFF file sequence entry term
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_obsolete: true
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0001002
@@ -20711,6 +21787,7 @@ name: PName
 def: "PEFF keyword for the protein full name." [PSI:PEFF]
 is_a: PEFF:0000003 ! PEFF file sequence entry term
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0001003
@@ -20718,6 +21795,7 @@ name: NcbiTaxId
 def: "PEFF keyword for the NCBI taxonomy identifier." [PSI:PEFF]
 is_a: PEFF:0000003 ! PEFF file sequence entry term
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0001004
@@ -20725,6 +21803,7 @@ name: TaxName
 def: "PEFF keyword for the taxonomy name (latin or common name)." [PSI:PEFF]
 is_a: PEFF:0000003 ! PEFF file sequence entry term
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0001005
@@ -20732,6 +21811,7 @@ name: GName
 def: "PEFF keyword for the gene name." [PSI:PEFF]
 is_a: PEFF:0000003 ! PEFF file sequence entry term
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0001006
@@ -20739,6 +21819,7 @@ name: Length
 def: "PEFF keyword for the sequence length." [PSI:PEFF]
 is_a: PEFF:0000003 ! PEFF file sequence entry term
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0001007
@@ -20746,6 +21827,7 @@ name: SV
 def: "PEFF keyword for the sequence version." [PSI:PEFF]
 is_a: PEFF:0000003 ! PEFF file sequence entry term
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0001008
@@ -20753,6 +21835,7 @@ name: EV
 def: "PEFF keyword for the entry version." [PSI:PEFF]
 is_a: PEFF:0000003 ! PEFF file sequence entry term
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0001009
@@ -20760,6 +21843,7 @@ name: PE
 def: "PEFF keyword for the Protein Evidence; A UniProtKB code 1-5." [PSI:PEFF]
 is_a: PEFF:0000003 ! PEFF file sequence entry term
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0001010
@@ -20768,6 +21852,7 @@ def: "PEFF keyword for information on how the full length original protein seque
 is_a: PEFF:0000003 ! PEFF file sequence entry term
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: has_regexp PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0001011
@@ -20778,6 +21863,7 @@ is_a: PEFF:0000003 ! PEFF file sequence entry term
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: has_regexp PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
 is_obsolete: true
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0001012
@@ -20786,6 +21872,7 @@ def: "PEFF keyword for the modified residue with PSI-MOD identifier." [PSI:PEFF]
 is_a: PEFF:0000003 ! PEFF file sequence entry term
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: has_regexp PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0001013
@@ -20794,6 +21881,7 @@ def: "PEFF keyword for the modified residue without aPSI-MOD or UniMod identifie
 is_a: PEFF:0000003 ! PEFF file sequence entry term
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: has_regexp PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0001014
@@ -20801,6 +21889,7 @@ name: AltAC
 def: "PEFF keyword for the Alternative Accession Code." [PSI:PEFF]
 is_a: PEFF:0000003 ! PEFF file sequence entry term
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0001015
@@ -20809,6 +21898,7 @@ def: "PEFF keyword for the sequence status. Complete or Fragment." [PSI:PEFF]
 is_a: PEFF:0000003 ! PEFF file sequence entry term
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: has_regexp PEFF:1002003 ! regular expression for PEFF sequence status
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0001016
@@ -20816,6 +21906,7 @@ name: CC
 def: "PEFF keyword for the entry associated comment." [PSI:PEFF]
 is_a: PEFF:0000003 ! PEFF file sequence entry term
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0001017
@@ -20823,6 +21914,7 @@ name: KW
 def: "PEFF keyword for the entry associated keyword(s)." [PSI:PEFF]
 is_a: PEFF:0000003 ! PEFF file sequence entry term
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0001018
@@ -20830,6 +21922,7 @@ name: GO
 def: "PEFF keyword for the Gene Ontology code." [PSI:PEFF]
 is_a: PEFF:0000003 ! PEFF file sequence entry term
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0001019
@@ -20837,6 +21930,7 @@ name: XRef
 def: "PEFF keyword for the cross-reference to an external resource." [PSI:PEFF]
 is_a: PEFF:0000003 ! PEFF file sequence entry term
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0001020
@@ -20845,6 +21939,7 @@ def: "Portion of a newly synthesized protein that contributes to a final structu
 is_a: PEFF:0001032 ! PEFF molecule processing keyword
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: has_regexp PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0001021
@@ -20853,6 +21948,7 @@ def: "Short peptide present at the N-terminus of a newly synthesized protein tha
 is_a: PEFF:0001032 ! PEFF molecule processing keyword
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: has_regexp PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0001022
@@ -20861,6 +21957,7 @@ def: "Short peptide present at the N-terminus of a newly synthesized protein tha
 is_a: PEFF:0001032 ! PEFF molecule processing keyword
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: has_regexp PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0001023
@@ -20869,6 +21966,7 @@ def: "PEFF keyword for the sequence conflict; a UniProtKB term." [PSI:PEFF]
 is_a: PEFF:0000003 ! PEFF file sequence entry term
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: has_regexp PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0001024
@@ -20876,6 +21974,7 @@ name: Crc64
 def: "PEFF keyword for the Sequence checksum in crc64." [PSI:PEFF]
 is_a: PEFF:0000003 ! PEFF file sequence entry term
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0001025
@@ -20883,6 +21982,7 @@ name: Domain
 def: "PEFF keyword for the sequence range of a domain." [PSI:PEFF]
 is_a: PEFF:0000003 ! PEFF file sequence entry term
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0001026
@@ -20890,6 +21990,7 @@ name: ID
 def: "PEFF keyword for the UniProtKB specific Protein identifier ID; a UniProtKB term." [PSI:PEFF]
 is_a: PEFF:0000003 ! PEFF file sequence entry term
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0001027
@@ -20898,6 +21999,7 @@ def: "PEFF keyword for the modified residue with UniMod identifier." [PSI:PEFF]
 is_a: PEFF:0000003 ! PEFF file sequence entry term
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: has_regexp PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0001028
@@ -20906,6 +22008,7 @@ def: "PEFF keyword for the simple sequence variation of a single amino acid chan
 is_a: PEFF:0000003 ! PEFF file sequence entry term
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: has_regexp PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0001029
@@ -20914,6 +22017,7 @@ def: "PEFF keyword for a sequence variation that is more complex than a single a
 is_a: PEFF:0000003 ! PEFF file sequence entry term
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: has_regexp PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0001030
@@ -20921,6 +22025,7 @@ name: Proteoform
 def: "PEFF keyword for the proteoforms of this protein, constructed as a set of annotation identifiers." [PSI:PEFF]
 is_a: PEFF:0000003 ! PEFF file sequence entry term
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0001031
@@ -20928,6 +22033,7 @@ name: DisulfideBond
 def: "PEFF keyword for the disulfide bonds in this protein, constructed as a sets of annotation identifiers of two half-cystine modifications." [PSI:PEFF]
 is_a: PEFF:0000003 ! PEFF file sequence entry term
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0001032
@@ -20941,6 +22047,7 @@ name: Comment
 def: "PEFF keyword for the individual protein entry comment. It is discouraged to put parsable information here. This is only for free-text commentary." [PSI:PEFF]
 is_a: PEFF:0000003 ! PEFF file sequence entry term
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0001034
@@ -20949,6 +22056,7 @@ def: "Short peptide that is cleaved off a newly synthesized protein and generall
 is_a: PEFF:0001032 ! PEFF molecule processing keyword
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: has_regexp PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0001035
@@ -20957,6 +22065,7 @@ def: "N-terminal methionine residue of a protein that can be co-translationally 
 is_a: PEFF:0001032 ! PEFF molecule processing keyword
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: has_regexp PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:1002001

--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -17814,12 +17814,6 @@ def: "A data type defining a list of values of a single type." []
 is_a: MS:1002709 ! compound data type
 
 [Term]
-id: MS:1002710
-name: list of type
-def: "A data type defining a list of values of a single type." []
-is_a: MS:1002709 ! compound data type
-
-[Term]
 id: MS:1002711
 name: list of strings
 def: "A list of xsd:string." []

--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -1,5 +1,5 @@
 format-version: 1.2
-data-version: 4.1.56
+data-version: 4.1.57
 date: 02:07:2021 00:00
 saved-by: Joshua Klein
 auto-generated-by: OBO-Edit 2.3.1

--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -18559,6 +18559,38 @@ is_a: MS:1001045 ! cleavage agent name
 relationship: has_regexp MS:1002707 ! (?=[KR])
 
 [Term]
+id: MS:1002709
+name: compound data type
+def: "A data type representing more than a single value." []
+
+[Term]
+id: MS:1002710
+name: list of type
+def: "A data type defining a list of values of a single type." []
+is_a: MS:1002709 ! compound data type
+
+[Term]
+id: MS:1002711
+name: list of strings
+def: "A list of xsd:string." []
+is_a: MS:1002710 ! list of type
+relationship: has_value_type: xsd\:string
+
+[Term]
+id: MS:1002712
+name: list of integers
+def: "A list of xsd:integer." []
+is_a: MS:1002710 ! list of type
+relationship: has_value_type: xsd\:integer
+
+[Term]
+id: MS:1002713
+name: list of floats
+def: "A list of xsd:float." []
+is_a: MS:1002710 ! list of type
+relationship: has_value_type: xsd\:float
+
+[Term]
 id: MS:1002719
 name: Pegasus BT
 def: "LECO bench-top GC time-of-flight mass spectrometer." [PSI:PI]
@@ -21615,6 +21647,13 @@ id: MS:1003161
 name: quality control data format
 def: "Grouping term for quality control data formats." [PSI:MS]
 is_a: MS:1001459 ! file format
+
+[Term]
+id: MS:1003162
+name: analyte mixture members
+def: "The set of analyte identifiers that compose an interpretation of a spectrum." [PSI:PI]
+is_a: MS:1003078 ! interpreted spectrum attribute
+relationship: has_value_type MS:1002712 ! list of integers
 
 [Term]
 id: PEFF:0000001

--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -72,7 +72,7 @@ name: sample number
 def: "A reference number relevant to the sample under study." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000548 ! sample attribute
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000002
@@ -80,7 +80,7 @@ name: sample name
 def: "A reference string relevant to the sample under study." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000548 ! sample attribute
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000003
@@ -94,8 +94,8 @@ name: sample mass
 def: "Total mass of sample used." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000548 ! sample attribute
-relationship: has_units: UO:0000021 ! gram
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units UO:0000021 ! gram
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000005
@@ -103,8 +103,8 @@ name: sample volume
 def: "Total volume of solution used." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000548 ! sample attribute
-relationship: has_units: UO:0000098 ! milliliter
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units UO:0000098 ! milliliter
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000006
@@ -112,20 +112,20 @@ name: sample concentration
 def: "Concentration of sample in picomol/ul, femtomol/ul or attomol/ul solution used." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000548 ! sample attribute
-relationship: has_units: UO:0000175 ! gram per liter
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units UO:0000175 ! gram per liter
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000007
 name: inlet type
 def: "The nature of the sample inlet." [PSI:MS]
-relationship: part_of: MS:1000458 ! source
+relationship: part_of MS:1000458 ! source
 
 [Term]
 id: MS:1000008
 name: ionization type
 def: "The method by which gas phase ions are generated from the sample." [PSI:MS]
-relationship: part_of: MS:1000458 ! source
+relationship: part_of MS:1000458 ! source
 
 [Term]
 id: MS:1000009
@@ -143,7 +143,7 @@ name: mass resolution
 def: "Smallest mass difference between two equal magnitude peaks so that the valley between them is a specified fraction of the peak height." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000503 ! scan attribute
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000012
@@ -162,9 +162,9 @@ name: accuracy
 def: "Accuracy is the degree of conformity of a measured mass to its actual value." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000480 ! mass analyzer attribute
-relationship: has_units: MS:1000040 ! m/z
-relationship: has_units: UO:0000169 ! parts per million
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units MS:1000040 ! m/z
+relationship: has_units UO:0000169 ! parts per million
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000015
@@ -172,8 +172,8 @@ name: scan rate
 def: "Rate in Th/sec for scanning analyzers." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000503 ! scan attribute
-relationship: has_units: MS:1000807 ! Th/s
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units MS:1000807 ! Th/s
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000016
@@ -182,9 +182,9 @@ def: "The time that an analyzer started a scan, relative to the start of the MS 
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000503 ! scan attribute
 is_a: MS:1002345 ! PSM-level attribute
-relationship: has_units: UO:0000010 ! second
-relationship: has_units: UO:0000031 ! minute
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units UO:0000010 ! second
+relationship: has_units UO:0000031 ! minute
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000017
@@ -195,13 +195,13 @@ def: "OBSOLETE Describes the type of mass analysis being performed. Two primary 
 id: MS:1000018
 name: scan direction
 def: "Direction in terms of m/z of the scan for scanning analyzers (low to high, or high to low)." [PSI:MS]
-relationship: part_of: MS:1000441 ! scan
+relationship: part_of MS:1000441 ! scan
 
 [Term]
 id: MS:1000019
 name: scan law
 def: "Describes the function in control of the m/z scan (for scanning instruments). Commonly the scan function is linear, but in principle any function can be used." [PSI:MS]
-relationship: part_of: MS:1000441 ! scan
+relationship: part_of MS:1000441 ! scan
 
 [Term]
 id: MS:1000020
@@ -220,16 +220,16 @@ name: TOF Total Path Length
 def: "The length of the field free drift space in a time of flight mass spectrometer." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000480 ! mass analyzer attribute
-relationship: has_units: UO:0000008 ! meter
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units UO:0000008 ! meter
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000023
 name: isolation width
 def: "OBSOLETE The total width (i.e. not half for plus-or-minus) of the gate applied around a selected precursor ion." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
-relationship: has_units: MS:1000040 ! m/z
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units MS:1000040 ! m/z
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000024
@@ -237,7 +237,7 @@ name: final MS exponent
 def: "Final MS level achieved when performing PFF with the ion trap (e.g. MS E10)." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1000480 ! mass analyzer attribute
-relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000025
@@ -245,20 +245,20 @@ name: magnetic field strength
 def: "A property of space that produces a force on a charged particle equal to qv x B where q is the particle charge and v its velocity." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000480 ! mass analyzer attribute
-relationship: has_units: UO:0000228 ! tesla
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units UO:0000228 ! tesla
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000026
 name: detector type
 def: "Type of detector used in the mass spectrometer." [PSI:MS]
-relationship: part_of: MS:1000453 ! detector
+relationship: part_of MS:1000453 ! detector
 
 [Term]
 id: MS:1000027
 name: detector acquisition mode
 def: "Method by which detector signal is acquired by the data system." [PSI:MS]
-relationship: part_of: MS:1000453 ! detector
+relationship: part_of MS:1000453 ! detector
 
 [Term]
 id: MS:1000028
@@ -266,7 +266,7 @@ name: detector resolution
 def: "The resolving power of the detector to detect the smallest difference between two ions so that the valley between them is a specified fraction of the peak height." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000481 ! detector attribute
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000029
@@ -274,8 +274,8 @@ name: sampling frequency
 def: "The rate of signal sampling (measurement) with respect to time." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000481 ! detector attribute
-relationship: has_units: UO:0000106 ! hertz
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units UO:0000106 ! hertz
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000030
@@ -286,7 +286,7 @@ def: "OBSOLETE Name of instrument vendor." [PSI:MS]
 id: MS:1000031
 name: instrument model
 def: "Instrument model name not including the vendor's name." [PSI:MS]
-relationship: part_of: MS:1000463 ! instrument
+relationship: part_of MS:1000463 ! instrument
 
 [Term]
 id: MS:1000032
@@ -294,7 +294,7 @@ name: customization
 def: "Free text description of a single customization made to the instrument; for several modifications, use several entries." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000496 ! instrument attribute
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000033
@@ -347,7 +347,7 @@ def: "Number of net charges, positive or negative, on an ion." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1000455 ! ion selection attribute
 is_a: MS:1000507 ! ion property
-relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000042
@@ -355,13 +355,13 @@ name: peak intensity
 def: "Intensity of ions as measured by the height or area of a peak in a mass spectrum." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000455 ! ion selection attribute
-relationship: has_units: MS:1000131 ! number of detector counts
-relationship: has_units: MS:1000132 ! percent of base peak
-relationship: has_units: MS:1000814 ! counts per second
-relationship: has_units: MS:1000905 ! percent of base peak times 100
-relationship: has_units: UO:0000269 ! absorbance unit
-relationship: part_of: MS:1000231 ! peak
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units MS:1000131 ! number of detector counts
+relationship: has_units MS:1000132 ! percent of base peak
+relationship: has_units MS:1000814 ! counts per second
+relationship: has_units MS:1000905 ! percent of base peak times 100
+relationship: has_units UO:0000269 ! absorbance unit
+relationship: part_of MS:1000231 ! peak
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000043
@@ -373,7 +373,7 @@ is_a: UO:0000000 ! unit
 id: MS:1000044
 name: dissociation method
 def: "Fragmentation method used for dissociation or fragmentation." [PSI:MS]
-relationship: part_of: MS:1000456 ! precursor activation
+relationship: part_of MS:1000456 ! precursor activation
 
 [Term]
 id: MS:1000045
@@ -381,8 +381,8 @@ name: collision energy
 def: "Energy for an ion experiencing collision with a stationary gas particle resulting in dissociation of the ion." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000510 ! precursor activation attribute
-relationship: has_units: UO:0000266 ! electronvolt
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units UO:0000266 ! electronvolt
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000046
@@ -432,7 +432,7 @@ name: sample batch
 def: "Sample batch lot identifier." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000548 ! sample attribute
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000054
@@ -894,7 +894,7 @@ name: percent of base peak
 def: "The magnitude of a peak or measurement element expressed in terms of the percentage of the magnitude of the base peak intensity." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000043 ! intensity unit
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000133
@@ -931,8 +931,8 @@ name: normalized collision energy
 def: "Instrument setting, expressed in percent, for adjusting collisional energies of ions in an effort to provide equivalent excitation of all ions." [PSI:PI]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000510 ! precursor activation attribute
-relationship: has_units: UO:0000187 ! percent
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units UO:0000187 ! percent
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000139
@@ -1346,24 +1346,24 @@ id: MS:1000207
 name: accurate mass
 def: "OBSOLETE An experimentally determined mass that is can be to determine a unique elemental formula. For ions less than 200 u, a measurement with 5 ppm accuracy is sufficient to determine the elemental composition." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
-relationship: has_units: UO:0000002 ! mass unit
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units UO:0000002 ! mass unit
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000208
 name: average mass
 def: "OBSOLETE The mass of an ion or molecule calculated using the average mass of each element weighted for its natural isotopic abundance." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
-relationship: has_units: UO:0000002 ! mass unit
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units UO:0000002 ! mass unit
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000209
 name: appearance energy
 def: "OBSOLETE The minimum energy that must be imparted to an atom or molecule to produce a specified ion. The term appearance potential is not recommended." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
-relationship: has_units: UO:0000266 ! electronvolt
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units UO:0000266 ! electronvolt
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000210
@@ -1376,7 +1376,7 @@ id: MS:1000211
 name: OBSOLETE charge number
 def: "OBSOLETE The total charge on an ion divided by the electron charge e. OBSOLETED 2009-10-27 since this was viewed as a duplication of 00041 charge state." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
-relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000212
@@ -1388,7 +1388,7 @@ id: MS:1000213
 name: electron affinity
 def: "OBSOLETE The electron affinity of M is the minimum energy required for the process M- ? M + e where M- and M are in their ground rotational, vibrational and electronic states and the electron has zero kinetic energy." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000214
@@ -1400,8 +1400,8 @@ id: MS:1000215
 name: exact mass
 def: "OBSOLETE The calculated mass of an ion or molecule containing a single isotope of each atom." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
-relationship: has_units: UO:0000002 ! mass unit
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units UO:0000002 ! mass unit
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000216
@@ -1419,15 +1419,15 @@ id: MS:1000218
 name: ionization efficiency
 def: "OBSOLETE The ratio of the number of ions formed to the number of electrons, molecules or photons used." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000219
 name: ionization energy
 def: "OBSOLETE The minimum energy required to remove an electron from an atom or molecule to produce a positive ion." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
-relationship: has_units: UO:0000266 ! electronvolt
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units UO:0000266 ! electronvolt
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000220
@@ -1445,15 +1445,15 @@ id: MS:1000222
 name: mass defect
 def: "OBSOLETE The difference between the monoisotopic and nominal mass of a molecule or atom." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
-relationship: has_units: UO:0000002 ! mass unit
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units UO:0000002 ! mass unit
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000223
 name: mass number
 def: "OBSOLETE The sum of the protons and neutrons in an atom, molecule or ion." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
-relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000224
@@ -1461,16 +1461,16 @@ name: molecular mass
 def: "Mass of a molecule measured in unified atomic mass units (u or Da)." [https://en.wikipedia.org/wiki/Molecular_mass]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000861 ! molecular entity property
-relationship: has_units: UO:0000002 ! mass unit
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units UO:0000002 ! mass unit
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000225
 name: monoisotopic mass
 def: "OBSOLETE The mass of an ion or molecule calculated using the mass of the most abundant isotope of each element." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
-relationship: has_units: UO:0000002 ! mass unit
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units UO:0000002 ! mass unit
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000226
@@ -1493,8 +1493,8 @@ id: MS:1000229
 name: nominal mass
 def: "OBSOLETE The mass of an ion or molecule calculated using the mass of the most abundant isotope of each element rounded to the nearest integer value." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
-relationship: has_units: UO:0000002 ! mass unit
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units UO:0000002 ! mass unit
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000230
@@ -1505,7 +1505,7 @@ def: "OBSOLETE Odd-electron ions may dissociate to form either odd or even-elect
 id: MS:1000231
 name: peak
 def: "A localized region of relatively large ion signal in a mass spectrum. Although peaks are often associated with particular ions, the terms peak and ion should not be used interchangeably." [PSI:MS]
-relationship: part_of: MS:1000442 ! spectrum
+relationship: part_of MS:1000442 ! spectrum
 
 [Term]
 id: MS:1000232
@@ -1517,14 +1517,14 @@ id: MS:1000233
 name: proton affinity
 def: "OBSOLETE The proton affinity of a species M is defined as the negative of the enthalpy change for the reaction M + H+ ->[M+H]+, where all species are in their ground rotational, vibrational and electronic states." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000234
 name: mass resolving power
 def: "OBSOLETE In a mass spectrum, the observed mass divided by the difference between two masses that can be separated. The method by which delta m was obtained and the mass at which the measurement was made should be reported." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000235
@@ -1538,7 +1538,7 @@ name: transmission
 def: "The ratio of the number of ions leaving a region of a mass spectrometer to the number entering that region." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000496 ! instrument attribute
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000237
@@ -1814,7 +1814,7 @@ name: total ion current
 def: "The sum of all the separate ion currents carried by the ions of different m/z contributing to a complete mass spectrum or in a specified m/z range of a mass spectrum." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1003058 ! spectrum property
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000286
@@ -1918,8 +1918,8 @@ name: accelerating voltage
 def: "The electrical potential used to impart kinetic energy to ions in a mass spectrometer." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000487 ! ion optics attribute
-relationship: has_units: UO:0000218 ! volt
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units UO:0000218 ! volt
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000305
@@ -1943,8 +1943,8 @@ name: electric field strength
 def: "The magnitude of the force per unit charge at a given point in space." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000487 ! ion optics attribute
-relationship: has_units: UO:0000268 ! volt per meter
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units UO:0000268 ! volt per meter
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000309
@@ -2096,7 +2096,7 @@ name: neutral loss
 def: "The loss of an uncharged species during a rearrangement process. The value slot holds the molecular formula in Hill notation of the neutral loss molecule, see PMID: 21182243. This term must be used in conjunction with a child of the term MS:1002307 (fragmentation ion type)." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001055 ! modification parameters
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000337
@@ -2399,7 +2399,7 @@ name: ionization efficiency
 def: "The ratio of the number of ions formed to the number of electrons, molecules or photons used." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000482 ! source attribute
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000393
@@ -2511,7 +2511,7 @@ name: buffer gas
 def: "An inert gas used for collisional deactivation of internally excited ions." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000510 ! precursor activation attribute
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000413
@@ -2549,7 +2549,7 @@ name: collision gas
 def: "An inert gas used for collisional excitation. The term target gas is not recommended." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000510 ! precursor activation attribute
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000420
@@ -2663,19 +2663,19 @@ def: "OBSOLETE Fragmentation reaction in which the molecularity is treated as on
 id: MS:1000441
 name: scan
 def: "Function or process of the mass spectrometer where it records a spectrum." [PSI:MS]
-relationship: part_of: MS:1001458 ! spectrum generation information
+relationship: part_of MS:1001458 ! spectrum generation information
 
 [Term]
 id: MS:1000442
 name: spectrum
 def: "Representation of intensity values corresponding to a range of measurement space." [PSI:MS]
-relationship: part_of: MS:1001458 ! spectrum generation information
+relationship: part_of MS:1001458 ! spectrum generation information
 
 [Term]
 id: MS:1000443
 name: mass analyzer type
 def: "Mass analyzer separates the ions according to their mass-to-charge ratio." [PSI:MS]
-relationship: part_of: MS:1000451 ! mass analyzer
+relationship: part_of MS:1000451 ! mass analyzer
 
 [Term]
 id: MS:1000444
@@ -2721,19 +2721,19 @@ is_a: MS:1000494 ! Thermo Scientific instrument model
 id: MS:1000451
 name: mass analyzer
 def: "Terms used to describe the Analyzer." [PSI:MS]
-relationship: part_of: MS:1000463 ! instrument
+relationship: part_of MS:1000463 ! instrument
 
 [Term]
 id: MS:1000452
 name: data transformation
 def: "Terms used to describe types of data processing." [PSI:MS]
-relationship: part_of: MS:1001458 ! spectrum generation information
+relationship: part_of MS:1001458 ! spectrum generation information
 
 [Term]
 id: MS:1000453
 name: detector
 def: "The device that detects ions." [PSI:MS]
-relationship: part_of: MS:1000463 ! instrument
+relationship: part_of MS:1000463 ! instrument
 
 [Term]
 id: MS:1000454
@@ -2745,25 +2745,25 @@ id: MS:1000455
 name: ion selection attribute
 def: "Ion selection properties that are associated with a value." [PSI:MS]
 is_a: MS:1000547 ! object attribute
-relationship: part_of: MS:1000442 ! spectrum
+relationship: part_of MS:1000442 ! spectrum
 
 [Term]
 id: MS:1000456
 name: precursor activation
 def: "Terms to describe the precursor activation." [PSI:MS]
-relationship: part_of: MS:1000442 ! spectrum
+relationship: part_of MS:1000442 ! spectrum
 
 [Term]
 id: MS:1000457
 name: sample
 def: "Terms to describe the sample." [PSI:MS]
-relationship: part_of: MS:1001458 ! spectrum generation information
+relationship: part_of MS:1001458 ! spectrum generation information
 
 [Term]
 id: MS:1000458
 name: source
 def: "Terms to describe the source." [PSI:MS]
-relationship: part_of: MS:1000463 ! instrument
+relationship: part_of MS:1000463 ! instrument
 
 [Term]
 id: MS:1000459
@@ -2774,7 +2774,7 @@ def: "OBSOLETE Terms used to describe the spectrum." [PSI:MS]
 id: MS:1000460
 name: unit
 def: "OBSOLETE Terms to describe units." [PSI:MS]
-relationship: part_of: MS:1001458 ! spectrum generation information
+relationship: part_of MS:1001458 ! spectrum generation information
 
 [Term]
 id: MS:1000461
@@ -2785,13 +2785,13 @@ def: "OBSOLETE Terms to describe Additional." [PSI:MS]
 id: MS:1000462
 name: ion optics
 def: "Device used in the construction of a mass spectrometer to focus, contain or otherwise manipulate ions." [PSI:MS]
-relationship: part_of: MS:1000463 ! instrument
+relationship: part_of MS:1000463 ! instrument
 
 [Term]
 id: MS:1000463
 name: instrument
 def: "Description of the instrument or the mass spectrometer." [PSI:MS]
-relationship: part_of: MS:1001458 ! spectrum generation information
+relationship: part_of MS:1001458 ! spectrum generation information
 
 [Term]
 id: MS:1000464
@@ -2802,7 +2802,7 @@ def: "OBSOLETE A unit of measurement for mass." [PSI:MS]
 id: MS:1000465
 name: scan polarity
 def: "Relative orientation of the electromagnetic field during the selection and detection of ions in the mass spectrometer." [PSI:MS]
-relationship: part_of: MS:1000441 ! scan
+relationship: part_of MS:1000441 ! scan
 
 [Term]
 id: MS:1000466
@@ -2890,19 +2890,19 @@ def: "OBSOLETE Terms that will likely become obsolete unless there are wails of 
 id: MS:1000480
 name: mass analyzer attribute
 def: "Analyzer properties that are associated with a value." [PSI:MS]
-relationship: part_of: MS:1000451 ! mass analyzer
+relationship: part_of MS:1000451 ! mass analyzer
 
 [Term]
 id: MS:1000481
 name: detector attribute
 def: "Detector attribute recognized as a value." [PSI:MS]
-relationship: part_of: MS:1000453 ! detector
+relationship: part_of MS:1000453 ! detector
 
 [Term]
 id: MS:1000482
 name: source attribute
 def: "Property of a source device that need a value." [PSI:MS]
-relationship: part_of: MS:1000458 ! source
+relationship: part_of MS:1000458 ! source
 
 [Term]
 id: MS:1000483
@@ -2928,8 +2928,8 @@ name: source potential
 def: "Potential difference at the MS source in volts." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000482 ! source attribute
-relationship: has_units: UO:0000218 ! volt
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units UO:0000218 ! volt
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000487
@@ -2990,7 +2990,7 @@ id: MS:1000496
 name: instrument attribute
 def: "Instrument properties that are associated with a value." [PSI:MS]
 is_a: MS:1000547 ! object attribute
-relationship: part_of: MS:1000463 ! instrument
+relationship: part_of MS:1000463 ! instrument
 
 [Term]
 id: MS:1000497
@@ -3007,7 +3007,7 @@ def: "OBSOLETE Feature of the ion trap mass spectrometer where MS data is acquir
 id: MS:1000499
 name: spectrum attribute
 def: "Nonphysical characteristic attributed to a spectrum." [PSI:MS]
-relationship: part_of: MS:1000442 ! spectrum
+relationship: part_of MS:1000442 ! spectrum
 
 [Term]
 id: MS:1000500
@@ -3015,8 +3015,8 @@ name: scan window upper limit
 def: "The lower m/z bound of a mass spectrometer scan window." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000549 ! selection window attribute
-relationship: has_units: MS:1000040 ! m/z
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units MS:1000040 ! m/z
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000501
@@ -3024,8 +3024,8 @@ name: scan window lower limit
 def: "The upper m/z bound of a mass spectrometer scan window." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000549 ! selection window attribute
-relationship: has_units: MS:1000040 ! m/z
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units MS:1000040 ! m/z
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000502
@@ -3033,16 +3033,16 @@ name: dwell time
 def: "The time spent gathering data across a peak." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000503 ! scan attribute
-relationship: has_units: UO:0000010 ! second
-relationship: has_units: UO:0000031 ! minute
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units UO:0000010 ! second
+relationship: has_units UO:0000031 ! minute
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000503
 name: scan attribute
 def: "Nonphysical characteristic attributed to a spectrum acquisition scan." [PSI:MS]
 is_a: MS:1000547 ! object attribute
-relationship: part_of: MS:1000441 ! scan
+relationship: part_of MS:1000441 ! scan
 
 [Term]
 id: MS:1000504
@@ -3050,8 +3050,8 @@ name: base peak m/z
 def: "M/z value of the signal of highest intensity in the mass spectrum." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1003058 ! spectrum property
-relationship: has_units: MS:1000040 ! m/z
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units MS:1000040 ! m/z
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000505
@@ -3059,12 +3059,12 @@ name: base peak intensity
 def: "The intensity of the greatest peak in the mass spectrum." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1003058 ! spectrum property
-relationship: has_units: MS:1000131 ! number of detector counts
-relationship: has_units: MS:1000132 ! percent of base peak
-relationship: has_units: MS:1000814 ! counts per second
-relationship: has_units: MS:1000905 ! percent of base peak times 100
-relationship: has_units: UO:0000269 ! absorbance unit
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units MS:1000131 ! number of detector counts
+relationship: has_units MS:1000132 ! percent of base peak
+relationship: has_units MS:1000814 ! counts per second
+relationship: has_units MS:1000905 ! percent of base peak times 100
+relationship: has_units UO:0000269 ! absorbance unit
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000506
@@ -3075,7 +3075,7 @@ def: "OBSOLETE Ion Role." [PSI:MS]
 id: MS:1000507
 name: ion property
 def: "Nonphysical characteristic attributed to an ion." [PSI:MS]
-relationship: part_of: MS:1002806 ! ion
+relationship: part_of MS:1002806 ! ion
 
 [Term]
 id: MS:1000508
@@ -3088,14 +3088,14 @@ name: activation energy
 def: "Activation Energy." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000510 ! precursor activation attribute
-relationship: has_units: UO:0000266 ! electronvolt
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units UO:0000266 ! electronvolt
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000510
 name: precursor activation attribute
 def: "Precursor Activation Attribute." [PSI:MS]
-relationship: part_of: MS:1000456 ! precursor activation
+relationship: part_of MS:1000456 ! precursor activation
 
 [Term]
 id: MS:1000511
@@ -3103,7 +3103,7 @@ name: ms level
 def: "Stage number achieved in a multi stage mass spectrometry acquisition." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1000499 ! spectrum attribute
-relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000512
@@ -3111,14 +3111,14 @@ name: filter string
 def: "A string unique to Thermo instrument describing instrument settings for the scan." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000503 ! scan attribute
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000513
 name: binary data array
 def: "A data array of values." [PSI:MS]
-relationship: part_of: MS:1000442 ! spectrum
-relationship: part_of: MS:1000625 ! chromatogram
+relationship: part_of MS:1000442 ! spectrum
+relationship: part_of MS:1000625 ! chromatogram
 
 [Term]
 id: MS:1000514
@@ -3127,7 +3127,7 @@ def: "A data array of m/z values." [PSI:MS]
 xref: binary-data-type:MS\:1000521 "32-bit float"
 xref: binary-data-type:MS\:1000523 "64-bit float"
 is_a: MS:1000513 ! binary data array
-relationship: has_units: MS:1000040 ! m/z
+relationship: has_units MS:1000040 ! m/z
 
 [Term]
 id: MS:1000515
@@ -3136,11 +3136,11 @@ def: "A data array of intensity values." [PSI:MS]
 xref: binary-data-type:MS\:1000521 "32-bit float"
 xref: binary-data-type:MS\:1000523 "64-bit float"
 is_a: MS:1000513 ! binary data array
-relationship: has_units: MS:1000131 ! number of detector counts
-relationship: has_units: MS:1000132 ! percent of base peak
-relationship: has_units: MS:1000814 ! counts per second
-relationship: has_units: MS:1000905 ! percent of base peak times 100
-relationship: has_units: UO:0000269 ! absorbance unit
+relationship: has_units MS:1000131 ! number of detector counts
+relationship: has_units MS:1000132 ! percent of base peak
+relationship: has_units MS:1000814 ! counts per second
+relationship: has_units MS:1000905 ! percent of base peak times 100
+relationship: has_units UO:0000269 ! absorbance unit
 
 [Term]
 id: MS:1000516
@@ -3161,8 +3161,8 @@ is_a: MS:1000513 ! binary data array
 id: MS:1000518
 name: binary data type
 def: "Encoding type of binary data specifying the binary representation and precision, e.g. 64-bit float." [PSI:MS]
-relationship: part_of: MS:1000442 ! spectrum
-relationship: part_of: MS:1000625 ! chromatogram
+relationship: part_of MS:1000442 ! spectrum
+relationship: part_of MS:1000625 ! chromatogram
 
 [Term]
 id: MS:1000519
@@ -3198,13 +3198,13 @@ is_a: MS:1000518 ! binary data type
 id: MS:1000524
 name: data file content
 def: "Describes the data content on the file." [PSI:MS]
-relationship: part_of: MS:1000577 ! source data file
+relationship: part_of MS:1000577 ! source data file
 
 [Term]
 id: MS:1000525
 name: spectrum representation
 def: "Way in which the spectrum is represented, either with regularly spaced data points or with a list of centroided peaks." [PSI:MS]
-relationship: part_of: MS:1000442 ! spectrum
+relationship: part_of MS:1000442 ! spectrum
 
 [Term]
 id: MS:1000526
@@ -3219,8 +3219,8 @@ def: "Highest m/z value observed in the m/z array." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000808 ! chromatogram attribute
 is_a: MS:1003058 ! spectrum property
-relationship: has_units: MS:1000040 ! m/z
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units MS:1000040 ! m/z
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000528
@@ -3229,8 +3229,8 @@ def: "Lowest m/z value observed in the m/z array." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000808 ! chromatogram attribute
 is_a: MS:1003058 ! spectrum property
-relationship: has_units: MS:1000040 ! m/z
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units MS:1000040 ! m/z
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000529
@@ -3238,7 +3238,7 @@ name: instrument serial number
 def: "Serial Number of the instrument." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000496 ! instrument attribute
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000530
@@ -3250,7 +3250,7 @@ is_a: MS:1000452 ! data transformation
 id: MS:1000531
 name: software
 def: "Software related to the recording or transformation of spectra." [PSI:MS]
-relationship: part_of: MS:0000000 ! Proteomics Standards Initiative Mass Spectrometry Vocabularies
+relationship: part_of MS:0000000 ! Proteomics Standards Initiative Mass Spectrometry Vocabularies
 
 [Term]
 id: MS:1000532
@@ -3366,21 +3366,21 @@ is_a: MS:1000530 ! file format conversion
 id: MS:1000547
 name: object attribute
 def: "Object Attribute." [PSI:MS]
-relationship: part_of: MS:1001458 ! spectrum generation information
+relationship: part_of MS:1001458 ! spectrum generation information
 
 [Term]
 id: MS:1000548
 name: sample attribute
 def: "Sample properties that are associated with a value." [PSI:MS]
 is_a: MS:1000547 ! object attribute
-relationship: part_of: MS:1000457 ! sample
+relationship: part_of MS:1000457 ! sample
 
 [Term]
 id: MS:1000549
 name: selection window attribute
 def: "Selection window properties that are associated with a value." [PSI:MS]
 is_a: MS:1000547 ! object attribute
-relationship: part_of: MS:1000441 ! scan
+relationship: part_of MS:1000441 ! scan
 
 [Term]
 id: MS:1000550
@@ -3441,7 +3441,7 @@ is_a: MS:1000125 ! Thermo Finnigan instrument model
 id: MS:1000559
 name: spectrum type
 def: "Spectrum type." [PSI:MS]
-relationship: part_of: MS:1000442 ! spectrum
+relationship: part_of MS:1000442 ! spectrum
 
 [Term]
 id: MS:1000560
@@ -3453,7 +3453,7 @@ is_a: MS:1001459 ! file format
 id: MS:1000561
 name: data file checksum type
 def: "Checksum is a form of redundancy check, a simple way to protect the integrity of data by detecting errors in data." [PSI:MS]
-relationship: part_of: MS:1000577 ! source data file
+relationship: part_of MS:1000577 ! source data file
 
 [Term]
 id: MS:1000562
@@ -3497,7 +3497,7 @@ name: MD5
 def: "MD5 (Message-Digest algorithm 5) is a (now deprecated) cryptographic hash function with a 128-bit hash value used to check the integrity of files." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000561 ! data file checksum type
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000569
@@ -3505,13 +3505,13 @@ name: SHA-1
 def: "SHA-1 (Secure Hash Algorithm-1) is a cryptographic hash function designed by the National Security Agency (NSA). It is also used to verify file integrity. Since 2011 it has been deprecated by the NIST as a U. S. government standard." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000561 ! data file checksum type
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000570
 name: spectra combination
 def: "Method used to combine the mass spectra." [PSI:MS]
-relationship: part_of: MS:1000442 ! spectrum
+relationship: part_of MS:1000442 ! spectrum
 
 [Term]
 id: MS:1000571
@@ -3523,8 +3523,8 @@ is_a: MS:1000570 ! spectra combination
 id: MS:1000572
 name: binary data compression type
 def: "Compression Type." [PSI:MS]
-relationship: part_of: MS:1000442 ! spectrum
-relationship: part_of: MS:1000625 ! chromatogram
+relationship: part_of MS:1000442 ! spectrum
+relationship: part_of MS:1000625 ! chromatogram
 
 [Term]
 id: MS:1000573
@@ -3555,7 +3555,7 @@ id: MS:1000577
 name: source data file
 def: "Data file from which an entity is sourced." [PSI:MS]
 is_a: MS:1000499 ! spectrum attribute
-relationship: part_of: MS:1001458 ! spectrum generation information
+relationship: part_of MS:1001458 ! spectrum generation information
 
 [Term]
 id: MS:1000578
@@ -3604,7 +3604,7 @@ id: MS:1000585
 name: contact attribute
 def: "Details about a person or organization to contact in case of concern or discussion about the file." [PSI:MS]
 is_a: MS:1000547 ! object attribute
-relationship: part_of: MS:0000000 ! Proteomics Standards Initiative Mass Spectrometry Vocabularies
+relationship: part_of MS:0000000 ! Proteomics Standards Initiative Mass Spectrometry Vocabularies
 
 [Term]
 id: MS:1000586
@@ -3612,7 +3612,7 @@ name: contact name
 def: "Name of the contact person or organization." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000585 ! contact attribute
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000587
@@ -3620,7 +3620,7 @@ name: contact address
 def: "Postal address of the contact person or organization." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000585 ! contact attribute
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000588
@@ -3628,7 +3628,7 @@ name: contact URL
 def: "Uniform Resource Locator related to the contact person or organization." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000585 ! contact attribute
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000589
@@ -3636,7 +3636,7 @@ name: contact email
 def: "Email address of the contact person or organization." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000585 ! contact attribute
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000590
@@ -3644,7 +3644,7 @@ name: contact affiliation
 def: "Home institution of the contact person." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000585 ! contact attribute
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000591
@@ -3677,14 +3677,14 @@ def: "A data array of relative time offset values from a reference time." [PSI:M
 xref: binary-data-type:MS\:1000521 "32-bit float"
 xref: binary-data-type:MS\:1000523 "64-bit float"
 is_a: MS:1000513 ! binary data array
-relationship: has_units: UO:0000010 ! second
-relationship: has_units: UO:0000031 ! minute
+relationship: has_units UO:0000010 ! second
+relationship: has_units UO:0000031 ! minute
 
 [Term]
 id: MS:1000596
 name: measurement method
 def: "An attribute of resolution when recording the detector response in absence of the analyte." [PSI:MS]
-relationship: part_of: MS:1001458 ! spectrum generation information
+relationship: part_of MS:1001458 ! spectrum generation information
 
 [Term]
 id: MS:1000597
@@ -3810,7 +3810,7 @@ name: preset scan configuration
 def: "A user-defined scan configuration that specifies the instrumental settings in which a spectrum is acquired. An instrument may cycle through a list of preset scan configurations to acquire data. This is a more generic term for the Thermo \"scan event\", which is defined in the Thermo Xcalibur glossary as: a mass spectrometer scan that is defined by choosing the necessary scan parameter settings. Multiple scan events can be defined for each segment of time." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000503 ! scan attribute
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000617
@@ -3819,7 +3819,7 @@ def: "A data array of electromagnetic radiation wavelength values." [PSI:MS]
 xref: binary-data-type:MS\:1000521 "32-bit float"
 xref: binary-data-type:MS\:1000523 "64-bit float"
 is_a: MS:1000513 ! binary data array
-relationship: has_units: UO:0000018 ! nanometer
+relationship: has_units UO:0000018 ! nanometer
 
 [Term]
 id: MS:1000618
@@ -3828,8 +3828,8 @@ def: "Highest wavelength observed in an EMR spectrum." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1003058 ! spectrum property
 is_a: MS:1000808 ! chromatogram attribute
-relationship: has_units: UO:0000018 ! nanometer
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units UO:0000018 ! nanometer
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000619
@@ -3838,8 +3838,8 @@ def: "Lowest wavelength observed in an EMR spectrum." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1003058 ! spectrum property
 is_a: MS:1000808 ! chromatogram attribute
-relationship: has_units: UO:0000018 ! nanometer
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units UO:0000018 ! nanometer
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000620
@@ -3876,13 +3876,13 @@ is_a: MS:1000026 ! detector type
 id: MS:1000625
 name: chromatogram
 def: "Representation of a chromatographic separation attribute measurement versus time." [PSI:MS]
-relationship: part_of: MS:1001458 ! spectrum generation information
+relationship: part_of MS:1001458 ! spectrum generation information
 
 [Term]
 id: MS:1000626
 name: chromatogram type
 def: "Type of chromatogram measurement being represented." [PSI:MS]
-relationship: part_of: MS:1000625 ! chromatogram
+relationship: part_of MS:1000625 ! chromatogram
 
 [Term]
 id: MS:1000627
@@ -3902,18 +3902,18 @@ name: low intensity threshold
 def: "Threshold below which some action is taken." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000630 ! data processing parameter
-relationship: has_units: MS:1000131 ! number of detector counts
-relationship: has_units: MS:1000132 ! percent of base peak
-relationship: has_units: MS:1000814 ! counts per second
-relationship: has_units: MS:1000905 ! percent of base peak times 100
-relationship: has_units: UO:0000269 ! absorbance unit
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units MS:1000131 ! number of detector counts
+relationship: has_units MS:1000132 ! percent of base peak
+relationship: has_units MS:1000814 ! counts per second
+relationship: has_units MS:1000905 ! percent of base peak times 100
+relationship: has_units UO:0000269 ! absorbance unit
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000630
 name: data processing parameter
 def: "Data processing parameter used in the data processing performed on the data file." [PSI:MS]
-relationship: part_of: MS:1001458 ! spectrum generation information
+relationship: part_of MS:1001458 ! spectrum generation information
 
 [Term]
 id: MS:1000631
@@ -3921,12 +3921,12 @@ name: high intensity threshold
 def: "Threshold above which some action is taken." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000630 ! data processing parameter
-relationship: has_units: MS:1000131 ! number of detector counts
-relationship: has_units: MS:1000132 ! percent of base peak
-relationship: has_units: MS:1000814 ! counts per second
-relationship: has_units: MS:1000905 ! percent of base peak times 100
-relationship: has_units: UO:0000269 ! absorbance unit
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units MS:1000131 ! number of detector counts
+relationship: has_units MS:1000132 ! percent of base peak
+relationship: has_units MS:1000814 ! counts per second
+relationship: has_units MS:1000905 ! percent of base peak times 100
+relationship: has_units UO:0000269 ! absorbance unit
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000632
@@ -3940,7 +3940,7 @@ name: possible charge state
 def: "A possible charge state of the ion in a situation where the charge of an ion is known to be one of several possible values rather than a completely unknown value or determined to be a specific charge with reasonable certainty." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1000455 ! ion selection attribute
-relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000634
@@ -4686,8 +4686,8 @@ name: selected ion m/z
 def: "Mass-to-charge ratio of an selected ion." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000455 ! ion selection attribute
-relationship: has_units: MS:1000040 ! m/z
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units MS:1000040 ! m/z
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000745
@@ -4707,7 +4707,7 @@ name: completion time
 def: "The time that a data processing action was finished." [PSI:MS]
 xref: value-type:xsd\:dateTime "The allowed value-type for this CV term."
 is_a: MS:1000630 ! data processing parameter
-relationship: has_value_type: xsd\:dateTime ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:dateTime ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000748
@@ -4828,7 +4828,7 @@ is_a: MS:1000752 ! TOPP software
 id: MS:1000767
 name: native spectrum identifier format
 def: "Describes how the native spectrum identifiers are formated." [PSI:MS]
-relationship: part_of: MS:1000577 ! source data file
+relationship: part_of MS:1000577 ! source data file
 
 [Term]
 id: MS:1000768
@@ -4949,7 +4949,7 @@ xref: binary-data-type:MS\:1000523 "64-bit float"
 xref: binary-data-type:MS\:1001479 "null-terminated ASCII string"
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000513 ! binary data array
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000787
@@ -4957,12 +4957,12 @@ name: inclusive low intensity threshold
 def: "Threshold at or below which some action is taken." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000630 ! data processing parameter
-relationship: has_units: MS:1000131 ! number of detector counts
-relationship: has_units: MS:1000132 ! percent of base peak
-relationship: has_units: MS:1000814 ! counts per second
-relationship: has_units: MS:1000905 ! percent of base peak times 100
-relationship: has_units: UO:0000269 ! absorbance unit
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units MS:1000131 ! number of detector counts
+relationship: has_units MS:1000132 ! percent of base peak
+relationship: has_units MS:1000814 ! counts per second
+relationship: has_units MS:1000905 ! percent of base peak times 100
+relationship: has_units UO:0000269 ! absorbance unit
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000788
@@ -4970,12 +4970,12 @@ name: inclusive high intensity threshold
 def: "Threshold at or above which some action is taken." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000630 ! data processing parameter
-relationship: has_units: MS:1000131 ! number of detector counts
-relationship: has_units: MS:1000132 ! percent of base peak
-relationship: has_units: MS:1000814 ! counts per second
-relationship: has_units: MS:1000905 ! percent of base peak times 100
-relationship: has_units: UO:0000269 ! absorbance unit
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units MS:1000131 ! number of detector counts
+relationship: has_units MS:1000132 ! percent of base peak
+relationship: has_units MS:1000814 ! counts per second
+relationship: has_units MS:1000905 ! percent of base peak times 100
+relationship: has_units UO:0000269 ! absorbance unit
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000789
@@ -4999,7 +4999,7 @@ id: MS:1000792
 name: isolation window attribute
 def: "Isolation window parameter." [PSI:MS]
 is_a: MS:1000547 ! object attribute
-relationship: part_of: MS:1000441 ! scan
+relationship: part_of MS:1000441 ! scan
 
 [Term]
 id: MS:1000793
@@ -5007,8 +5007,8 @@ name: isolation window upper limit
 def: "OBSOLETE The highest m/z being isolated in an isolation window." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000792 ! isolation window attribute
-relationship: has_units: MS:1000040 ! m/z
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units MS:1000040 ! m/z
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000794
@@ -5016,8 +5016,8 @@ name: isolation window lower limit
 def: "OBSOLETE The lowest m/z being isolated in an isolation window." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000792 ! isolation window attribute
-relationship: has_units: MS:1000040 ! m/z
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units MS:1000040 ! m/z
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000795
@@ -5032,7 +5032,7 @@ def: "Free-form text title describing a spectrum, usually a series of key value 
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001405 ! spectrum identification result details
 is_a: MS:1000499 ! spectrum attribute
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000797
@@ -5041,7 +5041,7 @@ def: "A list of scan numbers and or scan ranges associated with a peak list. If 
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001405 ! spectrum identification result details
 is_a: MS:1003058 ! spectrum property
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000798
@@ -5050,7 +5050,7 @@ def: "A list of raw scans and or scan ranges used to generate a peak list. If po
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001405 ! spectrum identification result details
 is_a: MS:1003058 ! spectrum property
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000799
@@ -5058,7 +5058,7 @@ name: custom unreleased software tool
 def: "A software tool that has not yet been released. The value should describe the software. Please do not use this term for publicly available software - contact the PSI-MS working group in order to have another CV term added." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000531 ! software
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000800
@@ -5066,7 +5066,7 @@ name: mass resolving power
 def: "The observed mass divided by the difference between two masses that can be separated: m/dm. The procedure by which dm was obtained and the mass at which the measurement was made should be reported." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000503 ! scan attribute
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000801
@@ -5086,8 +5086,8 @@ name: analyzer scan offset
 def: "Offset between two analyzers in a constant neutral loss or neutral gain scan. The value corresponds to the neutral loss or neutral gain value." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000503 ! scan attribute
-relationship: has_units: MS:1000040 ! m/z
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units MS:1000040 ! m/z
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000804
@@ -5121,7 +5121,7 @@ id: MS:1000808
 name: chromatogram attribute
 def: "Chromatogram properties that are associated with a value." [PSI:MS]
 is_a: MS:1000547 ! object attribute
-relationship: part_of: MS:1000625 ! chromatogram
+relationship: part_of MS:1000625 ! chromatogram
 
 [Term]
 id: MS:1000809
@@ -5129,7 +5129,7 @@ name: chromatogram title
 def: "A free-form text title describing a chromatogram." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000808 ! chromatogram attribute
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000810
@@ -5202,7 +5202,7 @@ def: "A data array of flow rate measurements." [PSI:MS]
 xref: binary-data-type:MS\:1000521 "32-bit float"
 xref: binary-data-type:MS\:1000523 "64-bit float"
 is_a: MS:1000513 ! binary data array
-relationship: has_units: UO:0000271 ! microliters per minute
+relationship: has_units UO:0000271 ! microliters per minute
 
 [Term]
 id: MS:1000821
@@ -5211,7 +5211,7 @@ def: "A data array of pressure measurements." [PSI:MS]
 xref: binary-data-type:MS\:1000521 "32-bit float"
 xref: binary-data-type:MS\:1000523 "64-bit float"
 is_a: MS:1000513 ! binary data array
-relationship: has_units: UO:0000110 ! pascal
+relationship: has_units UO:0000110 ! pascal
 
 [Term]
 id: MS:1000822
@@ -5220,7 +5220,7 @@ def: "A data array of temperature measurements." [PSI:MS]
 xref: binary-data-type:MS\:1000521 "32-bit float"
 xref: binary-data-type:MS\:1000523 "64-bit float"
 is_a: MS:1000513 ! binary data array
-relationship: has_units: UO:0000012 ! kelvin
+relationship: has_units UO:0000012 ! kelvin
 
 [Term]
 id: MS:1000823
@@ -5246,9 +5246,9 @@ name: elution time
 def: "The time of elution from all used chromatographic columns (one or more) in the chromatographic separation step, relative to the start of the chromatography." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000503 ! scan attribute
-relationship: has_units: UO:0000010 ! second
-relationship: has_units: UO:0000031 ! minute
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units UO:0000010 ! second
+relationship: has_units UO:0000031 ! minute
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000827
@@ -5256,8 +5256,8 @@ name: isolation window target m/z
 def: "The primary or reference m/z about which the isolation window is defined." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000792 ! isolation window attribute
-relationship: has_units: MS:1000040 ! m/z
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units MS:1000040 ! m/z
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000828
@@ -5265,8 +5265,8 @@ name: isolation window lower offset
 def: "The extent of the isolation window in m/z below the isolation window target m/z. The lower and upper offsets may be asymmetric about the target m/z." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000792 ! isolation window attribute
-relationship: has_units: MS:1000040 ! m/z
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units MS:1000040 ! m/z
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000829
@@ -5274,27 +5274,27 @@ name: isolation window upper offset
 def: "The extent of the isolation window in m/z above the isolation window target m/z. The lower and upper offsets may be asymmetric about the target m/z." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000792 ! isolation window attribute
-relationship: has_units: MS:1000040 ! m/z
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units MS:1000040 ! m/z
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000831
 name: sample preparation
 def: "Properties of the preparation steps which took place before the measurement was performed." [PSI:MS]
 is_a: MS:1000547 ! object attribute
-relationship: part_of: MS:1000548 ! sample attribute
+relationship: part_of MS:1000548 ! sample attribute
 
 [Term]
 id: MS:1000832
 name: MALDI matrix application
 def: "Attributes to describe the technique how the sample is prepared with the matrix solution." [PSI:MS]
-relationship: part_of: MS:1000831 ! sample preparation
+relationship: part_of MS:1000831 ! sample preparation
 
 [Term]
 id: MS:1000833
 name: matrix application type
 def: "Describes the technique how the matrix is put on the sample target." [PSI:MS]
-relationship: part_of: MS:1000832 ! MALDI matrix application
+relationship: part_of MS:1000832 ! MALDI matrix application
 
 [Term]
 id: MS:1000834
@@ -5302,7 +5302,7 @@ name: matrix solution
 def: "Describes the chemical solution used as matrix." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000832 ! MALDI matrix application
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000835
@@ -5310,8 +5310,8 @@ name: matrix solution concentration
 def: "Concentration of the chemical solution used as matrix." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000832 ! MALDI matrix application
-relationship: has_units: UO:0000175 ! gram per liter
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units UO:0000175 ! gram per liter
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000836
@@ -5342,19 +5342,19 @@ is_a: MS:1001938 ! sample plate type
 id: MS:1000840
 name: laser
 def: "Device that emits light (electromagnetic radiation) through a process called stimulated emission. The term is an acronym for Light Amplification by Stimulated Emission of Radiation." [PSI:MS]
-relationship: part_of: MS:1000482 ! source attribute
+relationship: part_of MS:1000482 ! source attribute
 
 [Term]
 id: MS:1000841
 name: laser attribute
 def: "Laser properties that are associated with a value." [PSI:MS]
-relationship: part_of: MS:1000840 ! laser
+relationship: part_of MS:1000840 ! laser
 
 [Term]
 id: MS:1000842
 name: laser type
 def: "Type of laser used for desorption purpose." [PSI:MS]
-relationship: part_of: MS:1000840 ! laser
+relationship: part_of MS:1000840 ! laser
 
 [Term]
 id: MS:1000843
@@ -5362,8 +5362,8 @@ name: wavelength
 def: "OBSOLETE The distance between two peaks of the emitted laser beam." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000841 ! laser attribute
-relationship: has_units: UO:0000018 ! nanometer
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units UO:0000018 ! nanometer
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000844
@@ -5371,8 +5371,8 @@ name: focus diameter x
 def: "Describes the diameter of the laser beam in x direction." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000841 ! laser attribute
-relationship: has_units: UO:0000017 ! micrometer
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units UO:0000017 ! micrometer
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000845
@@ -5380,8 +5380,8 @@ name: focus diameter y
 def: "Describes the diameter of the laser beam in y direction." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000841 ! laser attribute
-relationship: has_units: UO:0000017 ! micrometer
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units UO:0000017 ! micrometer
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000846
@@ -5389,8 +5389,8 @@ name: pulse energy
 def: "Describes output energy of the laser system. May be attenuated by filters or other means." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000841 ! laser attribute
-relationship: has_units: UO:0000112 ! joule
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units UO:0000112 ! joule
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000847
@@ -5398,8 +5398,8 @@ name: pulse duration
 def: "Describes how long the laser beam was emitted from the laser device." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000841 ! laser attribute
-relationship: has_units: UO:0000150 ! nanosecond
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units UO:0000150 ! nanosecond
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000848
@@ -5407,8 +5407,8 @@ name: attenuation
 def: "Describes the reduction of the intensity of the laser beam energy." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000841 ! laser attribute
-relationship: has_units: UO:0000187 ! percent
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units UO:0000187 ! percent
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000849
@@ -5416,8 +5416,8 @@ name: impact angle
 def: "Describes the angle between the laser beam and the sample target." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000841 ! laser attribute
-relationship: has_units: UO:0000185 ! degree
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units UO:0000185 ! degree
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000850
@@ -5473,7 +5473,7 @@ name: fraction identifier
 def: "Identier string that describes the sample fraction. This identifier should contain the fraction number(s) or similar information." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000857 ! run attribute
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000859
@@ -5491,7 +5491,7 @@ is_a: MS:1000859 ! molecule
 id: MS:1000861
 name: molecular entity property
 def: "A physical characteristic of a molecular entity." [PSI:MS]
-relationship: part_of: MS:1000881 ! molecular entity
+relationship: part_of MS:1000881 ! molecular entity
 
 [Term]
 id: MS:1000862
@@ -5499,7 +5499,7 @@ name: isoelectric point
 def: "The pH of a solution at which a charged molecule does not migrate in an electric field." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000861 ! molecular entity property
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000863
@@ -5507,7 +5507,7 @@ name: predicted isoelectric point
 def: "The pH of a solution at which a charged molecule would not migrate in an electric field, as predicted by a software algorithm." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000862 ! isoelectric point
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000864
@@ -5521,7 +5521,7 @@ name: empirical formula
 def: "A chemical formula which expresses the proportions of the elements present in a substance." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000864 ! chemical formula
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000866
@@ -5529,7 +5529,7 @@ name: molecular formula
 def: "A chemical compound formula expressing the number of atoms of each element present in a compound, without indicating how they are linked." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000864 ! chemical formula
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000867
@@ -5537,7 +5537,7 @@ name: structural formula
 def: "A chemical formula showing the number of atoms of each element in a molecule, their spatial arrangement, and their linkage to each other." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000864 ! chemical formula
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000868
@@ -5545,7 +5545,7 @@ name: SMILES formula
 def: "The simplified molecular input line entry specification or SMILES is a specification for unambiguously describing the structure of a chemical compound using a short ASCII string." [EDAM:2301]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000864 ! chemical formula
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000869
@@ -5553,8 +5553,8 @@ name: collision gas pressure
 def: "The gas pressure of the collision gas used for collisional excitation." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000510 ! precursor activation attribute
-relationship: has_units: UO:0000110 ! pascal
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units UO:0000110 ! pascal
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000870
@@ -5592,8 +5592,8 @@ name: declustering potential
 def: "Potential difference between the orifice and the skimmer in volts." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000482 ! source attribute
-relationship: has_units: UO:0000218 ! volt
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units UO:0000218 ! volt
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000876
@@ -5601,8 +5601,8 @@ name: cone voltage
 def: "Potential difference between the sampling cone/orifice in volts." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000482 ! source attribute
-relationship: has_units: UO:0000218 ! volt
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units UO:0000218 ! volt
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000877
@@ -5610,8 +5610,8 @@ name: tube lens voltage
 def: "Potential difference setting of the tube lens in volts." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000482 ! source attribute
-relationship: has_units: UO:0000218 ! volt
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units UO:0000218 ! volt
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000878
@@ -5625,7 +5625,7 @@ name: PubMed identifier
 def: "A unique identifier for a publication in the PubMed database (MIR:00000015)." [PSI:MS]
 xref: value-type:xsd\:integer "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
-relationship: has_value_type: xsd\:integer ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000880
@@ -5633,14 +5633,14 @@ name: interchannel delay
 def: "The duration of intervals between scanning, during which the instrument configuration is switched." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000503 ! scan attribute
-relationship: has_units: UO:0000010 ! second
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units UO:0000010 ! second
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000881
 name: molecular entity
 def: "Constitutionally or isotopically distinct atom, molecule, ion, ion pair, radical, radical ion, complex, conformer, etc., identifiable as a separately distinguishable entity." [https://en.wikipedia.org/wiki/Molecular_entity]
-relationship: part_of: MS:0000000 ! Proteomics Standards Initiative Mass Spectrometry Vocabularies
+relationship: part_of MS:0000000 ! Proteomics Standards Initiative Mass Spectrometry Vocabularies
 
 [Term]
 id: MS:1000882
@@ -5654,14 +5654,14 @@ name: protein short name
 def: "A short name or symbol of a protein (e.g., HSF 1 or HSF1_HUMAN)." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000884 ! protein attribute
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000884
 name: protein attribute
 def: "An nonphysical characterstic attributed to a specific protein." [PSI:MS]
 is_a: MS:1001806 ! quantification object attribute
-relationship: part_of: MS:1000882 ! protein
+relationship: part_of MS:1000882 ! protein
 
 [Term]
 id: MS:1000885
@@ -5670,7 +5670,7 @@ def: "Identifier for a specific protein in a database." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000884 ! protein attribute
 is_a: MS:1003046 ! peptide-to-protein mapping attribute
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000886
@@ -5678,13 +5678,13 @@ name: protein name
 def: "A long name describing the function of the protein." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000884 ! protein attribute
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000887
 name: peptide attribute
 def: "Nonphysical characteristic attributed to a peptide." [PSI:MS]
-relationship: part_of: MS:1000860 ! peptide
+relationship: part_of MS:1000860 ! peptide
 
 [Term]
 id: MS:1000888
@@ -5692,7 +5692,7 @@ name: stripped peptide sequence
 def: "Sequence of letter symbols denoting the order of amino acids that compose the peptide, with any amino acid mass modifications that might be present having been stripped away." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1003050 ! peptidoform attribute
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000889
@@ -5700,7 +5700,7 @@ name: peptidoform sequence
 def: "Sequence of letter symbols denoting the order of amino acid residues that compose the peptidoform including the encoding of any residue modifications that are present." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1003050 ! peptidoform attribute
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000890
@@ -5726,7 +5726,7 @@ name: peptidoform group label
 def: "An arbitrary string label used to mark a set of peptides that belong together in a set, whereby the members are differentiated by different isotopic labels. For example, the heavy and light forms of the same peptide will both be assigned the same peptide group label." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1003050 ! peptidoform attribute
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000894
@@ -5734,9 +5734,9 @@ name: retention time
 def: "A time interval from the start of chromatography when an analyte exits a chromatographic column." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1003050 ! peptidoform attribute
-relationship: has_units: UO:0000010 ! second
-relationship: has_units: UO:0000031 ! minute
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units UO:0000010 ! second
+relationship: has_units UO:0000031 ! minute
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000895
@@ -5744,9 +5744,9 @@ name: local retention time
 def: "A time interval from the start of chromatography when an analyte exits an unspecified local chromatographic column and instrumental setup." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000894 ! retention time
-relationship: has_units: UO:0000010 ! second
-relationship: has_units: UO:0000031 ! minute
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units UO:0000010 ! second
+relationship: has_units UO:0000031 ! minute
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000896
@@ -5754,9 +5754,9 @@ name: normalized retention time
 def: "A time interval from the start of chromatography when an analyte exits a standardized reference chromatographic column and instrumental setup." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000894 ! retention time
-relationship: has_units: UO:0000010 ! second
-relationship: has_units: UO:0000031 ! minute
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units UO:0000010 ! second
+relationship: has_units UO:0000031 ! minute
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000897
@@ -5764,15 +5764,15 @@ name: predicted retention time
 def: "A time interval from the start of chromatography when an analyte exits a chromatographic column as predicted by a referenced software application." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000894 ! retention time
-relationship: has_units: UO:0000010 ! second
-relationship: has_units: UO:0000031 ! minute
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units UO:0000010 ! second
+relationship: has_units UO:0000031 ! minute
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000898
 name: standard
 def: "Something, such as a practice or a product, that is widely recognized or employed, especially because of its excellence." [PSI:MS]
-relationship: part_of: MS:0000000 ! Proteomics Standards Initiative Mass Spectrometry Vocabularies
+relationship: part_of MS:0000000 ! Proteomics Standards Initiative Mass Spectrometry Vocabularies
 
 [Term]
 id: MS:1000899
@@ -5804,14 +5804,14 @@ name: product ion series ordinal
 def: "The ordinal of the fragment within a specified ion series. (e.g. 8 for a y8 ion)." [PSI:PI]
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1001221 ! product ion attribute
-relationship: has_value_type: xsd\:positiveInteger ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000904
 name: product ion m/z delta
 def: "The difference in m/z of the predicted m/z based on the assigned product ion minus the actual observed peak m/z." [PSI:PI]
 is_a: MS:1001221 ! product ion attribute
-relationship: has_units: MS:1000040 ! m/z
+relationship: has_units MS:1000040 ! m/z
 
 [Term]
 id: MS:1000905
@@ -5819,7 +5819,7 @@ name: percent of base peak times 100
 def: "The magnitude of a peak expressed in terms of the percentage of the magnitude of the base peak intensity multiplied by 100. The base peak is therefore 10000. This unit is common in normalized spectrum libraries." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000043 ! intensity unit
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000906
@@ -5827,8 +5827,8 @@ name: peak intensity rank
 def: "Ordinal specifying the rank in intensity of a peak in a spectrum. Base peak is 1. The next most intense peak is 2, etc." [PSI:MS]
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1000455 ! ion selection attribute
-relationship: part_of: MS:1000231 ! peak
-relationship: has_value_type: xsd\:positiveInteger ! The allowed value-type for this CV term.
+relationship: part_of MS:1000231 ! peak
+relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000907
@@ -5836,20 +5836,20 @@ name: peak targeting suitability rank
 def: "Ordinal specifying the rank of a peak in a spectrum in terms of suitability for targeting. The most suitable peak is 1. The next most suitability peak is 2, etc. Suitability is algorithm and context dependant." [PSI:MS]
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1000455 ! ion selection attribute
-relationship: part_of: MS:1000231 ! peak
-relationship: has_value_type: xsd\:positiveInteger ! The allowed value-type for this CV term.
+relationship: part_of MS:1000231 ! peak
+relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000908
 name: transition
 def: "A set of two m/z values corresponding to the precursor m/z and a fragment m/z that in combination can be used to identify or quantify a specific ion, although not necessarily uniquely." [PSI:MS]
-relationship: part_of: MS:1001458 ! spectrum generation information
+relationship: part_of MS:1001458 ! spectrum generation information
 
 [Term]
 id: MS:1000909
 name: transition validation method
 def: "The strategy used to validate that a transition is effective." [PSI:MS]
-relationship: part_of: MS:1000908 ! transition
+relationship: part_of MS:1000908 ! transition
 
 [Term]
 id: MS:1000910
@@ -5886,7 +5886,7 @@ is_a: MS:1001040 ! intermediate analysis format
 id: MS:1000915
 name: retention time window attribute
 def: "An attribute of a window in time about which a peptide might elute from the column." [PSI:MS]
-relationship: part_of: MS:1000894 ! retention time
+relationship: part_of MS:1000894 ! retention time
 
 [Term]
 id: MS:1000916
@@ -5894,9 +5894,9 @@ name: retention time window lower offset
 def: "The extent of the retention time window in time units below the target retention time. The lower and upper offsets may be asymmetric about the target time." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000915 ! retention time window attribute
-relationship: has_units: UO:0000010 ! second
-relationship: has_units: UO:0000031 ! minute
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units UO:0000010 ! second
+relationship: has_units UO:0000031 ! minute
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000917
@@ -5904,21 +5904,21 @@ name: retention time window upper offset
 def: "The extent of the retention time window in time units above the target retention time. The lower and upper offsets may be asymmetric about the target time." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000915 ! retention time window attribute
-relationship: has_units: UO:0000010 ! second
-relationship: has_units: UO:0000031 ! minute
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units UO:0000010 ! second
+relationship: has_units UO:0000031 ! minute
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000918
 name: target list
 def: "A list of peptides or compounds and their expected m/z coordinates that can be used to cause a mass spectrometry to obtain spectra of those molecules specifically." [PSI:MS]
-relationship: part_of: MS:1001458 ! spectrum generation information
+relationship: part_of MS:1001458 ! spectrum generation information
 
 [Term]
 id: MS:1000919
 name: target inclusion exclusion priority
 def: "A priority setting specifying whether included or excluded targets have priority over the other." [PSI:MS]
-relationship: part_of: MS:1000918 ! target list
+relationship: part_of MS:1000918 ! target list
 
 [Term]
 id: MS:1000920
@@ -5962,7 +5962,7 @@ name: product interpretation rank
 def: "The integer rank given an interpretation of an observed product ion. For example, if y8 is selected as the most likely interpretation of a peak, then it is assigned a rank of 1." [PSI:MS]
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1001221 ! product ion attribute
-relationship: has_value_type: xsd\:positiveInteger ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000927
@@ -5970,8 +5970,8 @@ name: ion injection time
 def: "The length of time spent filling an ion trapping device." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000503 ! scan attribute
-relationship: has_units: UO:0000028 ! millisecond
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units UO:0000028 ! millisecond
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000928
@@ -6009,7 +6009,7 @@ name: protein modifications
 def: "Encoding of modifications of the protein sequence from the specified accession, written in PEFF notation." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000884 ! protein attribute
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000934
@@ -6017,21 +6017,20 @@ name: gene name
 def: "Name of the gene from which the protein is translated." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000884 ! protein attribute
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001000
 name: spectrum interpretation
 def: "Collection of terms from the PSI Proteome Informatics standards describing the interpretation of spectra." [PSI:PI]
-relationship: part_of: MS:0000000 ! Proteomics Standards Initiative Mass Spectrometry Vocabularies
+relationship: part_of MS:0000000 ! Proteomics Standards Initiative Mass Spectrometry Vocabularies
 
 [Term]
 id: MS:1001005
 name: SEQUEST:CleavesAt
-def:
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002096 ! SEQUEST input parameter
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001006
@@ -6045,7 +6044,7 @@ name: SEQUEST:OutputLines
 def: "Number of peptide results to show." [PSI:MS]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1002096 ! SEQUEST input parameter
-relationship: has_value_type: xsd\:nonNegativeInteger ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001009
@@ -6053,7 +6052,7 @@ name: SEQUEST:DescriptionLines
 def: "Number of full protein descriptions to show for top N peptides." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002096 ! SEQUEST input parameter
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001010
@@ -6073,7 +6072,7 @@ name: database source
 def: "The organisation, project or laboratory from where the database is obtained (UniProt, NCBI, EBI, other)." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001011 ! search database details
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001013
@@ -6093,7 +6092,7 @@ name: database original uri
 def: "URI, from where the search database was originally downloaded." [PSI:PI]
 xref: value-type:xsd\:anyURI "The allowed value-type for this CV term."
 is_a: MS:1001011 ! search database details
-relationship: has_value_type: xsd\:anyURI ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:anyURI ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001016
@@ -6101,7 +6100,7 @@ name: database version
 def: "Version of the search database. In mzIdentML use the attribute instead." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001011 ! search database details
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001017
@@ -6157,15 +6156,14 @@ name: translation table
 def: "The translation table used to translate the nucleotides to amino acids." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001011 ! search database details
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001026
 name: SEQUEST:NormalizeXCorrValues
-def:
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002096 ! SEQUEST input parameter
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001027
@@ -6179,7 +6177,7 @@ name: SEQUEST:SequenceHeaderFilter
 def: "String in the header of a sequence entry for that entry to be searched." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002096 ! SEQUEST input parameter
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001029
@@ -6187,7 +6185,7 @@ name: number of sequences searched
 def: "The number of sequences (proteins / nucleotides) from the database search after filtering." [PSI:PI]
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1001011 ! search database details
-relationship: has_value_type: xsd\:positiveInteger ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001030
@@ -6196,7 +6194,7 @@ def: "Number of peptide seqs compared to each spectrum." [PSI:PI]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1001011 ! search database details
 is_a: MS:1001405 ! spectrum identification result details
-relationship: has_value_type: xsd\:nonNegativeInteger ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001031
@@ -6207,10 +6205,9 @@ is_a: MS:1001080 ! search type
 [Term]
 id: MS:1001032
 name: SEQUEST:SequencePartialFilter
-def:
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002096 ! SEQUEST input parameter
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001035
@@ -6224,7 +6221,7 @@ name: search time taken
 def: "The time taken to complete the search in seconds." [PSI:PI]
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1001184 ! search statistics
-relationship: has_value_type: xsd\:positiveInteger ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001037
@@ -6232,7 +6229,7 @@ name: SEQUEST:ShowFragmentIons
 def: "Flag indicating that fragment ions should be shown." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002096 ! SEQUEST input parameter
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001038
@@ -6240,7 +6237,7 @@ name: SEQUEST:Consensus
 def: "Specify depth as value of the CVParam." [PSI:PI]
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1001006 ! SEQUEST:ViewCV
-relationship: has_value_type: xsd\:positiveInteger ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001040
@@ -6260,7 +6257,7 @@ name: SEQUEST:LimitTo
 def: "Specify \"number of dtas shown\" as value of the CVParam." [PSI:PI]
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1002096 ! SEQUEST input parameter
-relationship: has_value_type: xsd\:positiveInteger ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001044
@@ -6280,7 +6277,7 @@ name: SEQUEST:sort by dCn
 def: "Sort order of SEQUEST search results by the delta of the normalized correlation score." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001041 ! SEQUEST:sortCV
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001047
@@ -6288,7 +6285,7 @@ name: SEQUEST:sort by dM
 def: "Sort order of SEQUEST search results by the difference between a theoretically calculated and the corresponding experimentally measured molecular mass M." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001041 ! SEQUEST:sortCV
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001048
@@ -6296,7 +6293,7 @@ name: SEQUEST:sort by Ions
 def: "Sort order of SEQUEST search results given by the ions." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001041 ! SEQUEST:sortCV
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001049
@@ -6304,7 +6301,7 @@ name: SEQUEST:sort by MH+
 def: "Sort order of SEQUEST search results given by the mass of the protonated ion." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001041 ! SEQUEST:sortCV
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001050
@@ -6312,14 +6309,14 @@ name: SEQUEST:sort by P
 def: "Sort order of SEQUEST search results given by the probability." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001041 ! SEQUEST:sortCV
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001051
 name: multiple enzyme combination rules
 def: "OBSOLETE: use attribute independent in mzIdentML instead. Description of multiple enzyme digestion protocol, if any." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001052
@@ -6327,7 +6324,7 @@ name: SEQUEST:sort by PreviousAminoAcid
 def: "Sort order of SEQUEST search results given by the previous amino acid." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001041 ! SEQUEST:sortCV
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001053
@@ -6335,13 +6332,13 @@ name: SEQUEST:sort by Ref
 def: "Sort order of SEQUEST search results given by the reference." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001041 ! SEQUEST:sortCV
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001055
 name: modification parameters
 def: "Modification parameters for the search engine run." [PSI:PI]
-relationship: part_of: MS:1001000 ! spectrum interpretation
+relationship: part_of MS:1001000 ! spectrum interpretation
 
 [Term]
 id: MS:1001056
@@ -6367,7 +6364,7 @@ name: SEQUEST:sort by RSp
 def: "Sort order of SEQUEST search results given by the result 'Sp' of 'Rank/Sp' in the out file (peptide)." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001041 ! SEQUEST:sortCV
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001060
@@ -6405,7 +6402,7 @@ name: SEQUEST:sort by Sp
 def: "Sort order of SEQUEST search results by the Sp score." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001041 ! SEQUEST:sortCV
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001069
@@ -6413,7 +6410,7 @@ name: SEQUEST:sort by TIC
 def: "Sort order of SEQUEST search results given by the total ion current." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001041 ! SEQUEST:sortCV
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001070
@@ -6421,7 +6418,7 @@ name: SEQUEST:sort by Scan
 def: "Sort order of SEQUEST search results given by the scan number." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001041 ! SEQUEST:sortCV
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001071
@@ -6429,7 +6426,7 @@ name: SEQUEST:sort by Sequence
 def: "Sort order of SEQUEST search results given by the sequence." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001041 ! SEQUEST:sortCV
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001072
@@ -6437,7 +6434,7 @@ name: SEQUEST:sort by Sf
 def: "Sort order of SEQUEST search results given by the SEQUEST result 'Sf'." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001041 ! SEQUEST:sortCV
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001073
@@ -6493,7 +6490,7 @@ name: SEQUEST:sort by XCorr
 def: "Sort order of SEQUEST search results by the correlation score." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001041 ! SEQUEST:sortCV
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001087
@@ -6508,7 +6505,7 @@ def: "The protein description line from the sequence entry in the source databas
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001085 ! protein-level identification attribute
 is_a: MS:1001342 ! database sequence details
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001089
@@ -6518,7 +6515,7 @@ xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001085 ! protein-level identification attribute
 is_a: MS:1001342 ! database sequence details
 is_a: MS:1001512 ! Sequence database filters
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001090
@@ -6529,7 +6526,6 @@ is_a: MS:1001089 ! molecule taxonomy
 [Term]
 id: MS:1001091
 name: NoEnzyme
-def:
 is_a: MS:1001045 ! cleavage agent name
 
 [Term]
@@ -6544,7 +6540,7 @@ name: sequence coverage
 def: "The percent coverage for the protein based upon the matched peptide sequences (can be calculated)." [PSI:PI]
 xref: value-type:xsd\:decimal "The allowed value-type for this CV term."
 is_a: MS:1001085 ! protein-level identification attribute
-relationship: has_value_type: xsd\:decimal ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:decimal ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001094
@@ -6552,15 +6548,14 @@ name: SEQUEST:sort by z
 def: "Sort order of SEQUEST search results given by the charge." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001041 ! SEQUEST:sortCV
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001095
 name: SEQUEST:ProcessAll
-def:
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001087 ! SEQUEST:ProcessCV
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001096
@@ -6568,7 +6563,7 @@ name: SEQUEST:TopPercentMostIntense
 def: "Specify \"percentage\" as value of the CVParam." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001087 ! SEQUEST:ProcessCV
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001097
@@ -6576,7 +6571,7 @@ name: distinct peptide sequences
 def: "This counts distinct sequences hitting the protein without regard to a minimal confidence threshold." [PSI:PI]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1001085 ! protein-level identification attribute
-relationship: has_value_type: xsd\:nonNegativeInteger ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001098
@@ -6584,7 +6579,7 @@ name: confident distinct peptide sequences
 def: "This counts the number of distinct peptide sequences. Multiple charge states and multiple modification states do NOT count as multiple sequences. The definition of 'confident' must be qualified elsewhere." [PSI:PI]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1001085 ! protein-level identification attribute
-relationship: has_value_type: xsd\:nonNegativeInteger ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001099
@@ -6592,7 +6587,7 @@ name: confident peptide qualification
 def: "The point of this entry is to define what is meant by confident for the term Confident distinct peptide sequence and/or Confident peptides. Example 1 - metric=Paragon:Confidence value=95 sense=greater than Example 2 - metric=Mascot:Eval value=0.05 sense=less than." [PSI:PI]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1001085 ! protein-level identification attribute
-relationship: has_value_type: xsd\:nonNegativeInteger ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001100
@@ -6600,7 +6595,7 @@ name: confident peptide sequence number
 def: "This counts the number of peptide sequences without regard to whether they are distinct. Multiple charges states and multiple modification states DO count as multiple peptides. The definition of 'confident' must be qualified elsewhere." [PSI:PI]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1001085 ! protein-level identification attribute
-relationship: has_value_type: xsd\:nonNegativeInteger ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001101
@@ -6611,18 +6606,16 @@ is_a: MS:1001085 ! protein-level identification attribute
 [Term]
 id: MS:1001102
 name: SEQUEST:Chromatogram
-def:
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001006 ! SEQUEST:ViewCV
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001103
 name: SEQUEST:InfoAndLog
-def:
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001006 ! SEQUEST:ViewCV
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001104
@@ -6642,7 +6635,7 @@ name: SEQUEST:TopNumber
 def: "Specify \"number\" as value of the CVParam." [PSI:PI]
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1001087 ! SEQUEST:ProcessCV
-relationship: has_value_type: xsd\:positiveInteger ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001107
@@ -6662,7 +6655,7 @@ name: SEQUEST:CullTo
 def: "Specify cull string as value of the CVParam." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001087 ! SEQUEST:ProcessCV
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001110
@@ -6673,10 +6666,9 @@ is_a: MS:1002096 ! SEQUEST input parameter
 [Term]
 id: MS:1001111
 name: SEQUEST:Full
-def:
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001110 ! SEQUEST:modeCV
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001112
@@ -6685,7 +6677,7 @@ def: "Residue preceding the first amino acid in the peptide sequence as it occur
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1003046 ! peptide-to-protein mapping attribute
 is_a: MS:1001105 ! peptide sequence-level identification attribute
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001113
@@ -6694,7 +6686,7 @@ def: "Residue following the last amino acid in the peptide sequence as it occurs
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1003046 ! peptide-to-protein mapping attribute
 is_a: MS:1001105 ! peptide sequence-level identification attribute
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001114
@@ -6702,9 +6694,9 @@ name: retention time(s)
 def: "OBSOLETE Retention time of the spectrum from the source file." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001105 ! peptide sequence-level identification attribute
-relationship: has_units: UO:0000010 ! second
-relationship: has_units: UO:0000031 ! minute
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_units UO:0000010 ! second
+relationship: has_units UO:0000031 ! minute
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001115
@@ -6723,8 +6715,8 @@ name: theoretical mass
 def: "The theoretical mass of the molecule (e.g. the peptide sequence and its modifications)." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001105 ! peptide sequence-level identification attribute
-relationship: has_units: UO:0000221 ! dalton
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_units UO:0000221 ! dalton
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001118
@@ -6741,10 +6733,9 @@ is_a: MS:1002473 ! ion series considered in search
 [Term]
 id: MS:1001120
 name: SEQUEST:FormatAndLinks
-def:
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001110 ! SEQUEST:modeCV
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001121
@@ -6752,7 +6743,7 @@ name: number of matched peaks
 def: "The number of peaks that were matched as qualified by the ion series considered field. If a peak matches multiple ions then only 1 would be added the count." [PSI:PI]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1001105 ! peptide sequence-level identification attribute
-relationship: has_value_type: xsd\:nonNegativeInteger ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001122
@@ -6766,7 +6757,7 @@ name: number of peaks used
 def: "The number of peaks from the original peak list that are used to calculate the scores for a particular search engine. All ions that have the opportunity to match or be counted even if they don't." [PSI:PI]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1001105 ! peptide sequence-level identification attribute
-relationship: has_value_type: xsd\:nonNegativeInteger ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001124
@@ -6774,7 +6765,7 @@ name: number of peaks submitted
 def: "The number of peaks from the original peaks listed that were submitted to the search engine." [PSI:PI]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1001105 ! peptide sequence-level identification attribute
-relationship: has_value_type: xsd\:nonNegativeInteger ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001125
@@ -6783,15 +6774,14 @@ def: "Result of quality estimation: decision of a manual validation." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001092 ! peptide sequence-level identification statistic
 is_a: MS:1001116 ! single protein identification statistic
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001126
 name: SEQUEST:Fast
-def:
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001110 ! SEQUEST:modeCV
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001127
@@ -6809,7 +6799,7 @@ is_a: MS:1002096 ! SEQUEST input parameter
 id: MS:1001129
 name: quantification information
 def: "Quantification information." [PSI:PI]
-relationship: part_of: MS:1001000 ! spectrum interpretation
+relationship: part_of MS:1001000 ! spectrum interpretation
 
 [Term]
 id: MS:1001130
@@ -6817,7 +6807,7 @@ name: peptide raw area
 def: "OBSOLETE Peptide raw area." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002737 ! peptide-level quantification datatype
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001131
@@ -6825,7 +6815,7 @@ name: error on peptide area
 def: "Error on peptide area." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002737 ! peptide-level quantification datatype
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001132
@@ -6833,7 +6823,7 @@ name: peptide ratio
 def: "Peptide ratio." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002737 ! peptide-level quantification datatype
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001133
@@ -6841,7 +6831,7 @@ name: error on peptide ratio
 def: "Error on peptide ratio." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002737 ! peptide-level quantification datatype
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001134
@@ -6849,7 +6839,7 @@ name: protein ratio
 def: "Protein ratio." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002738 ! protein-level quantification datatype
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001135
@@ -6857,7 +6847,7 @@ name: error on protein ratio
 def: "Error on protein ratio." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002738 ! protein-level quantification datatype
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001136
@@ -6865,7 +6855,7 @@ name: p-value (protein diff from 1 randomly)
 def: "OBSOLETE P-value (protein diff from 1 randomly)." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002738 ! protein-level quantification datatype
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001137
@@ -6873,7 +6863,7 @@ name: absolute quantity
 def: "Absolute quantity in terms of real concentration or molecule copy number in sample." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001138
@@ -6881,7 +6871,7 @@ name: error on absolute quantity
 def: "Error on absolute quantity." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001139
@@ -6902,7 +6892,7 @@ name: intensity of precursor ion
 def: "The intensity of the precursor ion." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001142
@@ -6919,7 +6909,6 @@ is_a: MS:1002347 ! PSM-level identification statistic
 [Term]
 id: MS:1001144
 name: SEQUEST:SelectDefault
-def:
 is_a: MS:1001128 ! SEQUEST:selectCV
 
 [Term]
@@ -6937,7 +6926,6 @@ is_a: MS:1001066 ! ions series considered in search
 [Term]
 id: MS:1001147
 name: protein ambiguity group result details
-def:
 is_a: MS:1001085 ! protein-level identification attribute
 is_a: MS:1001153 ! search engine specific score
 
@@ -6968,7 +6956,6 @@ is_a: MS:1001066 ! ions series considered in search
 [Term]
 id: MS:1001152
 name: param: y ion-H2O DEPRECATED
-def:
 is_a: MS:1001066 ! ions series considered in search
 
 [Term]
@@ -6983,7 +6970,7 @@ name: SEQUEST:probability
 def: "The SEQUEST result 'Probability'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001155
@@ -6991,8 +6978,8 @@ name: SEQUEST:xcorr
 def: "The SEQUEST result 'XCorr'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_order: MS:1002108 ! higher score better
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_order MS:1002108 ! higher score better
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001156
@@ -7000,7 +6987,7 @@ name: SEQUEST:deltacn
 def: "The SEQUEST result 'DeltaCn'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001157
@@ -7008,15 +6995,14 @@ name: SEQUEST:sp
 def: "The SEQUEST result 'Sp' (protein)." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001158
 name: SEQUEST:Uniq
-def:
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001159
@@ -7024,7 +7010,7 @@ name: SEQUEST:expectation value
 def: "The SEQUEST result 'Expectation value'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001153 ! search engine specific score
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001160
@@ -7032,7 +7018,7 @@ name: SEQUEST:sf
 def: "The SEQUEST result 'Sf'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001161
@@ -7040,7 +7026,7 @@ name: SEQUEST:matched ions
 def: "The SEQUEST result 'Matched Ions'." [PSI:PI]
 xref: value-type:xsd\:integer "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type: xsd\:integer ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001162
@@ -7048,7 +7034,7 @@ name: SEQUEST:total ions
 def: "The SEQUEST result 'Total Ions'." [PSI:PI]
 xref: value-type:xsd\:integer "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type: xsd\:integer ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001163
@@ -7056,7 +7042,7 @@ name: SEQUEST:consensus score
 def: "The SEQUEST result 'Consensus Score'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001153 ! search engine specific score
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001164
@@ -7065,7 +7051,7 @@ def: "The Paragon result 'Unused ProtScore'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
 is_a: MS:1002368 ! search engine specific score for protein groups
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001165
@@ -7074,7 +7060,7 @@ def: "The Paragon result 'Total ProtScore'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
 is_a: MS:1002368 ! search engine specific score for protein groups
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001166
@@ -7082,7 +7068,7 @@ name: Paragon:score
 def: "The Paragon result 'Score'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001167
@@ -7090,7 +7076,7 @@ name: Paragon:confidence
 def: "The Paragon result 'Confidence'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001168
@@ -7098,7 +7084,7 @@ name: Paragon:expression error factor
 def: "The Paragon result 'Expression Error Factor'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001169
@@ -7106,7 +7092,7 @@ name: Paragon:expression change p-value
 def: "The Paragon result 'Expression change P-value'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001170
@@ -7114,7 +7100,7 @@ name: Paragon:contrib
 def: "The Paragon result 'Contrib'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001171
@@ -7122,7 +7108,7 @@ name: Mascot:score
 def: "The Mascot result 'Score'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001172
@@ -7130,7 +7116,7 @@ name: Mascot:expectation value
 def: "The Mascot result 'expectation value'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001173
@@ -7138,7 +7124,7 @@ name: Mascot:matched ions
 def: "The Mascot result 'Matched ions'." [PSI:PI]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type: xsd\:nonNegativeInteger ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001174
@@ -7146,7 +7132,7 @@ name: Mascot:total ions
 def: "The Mascot result 'Total ions'." [PSI:PI]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type: xsd\:nonNegativeInteger ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001175
@@ -7166,7 +7152,7 @@ name: number of molecular hypothesis considered
 def: "Number of Molecular Hypothesis Considered - This is the number of molecules (e.g. peptides for proteomics) considered for a particular search." [PSI:PI]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1001184 ! search statistics
-relationship: has_value_type: xsd\:nonNegativeInteger ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001178
@@ -7179,7 +7165,7 @@ id: MS:1001180
 name: Cleavage agent regular expression
 def: "Regular expressions for cleavage enzymes." [PSI:PI]
 is_a: MS:1002479 ! regular expression
-relationship: part_of: MS:1001044 ! cleavage agent details
+relationship: part_of MS:1001044 ! cleavage agent details
 
 [Term]
 id: MS:1001184
@@ -7206,7 +7192,7 @@ def: "OBSOLETE Quality estimation by p-value." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001092 ! peptide sequence-level identification statistic
 is_a: MS:1001198 ! protein identification confidence metric
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001192
@@ -7215,7 +7201,7 @@ def: "Result of quality estimation: Expect value." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001092 ! peptide sequence-level identification statistic
 is_a: MS:1001116 ! single protein identification statistic
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001193
@@ -7224,7 +7210,7 @@ def: "Result of quality estimation: confidence score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001092 ! peptide sequence-level identification statistic
 is_a: MS:1001116 ! single protein identification statistic
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001194
@@ -7232,7 +7218,7 @@ name: quality estimation with decoy database
 def: "Quality estimation by decoy database." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001060 ! quality estimation method details
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001195
@@ -7276,9 +7262,9 @@ name: DB MW filter maximum
 def: "Maximum value of molecular weight filter." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001512 ! Sequence database filters
-relationship: has_units: UO:0000221 ! dalton
-relationship: has_units: UO:0000222 ! kilodalton
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_units UO:0000221 ! dalton
+relationship: has_units UO:0000222 ! kilodalton
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001202
@@ -7286,9 +7272,9 @@ name: DB MW filter minimum
 def: "Minimum value of molecular weight filter." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001512 ! Sequence database filters
-relationship: has_units: UO:0000221 ! dalton
-relationship: has_units: UO:0000222 ! kilodalton
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_units UO:0000221 ! dalton
+relationship: has_units UO:0000222 ! kilodalton
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001203
@@ -7296,7 +7282,7 @@ name: DB PI filter maximum
 def: "Maximum value of isoelectric point filter." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001512 ! Sequence database filters
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001204
@@ -7304,7 +7290,7 @@ name: DB PI filter minimum
 def: "Minimum value of isoelectric point filter." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001512 ! Sequence database filters
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001207
@@ -7353,8 +7339,8 @@ name: protein-level global FDR
 def: "Estimation of the global false discovery rate of proteins." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002705 ! protein-level result list statistic
-relationship: has_domain: MS:1002305 ! value between 0 and 1 inclusive
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001215
@@ -7362,7 +7348,7 @@ name: SEQUEST:PeptideSp
 def: "The SEQUEST result 'Sp' in out file (peptide)." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001217
@@ -7370,7 +7356,7 @@ name: SEQUEST:PeptideRankSp
 def: "The SEQUEST result 'Sp' of 'Rank/Sp' in out file (peptide). Also called 'rsp'." [PSI:PI]
 xref: value-type:xsd\:integer "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type: xsd\:integer ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001218
@@ -7378,7 +7364,7 @@ name: SEQUEST:PeptideNumber
 def: "The SEQUEST result '#' in out file (peptide)." [PSI:PI]
 xref: value-type:xsd\:integer "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type: xsd\:integer ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001219
@@ -7386,7 +7372,7 @@ name: SEQUEST:PeptideIdnumber
 def: "The SEQUEST result 'Id#' in out file (peptide)." [PSI:PI]
 xref: value-type:xsd\:integer "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type: xsd\:integer ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001220
@@ -7423,25 +7409,25 @@ id: MS:1001225
 name: product ion m/z
 def: "The m/z of the product ion." [PSI:PI]
 is_a: MS:1001221 ! product ion attribute
-relationship: has_units: MS:1000040 ! m/z
+relationship: has_units MS:1000040 ! m/z
 
 [Term]
 id: MS:1001226
 name: product ion intensity
 def: "The intensity of a single product ion." [PSI:PI]
 is_a: MS:1001221 ! product ion attribute
-relationship: has_units: MS:1000131 ! number of detector counts
-relationship: has_units: MS:1000132 ! percent of base peak
-relationship: has_units: MS:1000814 ! counts per second
-relationship: has_units: MS:1000905 ! percent of base peak times 100
+relationship: has_units MS:1000131 ! number of detector counts
+relationship: has_units MS:1000132 ! percent of base peak
+relationship: has_units MS:1000814 ! counts per second
+relationship: has_units MS:1000905 ! percent of base peak times 100
 
 [Term]
 id: MS:1001227
 name: product ion m/z error
 def: "The product ion m/z error." [PSI:PI]
 is_a: MS:1001221 ! product ion attribute
-relationship: has_units: MS:1000040 ! m/z
-relationship: has_units: UO:0000166 ! parts per notation unit
+relationship: has_units MS:1000040 ! m/z
+relationship: has_units UO:0000166 ! parts per notation unit
 
 [Term]
 id: MS:1001228
@@ -7561,7 +7547,7 @@ is_a: MS:1000560 ! mass spectrometer file format
 id: MS:1001249
 name: search input details
 def: "Details describing the search input." [PSI:PI]
-relationship: part_of: MS:1001000 ! spectrum interpretation
+relationship: part_of MS:1001000 ! spectrum interpretation
 
 [Term]
 id: MS:1001250
@@ -7570,14 +7556,14 @@ def: "Result of quality estimation: the local FDR at the current position of a s
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001092 ! peptide sequence-level identification statistic
 is_a: MS:1001116 ! single protein identification statistic
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001251
 name: Trypsin
 def: "Enzyme trypsin." [PSI:PI]
 is_a: MS:1001045 ! cleavage agent name
-relationship: has_regexp: MS:1001176 ! (?<=[KR])(?!P)
+relationship: has_regexp MS:1001176 ! (?<=[KR])(?!P)
 
 [Term]
 id: MS:1001252
@@ -7669,7 +7655,7 @@ name: programmer
 def: "Programmer role." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001266 ! role type
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001269
@@ -7677,7 +7663,7 @@ name: instrument vendor
 def: "Instrument vendor role." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001266 ! role type
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001270
@@ -7685,7 +7671,7 @@ name: lab personnel
 def: "Lab personnel role." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001266 ! role type
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001271
@@ -7729,7 +7715,7 @@ name: decoy DB accession regexp
 def: "Specify the regular expression for decoy accession numbers." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001450 ! decoy DB details
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001284
@@ -7829,7 +7815,7 @@ name: protein rank
 def: "The rank of the protein in a list sorted by the search engine." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1001085 ! protein-level identification attribute
-relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001302
@@ -7842,91 +7828,91 @@ id: MS:1001303
 name: Arg-C
 def: "Endoproteinase Arg-C." [PSI:PI]
 is_a: MS:1001045 ! cleavage agent name
-relationship: has_regexp: MS:1001272 ! (?<=R)(?!P)
+relationship: has_regexp MS:1001272 ! (?<=R)(?!P)
 
 [Term]
 id: MS:1001304
 name: Asp-N
 def: "Endoproteinase Asp-N." [PSI:PI]
 is_a: MS:1001045 ! cleavage agent name
-relationship: has_regexp: MS:1001273 ! (?=[BD])
+relationship: has_regexp MS:1001273 ! (?=[BD])
 
 [Term]
 id: MS:1001305
 name: Asp-N_ambic
 def: "Enzyme Asp-N, Ammonium Bicarbonate (AmBic)." [PSI:PI]
 is_a: MS:1001045 ! cleavage agent name
-relationship: has_regexp: MS:1001274 ! (?=[DE])
+relationship: has_regexp MS:1001274 ! (?=[DE])
 
 [Term]
 id: MS:1001306
 name: Chymotrypsin
 def: "Enzyme chymotrypsin." [PSI:PI]
 is_a: MS:1001045 ! cleavage agent name
-relationship: has_regexp: MS:1001332 ! (?<=[FYWL])(?!P)
+relationship: has_regexp MS:1001332 ! (?<=[FYWL])(?!P)
 
 [Term]
 id: MS:1001307
 name: CNBr
 def: "Cyanogen bromide." [PSI:PI]
 is_a: MS:1001045 ! cleavage agent name
-relationship: has_regexp: MS:1001333 ! (?<=M)
+relationship: has_regexp MS:1001333 ! (?<=M)
 
 [Term]
 id: MS:1001308
 name: Formic_acid
 def: "Formic acid." [PubChem_Compound:284]
 is_a: MS:1001045 ! cleavage agent name
-relationship: has_regexp: MS:1001334 ! ((?<=D))|((?=D))
+relationship: has_regexp MS:1001334 ! ((?<=D))|((?=D))
 
 [Term]
 id: MS:1001309
 name: Lys-C
 def: "Endoproteinase Lys-C." [PSI:PI]
 is_a: MS:1001045 ! cleavage agent name
-relationship: has_regexp: MS:1001335 ! (?<=K)(?!P)
+relationship: has_regexp MS:1001335 ! (?<=K)(?!P)
 
 [Term]
 id: MS:1001310
 name: Lys-C/P
 def: "Proteinase Lys-C/P." [PSI:PI]
 is_a: MS:1001045 ! cleavage agent name
-relationship: has_regexp: MS:1001336 ! (?<=K)
+relationship: has_regexp MS:1001336 ! (?<=K)
 
 [Term]
 id: MS:1001311
 name: PepsinA
 def: "PepsinA proteinase." [PSI:PI]
 is_a: MS:1001045 ! cleavage agent name
-relationship: has_regexp: MS:1001337 ! (?<=[FL])
+relationship: has_regexp MS:1001337 ! (?<=[FL])
 
 [Term]
 id: MS:1001312
 name: TrypChymo
 def: "Cleavage agent TrypChymo." [PSI:PI]
 is_a: MS:1001045 ! cleavage agent name
-relationship: has_regexp: MS:1001338 ! (?<=[FYWLKR])(?!P)
+relationship: has_regexp MS:1001338 ! (?<=[FYWLKR])(?!P)
 
 [Term]
 id: MS:1001313
 name: Trypsin/P
 def: "Cleavage agent Trypsin/P." [PSI:PI]
 is_a: MS:1001045 ! cleavage agent name
-relationship: has_regexp: MS:1001339 ! (?<=[KR])
+relationship: has_regexp MS:1001339 ! (?<=[KR])
 
 [Term]
 id: MS:1001314
 name: V8-DE
 def: "Cleavage agent V8-DE." [PSI:PI]
 is_a: MS:1001045 ! cleavage agent name
-relationship: has_regexp: MS:1001340 ! (?<=[BDEZ])(?!P)
+relationship: has_regexp MS:1001340 ! (?<=[BDEZ])(?!P)
 
 [Term]
 id: MS:1001315
 name: V8-E
 def: "Cleavage agent V8-E." [PSI:PI]
 is_a: MS:1001045 ! cleavage agent name
-relationship: has_regexp: MS:1001341 ! (?<=[EZ])(?!P)
+relationship: has_regexp MS:1001341 ! (?<=[EZ])(?!P)
 
 [Term]
 id: MS:1001316
@@ -7934,7 +7920,7 @@ name: Mascot:SigThreshold
 def: "Significance threshold below which the p-value of a peptide match must lie to be considered statistically significant (default 0.05)." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002095 ! Mascot input parameter
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001317
@@ -7942,7 +7928,7 @@ name: Mascot:MaxProteinHits
 def: "The number of protein hits to display in the report. If 'Auto', all protein hits that have a protein score exceeding the average peptide identity threshold are reported. Otherwise an integer at least 1." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002095 ! Mascot input parameter
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001318
@@ -7950,7 +7936,7 @@ name: Mascot:ProteinScoringMethod
 def: "Mascot protein scoring method; either 'Standard' or 'MudPIT'." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002095 ! Mascot input parameter
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001319
@@ -7958,7 +7944,7 @@ name: Mascot:MinMSMSThreshold
 def: "Mascot peptide match ion score threshold. If between 0 and 1, then peptide matches whose expect value exceeds the thresholds are suppressed; if at least 1, then peptide matches whose ion score is below the threshold are suppressed." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002095 ! Mascot input parameter
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001320
@@ -7966,7 +7952,7 @@ name: Mascot:ShowHomologousProteinsWithSamePeptides
 def: "If true, show (sequence or spectrum) same-set proteins. Otherwise they are suppressed." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002095 ! Mascot input parameter
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001321
@@ -7974,7 +7960,7 @@ name: Mascot:ShowHomologousProteinsWithSubsetOfPeptides
 def: "If true, show (sequence or spectrum) sub-set and subsumable proteins. Otherwise they are suppressed." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002095 ! Mascot input parameter
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001322
@@ -7982,7 +7968,7 @@ name: Mascot:RequireBoldRed
 def: "Only used in Peptide Summary and Select Summary reports. If true, a peptide match must be 'bold red' to be included in the report; bold red means the peptide is a top ranking match in a query and appears for the first time (in linear order) in the list of protein hits." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002095 ! Mascot input parameter
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001323
@@ -7990,7 +7976,7 @@ name: Mascot:UseUnigeneClustering
 def: "If true, then the search results are against a nucleic acid database and Unigene clustering is enabled. Otherwise UniGene clustering is not in use." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002095 ! Mascot input parameter
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001324
@@ -7998,7 +7984,7 @@ name: Mascot:IncludeErrorTolerantMatches
 def: "If true, then the search results are error tolerant and peptide matches from the second pass are included in search results. Otherwise no error tolerant peptide matches are included." [http://www.matrixscience.com/help/error_tolerant_help.html]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002095 ! Mascot input parameter
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001325
@@ -8006,7 +7992,7 @@ name: Mascot:ShowDecoyMatches
 def: "If true, then the search results are against an automatically generated decoy database and the reported peptide matches and protein hits come from the decoy database. Otherwise peptide matches and protein hits come from the original database." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002095 ! Mascot input parameter
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001326
@@ -8019,7 +8005,7 @@ name: OMSSA:evalue
 def: "OMSSA E-value." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001329
@@ -8027,7 +8013,7 @@ name: OMSSA:pvalue
 def: "OMSSA p-value." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001330
@@ -8035,7 +8021,7 @@ name: X\!Tandem:expect
 def: "The X!Tandem expectation value." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001331
@@ -8043,7 +8029,7 @@ name: X\!Tandem:hyperscore
 def: "The X!Tandem hyperscore." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001332
@@ -8181,7 +8167,7 @@ is_a: MS:1001347 ! database file formats
 id: MS:1001354
 name: mass table options
 def: "Root node for options for the mass table used." [PSI:PI]
-relationship: part_of: MS:1001000 ! spectrum interpretation
+relationship: part_of MS:1001000 ! spectrum interpretation
 
 [Term]
 id: MS:1001355
@@ -8207,13 +8193,13 @@ name: msmsEval quality
 def: "This term reports the quality of the spectrum assigned by msmsEval." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001357 ! spectrum quality descriptions
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001359
 name: ambiguous residues
 def: "Children of this term describe ambiguous residues." [PSI:PI]
-relationship: part_of: MS:1001000 ! spectrum interpretation
+relationship: part_of MS:1001000 ! spectrum interpretation
 
 [Term]
 id: MS:1001360
@@ -8221,7 +8207,7 @@ name: alternate single letter codes
 def: "List of standard residue one letter codes which are used to replace a non-standard." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001359 ! ambiguous residues
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001361
@@ -8229,8 +8215,8 @@ name: alternate mass
 def: "List of masses a non-standard letter code is replaced with." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001359 ! ambiguous residues
-relationship: has_units: UO:0000221 ! dalton
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_units UO:0000221 ! dalton
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001362
@@ -8238,7 +8224,7 @@ name: number of unmatched peaks
 def: "The number of unmatched peaks." [PSI:PI]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1002345 ! PSM-level attribute
-relationship: has_value_type: xsd\:nonNegativeInteger ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001363
@@ -8252,8 +8238,8 @@ name: peptide sequence-level global FDR
 def: "Estimation of the global false discovery rate for distinct peptides once redundant identifications of the same peptide have been removed (id est multiple PSMs have been collapsed to one entry)." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002703 ! peptide sequence-level result list statistic
-relationship: has_domain: MS:1002305 ! value between 0 and 1 inclusive
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001365
@@ -8291,7 +8277,7 @@ name: Mascot:homology threshold
 def: "The Mascot result 'homology threshold'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001371
@@ -8299,15 +8285,14 @@ name: Mascot:identity threshold
 def: "The Mascot result 'identity threshold'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001372
 name: SEQUEST:Sequences
-def:
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_value_type: xsd\:positiveInteger ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001373
@@ -8315,15 +8300,14 @@ name: SEQUEST:TIC
 def: "SEQUEST total ion current." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001374
 name: SEQUEST:Sum
-def:
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001375
@@ -8331,7 +8315,7 @@ name: Phenyx:Instrument Type
 def: "The instrument type parameter value in Phenyx." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002097 ! Phenyx input parameter
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001376
@@ -8339,7 +8323,7 @@ name: Phenyx:Scoring Model
 def: "The selected scoring model in Phenyx." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002097 ! Phenyx input parameter
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001377
@@ -8347,7 +8331,7 @@ name: Phenyx:Default Parent Charge
 def: "The default parent charge value in Phenyx." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002097 ! Phenyx input parameter
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001378
@@ -8355,7 +8339,7 @@ name: Phenyx:Trust Parent Charge
 def: "The parameter in Phenyx that specifies if the experimental charge state is to be considered as correct." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002097 ! Phenyx input parameter
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001379
@@ -8363,7 +8347,7 @@ name: Phenyx:Turbo
 def: "The turbo mode parameter in Phenyx." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002097 ! Phenyx input parameter
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001380
@@ -8371,7 +8355,7 @@ name: Phenyx:Turbo:ErrorTol
 def: "The maximal allowed fragment m/z error filter considered in the turbo mode of Phenyx." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002097 ! Phenyx input parameter
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001381
@@ -8379,7 +8363,7 @@ name: Phenyx:Turbo:Coverage
 def: "The minimal peptide sequence coverage value, expressed in percent, considered in the turbo mode of Phenyx." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002097 ! Phenyx input parameter
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001382
@@ -8387,7 +8371,7 @@ name: Phenyx:Turbo:Series
 def: "The list of ion series considered in the turbo mode of Phenyx." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002097 ! Phenyx input parameter
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001383
@@ -8395,7 +8379,7 @@ name: Phenyx:MinPepLength
 def: "The minimal number of residues for a peptide to be considered for a valid identification in Phenyx." [PSI:PI]
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1002097 ! Phenyx input parameter
-relationship: has_value_type: xsd\:positiveInteger ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001384
@@ -8403,7 +8387,7 @@ name: Phenyx:MinPepzscore
 def: "The minimal peptide z-score for a peptide to be considered for a valid identification in Phenyx." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002097 ! Phenyx input parameter
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001385
@@ -8411,7 +8395,7 @@ name: Phenyx:MaxPepPvalue
 def: "The maximal peptide p-value for a peptide to be considered for a valid identification in Phenyx." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002097 ! Phenyx input parameter
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001386
@@ -8419,7 +8403,7 @@ name: Phenyx:AC Score
 def: "The minimal protein score required for a protein database entry to be displayed in the list of identified proteins in Phenyx." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002097 ! Phenyx input parameter
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001387
@@ -8427,7 +8411,7 @@ name: Phenyx:Conflict Resolution
 def: "The parameter in Phenyx that specifies if the conflict resolution algorithm is to be used." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002097 ! Phenyx input parameter
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001388
@@ -8435,7 +8419,7 @@ name: Phenyx:AC
 def: "The primary sequence database identifier of a protein in Phenyx." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001389
@@ -8443,7 +8427,7 @@ name: Phenyx:ID
 def: "A secondary sequence database identifier of a protein in Phenyx." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001390
@@ -8451,7 +8435,7 @@ name: Phenyx:Score
 def: "The protein score of a protein match in Phenyx." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001391
@@ -8459,7 +8443,7 @@ name: Phenyx:Peptides1
 def: "First number of phenyx result \"#Peptides\"." [PSI:PI]
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_value_type: xsd\:positiveInteger ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001392
@@ -8467,7 +8451,7 @@ name: Phenyx:Peptides2
 def: "Second number of phenyx result \"#Peptides\"." [PSI:PI]
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_value_type: xsd\:positiveInteger ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001393
@@ -8475,7 +8459,7 @@ name: Phenyx:Auto
 def: "The value of the automatic peptide acceptance filter in Phenyx." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001394
@@ -8484,7 +8468,7 @@ def: "The value of the user-defined peptide acceptance filter in Phenyx." [PSI:P
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001395
@@ -8492,7 +8476,7 @@ name: Phenyx:Pepzscore
 def: "The z-score value of a peptide sequence match in Phenyx." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001396
@@ -8501,7 +8485,7 @@ def: "The p-value of a peptide sequence match in Phenyx." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1002358 ! search engine specific peptide sequence-level identification statistic
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001397
@@ -8509,7 +8493,7 @@ name: Phenyx:NumberOfMC
 def: "The number of missed cleavages of a peptide sequence in Phenyx." [PSI:PI]
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type: xsd\:positiveInteger ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001398
@@ -8518,7 +8502,7 @@ def: "The expression of the nature and position(s) of modified residue(s) on a m
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001399
@@ -8542,7 +8526,7 @@ is_a: MS:1001040 ! intermediate analysis format
 id: MS:1001405
 name: spectrum identification result details
 def: "This subsection describes terms which can describe details of spectrum identification results." [PSI:PI]
-relationship: part_of: MS:1001000 ! spectrum interpretation
+relationship: part_of MS:1001000 ! spectrum interpretation
 
 [Term]
 id: MS:1001406
@@ -8574,7 +8558,7 @@ name: translation start codons
 def: "The translation start codons used to translate the nucleotides to amino acids." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001011 ! search database details
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001411
@@ -8585,26 +8569,24 @@ is_a: MS:1001249 ! search input details
 [Term]
 id: MS:1001412
 name: search tolerance plus value
-def:
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001411 ! search tolerance specification
-relationship: has_units: UO:0000166 ! parts per notation unit
-relationship: has_units: UO:0000169 ! parts per million
-relationship: has_units: UO:0000187 ! percent
-relationship: has_units: UO:0000221 ! dalton
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_units UO:0000166 ! parts per notation unit
+relationship: has_units UO:0000169 ! parts per million
+relationship: has_units UO:0000187 ! percent
+relationship: has_units UO:0000221 ! dalton
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001413
 name: search tolerance minus value
-def:
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001411 ! search tolerance specification
-relationship: has_units: UO:0000166 ! parts per notation unit
-relationship: has_units: UO:0000169 ! parts per million
-relationship: has_units: UO:0000187 ! percent
-relationship: has_units: UO:0000221 ! dalton
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_units UO:0000166 ! parts per notation unit
+relationship: has_units UO:0000169 ! parts per million
+relationship: has_units UO:0000187 ! percent
+relationship: has_units UO:0000221 ! dalton
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001414
@@ -8612,7 +8594,7 @@ name: MGF scans
 def: "OBSOLETE: replaced by MS:1000797 (peak list scans): This term can hold the scans attribute from an MGF input file." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001405 ! spectrum identification result details
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001415
@@ -8620,7 +8602,7 @@ name: MGF raw scans
 def: "OBSOLETE: replaced by MS:1000798 (peak list raw scans): This term can hold the raw scans attribute from an MGF input file." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001405 ! spectrum identification result details
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001416
@@ -8628,7 +8610,7 @@ name: spectrum title
 def: "OBSOLETE: replaced by MS:1000796 (spectrum title): Holds the spectrum title from different input file formats, e.g. MGF TITLE." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001405 ! spectrum identification result details
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001417
@@ -8636,7 +8618,7 @@ name: SpectraST:dot
 def: "SpectraST dot product of two spectra, measuring spectral similarity." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001418
@@ -8644,7 +8626,7 @@ name: SpectraST:dot_bias
 def: "SpectraST measure of how much of the dot product is dominated by a few peaks." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001419
@@ -8652,7 +8634,7 @@ name: SpectraST:discriminant score F
 def: "SpectraST spectrum score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001420
@@ -8660,7 +8642,7 @@ name: SpectraST:delta
 def: "SpectraST normalised difference between dot product of top hit and runner-up." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001421
@@ -8680,7 +8662,7 @@ name: translation table description
 def: "A URL that describes the translation table used to translate the nucleotides to amino acids." [PSI:PI]
 xref: value-type:xsd\:anyURI "The allowed value-type for this CV term."
 is_a: MS:1001011 ! search database details
-relationship: has_value_type: xsd\:anyURI ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:anyURI ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001424
@@ -8688,7 +8670,7 @@ name: ProteinExtractor:Methodname
 def: "Name of the used method in the ProteinExtractor algorithm." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001425
@@ -8696,7 +8678,7 @@ name: ProteinExtractor:GenerateNonRedundant
 def: "Flag indicating if a non redundant scoring should be generated." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001426
@@ -8704,7 +8686,7 @@ name: ProteinExtractor:IncludeIdentified
 def: "Flag indicating if identified proteins should be included." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001427
@@ -8712,7 +8694,7 @@ name: ProteinExtractor:MaxNumberOfProteins
 def: "The maximum number of proteins to consider." [PSI:PI]
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
-relationship: has_value_type: xsd\:positiveInteger ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001428
@@ -8720,7 +8702,7 @@ name: ProteinExtractor:MaxProteinMass
 def: "The maximum considered mass for a protein." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001429
@@ -8728,7 +8710,7 @@ name: ProteinExtractor:MinNumberOfPeptides
 def: "The minimum number of proteins to consider." [PSI:PI]
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
-relationship: has_value_type: xsd\:positiveInteger ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001430
@@ -8736,7 +8718,7 @@ name: ProteinExtractor:UseMascot
 def: "Flag indicating to include Mascot scoring for calculation of the ProteinExtractor meta score." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001431
@@ -8744,7 +8726,7 @@ name: ProteinExtractor:MascotPeptideScoreThreshold
 def: "Only peptides with scores higher than that threshold are taken into account in Mascot scoring for calculation of the ProteinExtractor meta score." [DOI:10.4172/jpb.1000056]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001432
@@ -8752,15 +8734,14 @@ name: ProteinExtractor:MascotUniqueScore
 def: "In the final result each protein must have at least one peptide above this Mascot score threshold in ProteinExtractor meta score calculation." [DOI:10.4172/jpb.1000056]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001433
 name: ProteinExtractor:MascotUseIdentityScore
-def:
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001434
@@ -8768,7 +8749,7 @@ name: ProteinExtractor:MascotWeighting
 def: "Influence of Mascot search engine in the process of merging the search engine specific protein lists into the global protein list of ProteinExtractor." [DOI:10.4172/jpb.1000056]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001435
@@ -8776,7 +8757,7 @@ name: ProteinExtractor:UseSequest
 def: "Flag indicating to include SEQUEST scoring for calculation of the ProteinExtractor meta score." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001436
@@ -8784,7 +8765,7 @@ name: ProteinExtractor:SequestPeptideScoreThreshold
 def: "Only peptides with scores higher than that threshold are taken into account in SEQUEST scoring for calculation of the ProteinExtractor meta score." [DOI:10.4172/jpb.1000056]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001437
@@ -8792,7 +8773,7 @@ name: ProteinExtractor:SequestUniqueScore
 def: "In the final result each protein must have at least one peptide above this SEQUEST score threshold in ProteinExtractor meta score calculation." [DOI:10.4172/jpb.1000056]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001438
@@ -8800,7 +8781,7 @@ name: ProteinExtractor:SequestWeighting
 def: "Influence of SEQUEST search engine in the process of merging the search engine specific protein lists into the global protein list of ProteinExtractor." [DOI:10.4172/jpb.1000056]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001439
@@ -8808,7 +8789,7 @@ name: ProteinExtractor:UseProteinSolver
 def: "Flag indicating to include ProteinSolver scoring for calculation of the ProteinExtractor meta score." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001440
@@ -8816,7 +8797,7 @@ name: ProteinExtractor:ProteinSolverPeptideScoreThreshold
 def: "Only peptides with scores higher than that threshold are taken into account in ProteinSolver scoring for calculation of the ProteinExtractor meta score." [DOI:10.4172/jpb.1000056]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001441
@@ -8824,7 +8805,7 @@ name: ProteinExtractor:ProteinSolverUniqueScore
 def: "In the final result each protein must have at least one peptide above this ProteinSolver score threshold in ProteinExtractor meta score calculation." [DOI:10.4172/jpb.1000056]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001442
@@ -8832,7 +8813,7 @@ name: ProteinExtractor:ProteinSolverWeighting
 def: "Influence of ProteinSolver search engine in the process of merging the search engine specific protein lists into the global protein list of ProteinExtractor." [DOI:10.4172/jpb.1000056]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001443
@@ -8840,7 +8821,7 @@ name: ProteinExtractor:UsePhenyx
 def: "Flag indicating to include Phenyx scoring for calculation of the ProteinExtractor meta score." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001444
@@ -8848,7 +8829,7 @@ name: ProteinExtractor:PhenyxPeptideScoreThreshold
 def: "Only peptides with scores higher than that threshold are taken into account in Phenyx scoring for calculation of the ProteinExtractor meta score." [DOI:10.4172/jpb.1000056]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001445
@@ -8856,7 +8837,7 @@ name: ProteinExtractor:PhenyxUniqueScore
 def: "In the final result each protein must have at least one peptide above this Phenyx score threshold in ProteinExtractor meta score calculation." [DOI:10.4172/jpb.1000056]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001446
@@ -8864,7 +8845,7 @@ name: ProteinExtractor:PhenyxWeighting
 def: "Influence of Phenyx search engine in the process of merging the search engine specific protein lists into the global protein list of ProteinExtractor." [DOI:10.4172/jpb.1000056]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001447
@@ -8872,7 +8853,7 @@ name: prot:FDR threshold
 def: "False-discovery rate threshold for proteins." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002485 ! protein-level statistical threshold
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001448
@@ -8880,7 +8861,7 @@ name: pep:FDR threshold
 def: "False-discovery rate threshold for peptides." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002484 ! peptide-level statistical threshold
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001449
@@ -8888,7 +8869,7 @@ name: OMSSA e-value threshold
 def: "Threshold for OMSSA e-value for quality estimation." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002099 ! OMSSA input parameter
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001450
@@ -8902,7 +8883,7 @@ name: decoy DB generation algorithm
 def: "Name of algorithm used for decoy generation." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001450 ! decoy DB details
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001452
@@ -8944,13 +8925,13 @@ is_a: MS:1000531 ! software
 id: MS:1001458
 name: spectrum generation information
 def: "Vocabularies describing the spectrum generation information." [PSI:PI]
-relationship: part_of: MS:0000000 ! Proteomics Standards Initiative Mass Spectrometry Vocabularies
+relationship: part_of MS:0000000 ! Proteomics Standards Initiative Mass Spectrometry Vocabularies
 
 [Term]
 id: MS:1001459
 name: file format
 def: "Format of data files." [PSI:MS]
-relationship: part_of: MS:0000000 ! Proteomics Standards Initiative Mass Spectrometry Vocabularies
+relationship: part_of MS:0000000 ! Proteomics Standards Initiative Mass Spectrometry Vocabularies
 
 [Term]
 id: MS:1001460
@@ -8995,7 +8976,7 @@ name: taxonomy: NCBI TaxID
 def: "This term is used if a NCBI TaxID is specified, e.g. 9606 for Homo sapiens." [PSI:PI]
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1001089 ! molecule taxonomy
-relationship: has_value_type: xsd\:positiveInteger ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001468
@@ -9003,7 +8984,7 @@ name: taxonomy: common name
 def: "This term is used if a common name is specified, e.g. human. Recommend using MS:1001467 (taxonomy: NCBI TaxID) where possible." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001089 ! molecule taxonomy
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001469
@@ -9011,7 +8992,7 @@ name: taxonomy: scientific name
 def: "This term is used if a scientific name is specified, e.g. Homo sapiens. Recommend using MS:1001467 (taxonomy: NCBI TaxID) where possible." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001089 ! molecule taxonomy
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001470
@@ -9019,13 +9000,13 @@ name: taxonomy: Swiss-Prot ID
 def: "This term is used if a swiss prot taxonomy id is specified, e.g. Human. Recommend using MS:1001467 (taxonomy: NCBI TaxID) where possible." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001089 ! molecule taxonomy
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001471
 name: peptide modification details
 def: "The children of this term can be used to describe modifications." [PSI:PI]
-relationship: part_of: MS:1001000 ! spectrum interpretation
+relationship: part_of MS:1001000 ! spectrum interpretation
 
 [Term]
 id: MS:1001472
@@ -9152,7 +9133,7 @@ name: percolator:Q value
 def: "Percolator:Q value." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001492
@@ -9160,7 +9141,7 @@ name: percolator:score
 def: "Percolator:score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001493
@@ -9168,7 +9149,7 @@ name: percolator:PEP
 def: "Posterior error probability." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001494
@@ -9182,7 +9163,7 @@ name: ProteinScape:SearchResultId
 def: "The SearchResultId of this peptide as SearchResult in the ProteinScape database." [PSI:PI]
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type: xsd\:positiveInteger ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001496
@@ -9190,7 +9171,7 @@ name: ProteinScape:SearchEventId
 def: "The SearchEventId of the SearchEvent in the ProteinScape database." [PSI:PI]
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type: xsd\:positiveInteger ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001497
@@ -9198,7 +9179,7 @@ name: ProteinScape:ProfoundProbability
 def: "The Profound probability score stored by ProteinScape." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001498
@@ -9206,7 +9187,7 @@ name: Profound:z value
 def: "The Profound z value." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001499
@@ -9214,7 +9195,7 @@ name: Profound:Cluster
 def: "The Profound cluster score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001500
@@ -9222,7 +9203,7 @@ name: Profound:ClusterRank
 def: "The Profound cluster rank." [PSI:PI]
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type: xsd\:positiveInteger ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001501
@@ -9230,7 +9211,7 @@ name: MSFit:Mowse score
 def: "The MSFit Mowse score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001502
@@ -9238,7 +9219,7 @@ name: Sonar:Score
 def: "The Sonar score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001503
@@ -9246,7 +9227,7 @@ name: ProteinScape:PFFSolverExp
 def: "The ProteinSolver exp value stored by ProteinScape." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001504
@@ -9254,7 +9235,7 @@ name: ProteinScape:PFFSolverScore
 def: "The ProteinSolver score stored by ProteinScape." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001505
@@ -9262,7 +9243,7 @@ name: ProteinScape:IntensityCoverage
 def: "The intensity coverage of the identified peaks in the spectrum calculated by ProteinScape." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001506
@@ -9270,7 +9251,7 @@ name: ProteinScape:SequestMetaScore
 def: "The SEQUEST meta score calculated by ProteinScape from the original SEQUEST scores." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001507
@@ -9278,7 +9259,7 @@ name: ProteinExtractor:Score
 def: "The score calculated by ProteinExtractor." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001508
@@ -9316,7 +9297,7 @@ name: DB sequence filter pattern
 def: "DB sequence filter pattern." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001512 ! Sequence database filters
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001514
@@ -9324,7 +9305,7 @@ name: DB accession filter string
 def: "DB accession filter string." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001512 ! Sequence database filters
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001515
@@ -9386,8 +9367,8 @@ name: fragment neutral loss
 def: "This term can describe a neutral loss m/z value that is lost from an ion." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001471 ! peptide modification details
-relationship: has_units: UO:0000221 ! dalton
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_units UO:0000221 ! dalton
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001525
@@ -9395,8 +9376,8 @@ name: precursor neutral loss
 def: "This term can describe a neutral loss m/z value that is lost from an ion." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001471 ! peptide modification details
-relationship: has_units: UO:0000221 ! dalton
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_units UO:0000221 ! dalton
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001526
@@ -9650,7 +9631,7 @@ name: Scaffold:Peptide Probability
 def: "Scaffold peptide probability score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001569
@@ -9658,7 +9639,7 @@ name: IdentityE Score
 def: "Waters IdentityE peptide score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001570
@@ -9666,7 +9647,7 @@ name: ProteinLynx:Log Likelihood
 def: "ProteinLynx log likelihood score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001571
@@ -9674,7 +9655,7 @@ name: ProteinLynx:Ladder Score
 def: "Waters ProteinLynx Ladder score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001572
@@ -9682,7 +9663,7 @@ name: SpectrumMill:Score
 def: "Spectrum mill peptide score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001573
@@ -9690,7 +9671,7 @@ name: SpectrumMill:SPI
 def: "SpectrumMill SPI score (%)." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001574
@@ -9704,7 +9685,7 @@ name: Scaffold: Minimum Peptide Count
 def: "Minimum number of peptides a protein must have to be accepted." [PSI:PI]
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1002106 ! Scaffold input parameter
-relationship: has_value_type: xsd\:positiveInteger ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001576
@@ -9712,7 +9693,7 @@ name: Scaffold: Minimum Protein Probability
 def: "Minimum protein probability a protein must have to be accepted." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002106 ! Scaffold input parameter
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001577
@@ -9720,7 +9701,7 @@ name: Scaffold: Minimum Peptide Probability
 def: "Minimum probability a peptide must have to be accepted for protein scoring." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002106 ! Scaffold input parameter
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001578
@@ -9728,7 +9709,7 @@ name: minimum number of enzymatic termini
 def: "Minimum number of enzymatic termini a peptide must have to be accepted." [PSI:PI]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1002094 ! common search engine input parameter
-relationship: has_value_type: xsd\:nonNegativeInteger ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001579
@@ -9736,7 +9717,7 @@ name: Scaffold:Protein Probability
 def: "Scaffold protein probability score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001580
@@ -9744,7 +9725,7 @@ name: SpectrumMill:Discriminant Score
 def: "Discriminant score from Agilent SpectrumMill software." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001581
@@ -9752,8 +9733,8 @@ name: FAIMS compensation voltage
 def: "The DC potential applied to the asymmetric waveform in FAIMS that compensates for the difference between high and low field mobility of an ion." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002892 ! ion mobility attribute
-relationship: has_units: UO:0000218 ! volt
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_units UO:0000218 ! volt
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001582
@@ -9817,7 +9798,7 @@ name: anchor protein
 def: "A representative protein selected from a set of sequence same-set or spectrum same-set proteins." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001101 ! protein group or subset relationship
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001592
@@ -9825,7 +9806,7 @@ name: family member protein
 def: "A protein with significant homology to another protein, but some distinguishing peptide matches." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001101 ! protein group or subset relationship
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001593
@@ -9839,7 +9820,7 @@ name: sequence same-set protein
 def: "A protein which is indistinguishable or equivalent to another protein, having matches to an identical set of peptide sequences." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001101 ! protein group or subset relationship
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001595
@@ -9847,7 +9828,7 @@ name: spectrum same-set protein
 def: "A protein which is indistinguishable or equivalent to another protein, having matches to a set of peptide sequences that cannot be distinguished using the evidence in the mass spectra." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001101 ! protein group or subset relationship
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001596
@@ -9855,7 +9836,7 @@ name: sequence sub-set protein
 def: "A protein with a sub-set of the peptide sequence matches for another protein, and no distinguishing peptide matches." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001101 ! protein group or subset relationship
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001597
@@ -9863,7 +9844,7 @@ name: spectrum sub-set protein
 def: "A protein with a sub-set of the matched spectra for another protein, where the matches cannot be distinguished using the evidence in the mass spectra, and no distinguishing peptide matches." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001101 ! protein group or subset relationship
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001598
@@ -9871,7 +9852,7 @@ name: sequence subsumable protein
 def: "A sequence same-set or sequence sub-set protein where the matches are distributed across two or more proteins." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001101 ! protein group or subset relationship
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001599
@@ -9879,7 +9860,7 @@ name: spectrum subsumable protein
 def: "A spectrum same-set or spectrum sub-set protein where the matches are distributed across two or more proteins." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001101 ! protein group or subset relationship
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001600
@@ -9887,7 +9868,7 @@ name: protein inference confidence category
 def: "Confidence category of inferred protein (conclusive, non conclusive, ambiguous group or indistinguishable)." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001101 ! protein group or subset relationship
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001601
@@ -9895,7 +9876,7 @@ name: ProteomeDiscoverer:Spectrum Files:Raw File names
 def: "OBSOLETE Name and location of the .raw file or files." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001602
@@ -9903,7 +9884,7 @@ name: ProteomeDiscoverer:SRF File Selector:SRF File Path
 def: "OBSOLETE Path and name of the .srf (SEQUEST Result Format) file." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001603
@@ -9911,7 +9892,7 @@ name: ProteomeDiscoverer:Spectrum Selector:Ionization Source
 def: "OBSOLETE Ionization source (electro-, nano-, thermospray, electron impact, APCI, MALDI, FAB etc)." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001604
@@ -9919,7 +9900,7 @@ name: ProteomeDiscoverer:Activation Type
 def: "OBSOLETE Fragmentation method used (CID, MPD, ECD, PQD, ETD, HCD, Any)." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001605
@@ -9927,7 +9908,7 @@ name: ProteomeDiscoverer:Spectrum Selector:Lower RT Limit
 def: "Lower retention-time limit." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001606
@@ -9935,7 +9916,7 @@ name: ProteomeDiscoverer:Mass Analyzer
 def: "OBSOLETE Type of mass spectrometer used (ITMS, FTMS, TOFMS, SQMS, TQMS, SectorMS)." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001607
@@ -9943,7 +9924,7 @@ name: ProteomeDiscoverer:Max Precursor Mass
 def: "Maximum mass limit of a singly charged precursor ion." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001608
@@ -9951,7 +9932,7 @@ name: ProteomeDiscoverer:Min Precursor Mass
 def: "Minimum mass limit of a singly charged precursor ion." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001609
@@ -9959,7 +9940,7 @@ name: ProteomeDiscoverer:Spectrum Selector:Minimum Peak Count
 def: "Minimum number of peaks in a tandem mass spectrum that is allowed to pass the filter and to be subjected to further processing in the workflow." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001610
@@ -9967,7 +9948,7 @@ name: ProteomeDiscoverer:MS Order
 def: "OBSOLETE Level of the mass spectrum (MS2 ... MS10)." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001611
@@ -9975,7 +9956,7 @@ name: ProteomeDiscoverer:Polarity Mode
 def: "OBSOLETE Polarity mode (positive or negative)." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001612
@@ -9983,7 +9964,7 @@ name: ProteomeDiscoverer:Spectrum Selector:Precursor Selection
 def: "Determines which precursor mass to use for a given MSn scan. This option applies only to higher-order MSn scans (n >= 3)." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001613
@@ -9991,7 +9972,7 @@ name: ProteomeDiscoverer:SN Threshold
 def: "Signal-to-Noise ratio below which peaks are removed." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001614
@@ -9999,7 +9980,7 @@ name: ProteomeDiscoverer:Scan Type
 def: "OBSOLETE Scan type for the precursor ion (full, Single Ion Monitoring (SIM), Single Reaction Monitoring (SRM))." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001615
@@ -10007,7 +9988,7 @@ name: ProteomeDiscoverer:Spectrum Selector:Total Intensity Threshold
 def: "Used to filter out tandem mass spectra that have a total intensity current(sum of the intensities of all peaks in a spectrum) below the specified value." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001616
@@ -10015,7 +9996,7 @@ name: ProteomeDiscoverer:Spectrum Selector:Unrecognized Activation Type Replacem
 def: "Specifies the fragmentation method to use in the search algorithm if it is not included in the scan header." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001617
@@ -10023,7 +10004,7 @@ name: ProteomeDiscoverer:Spectrum Selector:Unrecognized Charge Replacements
 def: "Specifies the charge state of the precursor ions, if it is not defined in the scan header." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001618
@@ -10031,7 +10012,7 @@ name: ProteomeDiscoverer:Spectrum Selector:Unrecognized Mass Analyzer Replacemen
 def: "Specifies the mass spectrometer to use to produce the spectra, if it is not included in the scan header." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001619
@@ -10039,7 +10020,7 @@ name: ProteomeDiscoverer:Spectrum Selector:Unrecognized MS Order Replacements
 def: "Specifies the MS scan order used to produce the product spectra, if it is not included in the scan header." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001620
@@ -10047,7 +10028,7 @@ name: ProteomeDiscoverer:Spectrum Selector:Unrecognized Polarity Replacements
 def: "Specifies the polarity of the ions monitored if it is not included in the scan header." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001621
@@ -10055,7 +10036,7 @@ name: ProteomeDiscoverer:Spectrum Selector:Upper RT Limit
 def: "Upper retention-time limit." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001622
@@ -10063,7 +10044,7 @@ name: ProteomeDiscoverer:Non-Fragment Filter:Mass Window Offset
 def: "Specifies the size of the mass-to-charge ratio (m/z) window in daltons used to remove precursors." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001623
@@ -10071,7 +10052,7 @@ name: ProteomeDiscoverer:Non-Fragment Filter:Maximum Neutral Loss Mass
 def: "Maximum allowed mass of a neutral loss." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001624
@@ -10079,7 +10060,7 @@ name: ProteomeDiscoverer:Non-Fragment Filter:Remove Charge Reduced Precursor
 def: "Determines whether the charge-reduced precursor peaks found in an ETD or ECD spectrum are removed." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001625
@@ -10087,7 +10068,7 @@ name: ProteomeDiscoverer:Non-Fragment Filter:Remove Neutral Loss Peaks
 def: "Determines whether neutral loss peaks are removed from ETD and ECD spectra." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001626
@@ -10095,7 +10076,7 @@ name: ProteomeDiscoverer:Non-Fragment Filter:Remove Only Known Masses
 def: "Determines whether overtone peaks are removed from LTQ FT or LTQ FT Ultra ECD spectra." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001627
@@ -10103,7 +10084,7 @@ name: ProteomeDiscoverer:Non-Fragment Filter:Remove Precursor Overtones
 def: "Determines whether precursor overtone peaks in the spectrum are removed from the input spectrum." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001628
@@ -10111,7 +10092,7 @@ name: ProteomeDiscoverer:Non-Fragment Filter:Remove Precursor Peak
 def: "Determines whether precursor artifact peaks from the MS2 input spectra are removed." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001629
@@ -10119,7 +10100,7 @@ name: ProteomeDiscoverer:Spectrum Grouper:Allow Mass Analyzer Mismatch
 def: "Determines whether the fragment spectrum for scans with the same precursor mass is grouped, regardless of mass analyzer and activation type." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001630
@@ -10127,7 +10108,7 @@ name: ProteomeDiscoverer:Spectrum Grouper:Allow MS Order Mismatch
 def: "Determines whether spectra from different MS order scans can be grouped together." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001631
@@ -10135,7 +10116,7 @@ name: ProteomeDiscoverer:Spectrum Grouper:Max RT Difference
 def: "OBSOLETE Chromatographic window where precursors to be grouped must reside to be considered the same species." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001632
@@ -10143,7 +10124,7 @@ name: ProteomeDiscoverer:Spectrum Grouper:Precursor Mass Criterion
 def: "Groups spectra measured within the given mass and retention-time tolerances into a single spectrum for analysis." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001633
@@ -10151,7 +10132,7 @@ name: ProteomeDiscoverer:Xtract:Highest Charge
 def: "Highest charge state that is allowed for the deconvolution of multiply charged data." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001634
@@ -10159,7 +10140,7 @@ name: ProteomeDiscoverer:Xtract:Highest MZ
 def: "OBSOLETE Highest mass-to-charge (mz) value for spectral peaks in the measured spectrum that are considered for Xtract." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001635
@@ -10167,7 +10148,7 @@ name: ProteomeDiscoverer:Xtract:Lowest Charge
 def: "Lowest charge state that is allowed for the deconvolution of multiply charged data." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001636
@@ -10175,7 +10156,7 @@ name: ProteomeDiscoverer:Xtract:Lowest MZ
 def: "OBSOLETE Lowest mass-to-charge (mz) value for spectral peaks in the measured spectrum that are considered for Xtract." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001637
@@ -10183,7 +10164,7 @@ name: ProteomeDiscoverer:Xtract:Monoisotopic Mass Only
 def: "Determines whether the isotopic pattern, i.e. all isotopes of a mass are removed from the spectrum." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001638
@@ -10191,7 +10172,7 @@ name: ProteomeDiscoverer:Xtract:Overlapping Remainder
 def: "Fraction of the more abundant peak that an overlapping multiplet must exceed in order to be processed (deconvoluted)." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001639
@@ -10199,7 +10180,7 @@ name: ProteomeDiscoverer:Xtract:Required Fitting Accuracy
 def: "Accuracy required for a pattern fit to be considered valid." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001640
@@ -10207,7 +10188,7 @@ name: ProteomeDiscoverer:Xtract:Resolution At 400
 def: "Resolution at mass 400." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001641
@@ -10215,7 +10196,7 @@ name: ProteomeDiscoverer:Lowest Charge State
 def: "Minimum charge state below which peptides are filtered out." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001642
@@ -10223,7 +10204,7 @@ name: ProteomeDiscoverer:Highest Charge State
 def: "Maximum charge above which peptides are filtered out." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001643
@@ -10231,7 +10212,7 @@ name: ProteomeDiscoverer:Spectrum Score Filter:Let Pass Above Scores
 def: "Determines whether spectra with scores above the threshold score are retained rather than filtered out." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001644
@@ -10239,7 +10220,7 @@ name: ProteomeDiscoverer:Dynamic Modification
 def: "Determine dynamic post-translational modifications (PTMs)." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001645
@@ -10247,7 +10228,7 @@ name: ProteomeDiscoverer:Static Modification
 def: "Static Modification to all occurrences of a named amino acid." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001646
@@ -10255,7 +10236,7 @@ name: ProteomeDiscoverer:Mascot:Decoy Search
 def: "OBSOLETE Determines whether the Proteome Discoverer application searches an additional decoy database." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001647
@@ -10263,7 +10244,7 @@ name: ProteomeDiscoverer:Mascot:Error tolerant Search
 def: "Determines whether to search error-tolerant." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001648
@@ -10271,7 +10252,7 @@ name: ProteomeDiscoverer:Mascot:Max MGF File Size
 def: "Maximum size of the .mgf (Mascot Generic Format) file in MByte." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001649
@@ -10279,7 +10260,7 @@ name: ProteomeDiscoverer:Mascot:Mascot Server URL
 def: "URL (Uniform resource Locator) of the Mascot server." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001650
@@ -10287,7 +10268,7 @@ name: ProteomeDiscoverer:Mascot:Number of attempts to submit the search
 def: "Number of attempts to submit the Mascot search." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001651
@@ -10295,7 +10276,7 @@ name: ProteomeDiscoverer:Mascot:X Static Modification
 def: "Number of attempts to submit the Mascot search." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001652
@@ -10303,7 +10284,7 @@ name: ProteomeDiscoverer:Mascot:User Name
 def: "OBSOLETE Name of the user submitting the Mascot search." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001653
@@ -10311,7 +10292,7 @@ name: ProteomeDiscoverer:Mascot:Time interval between attempts to submit a searc
 def: "Time interval between attempts to submit a search in seconds." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001654
@@ -10319,7 +10300,7 @@ name: ProteomeDiscoverer:Enzyme Name
 def: "OBSOLETE Specifies the enzyme reagent used for protein digestion." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001655
@@ -10327,7 +10308,7 @@ name: ProteomeDiscoverer:Fragment Mass Tolerance
 def: "OBSOLETE Mass tolerance used for matching fragment peaks in Da or mmu." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001656
@@ -10335,7 +10316,7 @@ name: Mascot:Instrument
 def: "Type of instrument used to acquire the data in the raw file." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002095 ! Mascot input parameter
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001657
@@ -10343,7 +10324,7 @@ name: ProteomeDiscoverer:Maximum Missed Cleavage Sites
 def: "Maximum number of missed cleavage sites to consider during the digest." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001658
@@ -10351,7 +10332,7 @@ name: ProteomeDiscoverer:Mascot:Peptide CutOff Score
 def: "Minimum score in the IonScore column that each peptide must exceed in order to be reported." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001659
@@ -10359,7 +10340,7 @@ name: ProteomeDiscoverer:Precursor Mass Tolerance
 def: "OBSOLETE Mass window for which precursor ions are considered to be the same species." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001660
@@ -10367,7 +10348,7 @@ name: ProteomeDiscoverer:Mascot:Protein CutOff Score
 def: "Minimum protein score in the IonScore column that each protein must exceed in order to be reported." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001661
@@ -10375,7 +10356,7 @@ name: ProteomeDiscoverer:Protein Database
 def: "OBSOLETE Database to use in the search (configured on the Mascot server)." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001662
@@ -10383,7 +10364,7 @@ name: ProteomeDiscoverer:Mascot:Protein Relevance Factor
 def: "Specifies a factor that is used in calculating a threshold that determines whether a protein appears in the results report." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001663
@@ -10391,7 +10372,7 @@ name: ProteomeDiscoverer:Target FDR Relaxed
 def: "Specifies the relaxed target false discovery rate (FDR, 0.0 - 1.0) for peptide hits with moderate confidence." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001664
@@ -10399,7 +10380,7 @@ name: ProteomeDiscoverer:Target FDR Strict
 def: "Specifies the strict target false discovery rate (FDR, 0.0 - 1.0) for peptide hits with high confidence." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001665
@@ -10407,7 +10388,7 @@ name: ProteomeDiscoverer:Mascot:Taxonomy
 def: "OBSOLETE Limits searches to entries from a particular species or group of species." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001666
@@ -10415,7 +10396,7 @@ name: ProteomeDiscoverer:Use Average Precursor Mass
 def: "OBSOLETE Use average mass for the precursor." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001667
@@ -10423,7 +10404,7 @@ name: Mascot:use MudPIT scoring
 def: "OBSOLETE Determines whether to use MudPIT or normal scoring." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002095 ! Mascot input parameter
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001668
@@ -10431,7 +10412,7 @@ name: ProteomeDiscoverer:Absolute XCorr Threshold
 def: "Minimum cross-correlation threshold that determines whether peptides in an .srf file are imported." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001669
@@ -10439,7 +10420,7 @@ name: ProteomeDiscoverer:SEQUEST:Calculate Probability Score
 def: "Determines whether to calculate a probability score for every peptide match." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001670
@@ -10447,7 +10428,7 @@ name: ProteomeDiscoverer:SEQUEST:CTerminal Modification
 def: "Dynamic C-terminal modification that is used during the search." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001671
@@ -10455,7 +10436,7 @@ name: ProteomeDiscoverer:SEQUEST:Fragment Ion Cutoff Percentage
 def: "Percentage of the theoretical ions that must be found in order for a peptide to be scored and retained." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001672
@@ -10463,7 +10444,7 @@ name: ProteomeDiscoverer:SEQUEST:Max Identical Modifications Per Peptide
 def: "Maximum number of identical modifications that a single peptide can have." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001673
@@ -10471,7 +10452,7 @@ name: ProteomeDiscoverer:Max Modifications Per Peptide
 def: "Maximum number of different modifications that a peptide can have, e.g. because of steric hindrance." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001674
@@ -10479,7 +10460,7 @@ name: ProteomeDiscoverer:SEQUEST:Maximum Peptides Considered
 def: "Maximum number of peptides that are searched and scored per spectrum." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001675
@@ -10487,7 +10468,7 @@ name: ProteomeDiscoverer:Maximum Peptides Output
 def: "Maximum number of peptide matches reported per spectrum." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001676
@@ -10495,7 +10476,7 @@ name: ProteomeDiscoverer:Maximum Protein References Per Peptide
 def: "Maximum number of proteins that a single identified peptide can be associated with during protein assembly." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001677
@@ -10503,7 +10484,7 @@ name: ProteomeDiscoverer:SEQUEST:NTerminal Modification
 def: "Dynamic N-terminal modification that is used during the search." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001678
@@ -10511,7 +10492,7 @@ name: ProteomeDiscoverer:Peptide CTerminus
 def: "Static modification for the C terminal of the peptide used during the search." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001679
@@ -10519,7 +10500,7 @@ name: ProteomeDiscoverer:Peptide NTerminus
 def: "Static modification for the N terminal of the peptide used during the search." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001680
@@ -10527,7 +10508,7 @@ name: ProteomeDiscoverer:SEQUEST:Peptide Relevance Factor
 def: "Specifies a factor to apply to the protein score." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001681
@@ -10535,7 +10516,7 @@ name: ProteomeDiscoverer:Protein Relevance Threshold
 def: "Specifies a peptide threshold that determines whether the protein that it is a part of is scored and retained in the report." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001682
@@ -10543,7 +10524,7 @@ name: ProteomeDiscoverer:Search Against Decoy Database
 def: "OBSOLETE Determines whether the Proteome Discoverer application searches against a decoy database." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001683
@@ -10551,7 +10532,7 @@ name: ProteomeDiscoverer:SEQUEST:Use Average Fragment Masses
 def: "Use average masses for the fragments." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001684
@@ -10559,7 +10540,7 @@ name: ProteomeDiscoverer:Use Neutral Loss a Ions
 def: "Determines whether a ions with neutral loss are used for spectrum matching." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001685
@@ -10567,7 +10548,7 @@ name: ProteomeDiscoverer:Use Neutral Loss b Ions
 def: "Determines whether b ions with neutral loss are used for spectrum matching." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001686
@@ -10575,7 +10556,7 @@ name: ProteomeDiscoverer:Use Neutral Loss y Ions
 def: "Determines whether y ions with neutral loss are used for spectrum matching." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001687
@@ -10583,7 +10564,7 @@ name: ProteomeDiscoverer:Use Neutral Loss z Ions
 def: "Determines whether z ions with neutral loss are used for spectrum matching." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001688
@@ -10591,7 +10572,7 @@ name: ProteomeDiscoverer:SEQUEST:Weight of a Ions
 def: "Uses a ions for spectrum matching with this relative factor." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001689
@@ -10599,7 +10580,7 @@ name: ProteomeDiscoverer:SEQUEST:Weight of b Ions
 def: "Uses b ions for spectrum matching with this relative factor." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001690
@@ -10607,7 +10588,7 @@ name: ProteomeDiscoverer:SEQUEST:Weight of c Ions
 def: "Uses c ions for spectrum matching with this relative factor." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001691
@@ -10615,7 +10596,7 @@ name: ProteomeDiscoverer:SEQUEST:Weight of d Ions
 def: "Uses c ions for spectrum matching with this relative factor." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001692
@@ -10623,7 +10604,7 @@ name: ProteomeDiscoverer:SEQUEST:Weight of v Ions
 def: "Uses c ions for spectrum matching with this relative factor." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001693
@@ -10631,7 +10612,7 @@ name: ProteomeDiscoverer:SEQUEST:Weight of w Ions
 def: "Uses c ions for spectrum matching with this relative factor." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001694
@@ -10639,7 +10620,7 @@ name: ProteomeDiscoverer:SEQUEST:Weight of x Ions
 def: "Uses x ions for spectrum matching with this relative factor." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001695
@@ -10647,7 +10628,7 @@ name: ProteomeDiscoverer:SEQUEST:Weight of y Ions
 def: "Uses y ions for spectrum matching with this relative factor." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001696
@@ -10655,7 +10636,7 @@ name: ProteomeDiscoverer:SEQUEST:Weight of z Ions
 def: "Uses z ions for spectrum matching with this relative factor." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001697
@@ -10663,7 +10644,7 @@ name: ProteomeDiscoverer:ZCore:Protein Score Cutoff
 def: "Sets a minimum protein score that each protein must exceed in order to be reported." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001698
@@ -10671,7 +10652,7 @@ name: ProteomeDiscoverer:Reporter Ions Quantizer:Integration Method
 def: "Specifies which peak to select if more than one peak is found inside the integration window." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001699
@@ -10679,7 +10660,7 @@ name: ProteomeDiscoverer:Reporter Ions Quantizer:Integration Window Tolerance
 def: "Specifies the mass-to-charge window that enables one to look for the reporter peaks." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001700
@@ -10687,7 +10668,7 @@ name: ProteomeDiscoverer:Reporter Ions Quantizer:Quantitation Method
 def: "Quantitation method for isobarically labeled quantitation." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001701
@@ -10695,7 +10676,7 @@ name: ProteomeDiscoverer:Spectrum Exporter:Export Format
 def: "OBSOLETE Format of the exported spectra (dta, mgf or mzData)." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001702
@@ -10703,7 +10684,7 @@ name: ProteomeDiscoverer:Spectrum Exporter:File name
 def: "Name of the output file that contains the exported data." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001703
@@ -10711,7 +10692,7 @@ name: ProteomeDiscoverer:Search Modifications Only For Identified Proteins
 def: "Influences the modifications search." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001704
@@ -10719,7 +10700,7 @@ name: ProteomeDiscoverer:SEQUEST:Std High Confidence XCorr Charge1
 def: "Standard high confidence XCorr parameter for charge = 1." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001705
@@ -10727,7 +10708,7 @@ name: ProteomeDiscoverer:SEQUEST:Std High Confidence XCorr Charge2
 def: "Standard high confidence XCorr parameter for charge = 2." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001706
@@ -10735,7 +10716,7 @@ name: ProteomeDiscoverer:SEQUEST:Std High Confidence XCorr Charge3
 def: "Standard high confidence XCorr parameter for charge = 3." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001707
@@ -10743,7 +10724,7 @@ name: ProteomeDiscoverer:SEQUEST:Std High Confidence XCorr Charge4
 def: "Standard high confidence XCorr parameter for charge >= 4." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001708
@@ -10751,7 +10732,7 @@ name: ProteomeDiscoverer:SEQUEST:Std Medium Confidence XCorr Charge1
 def: "Standard medium confidence XCorr parameter for charge = 1." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001709
@@ -10759,7 +10740,7 @@ name: ProteomeDiscoverer:SEQUEST:Std Medium Confidence XCorr Charge2
 def: "Standard medium confidence XCorr parameter for charge = 2." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001710
@@ -10767,7 +10748,7 @@ name: ProteomeDiscoverer:SEQUEST:Std Medium Confidence XCorr Charge3
 def: "Standard medium confidence XCorr parameter for charge = 3." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001711
@@ -10775,7 +10756,7 @@ name: ProteomeDiscoverer:SEQUEST:Std Medium Confidence XCorr Charge4
 def: "Standard medium confidence XCorr parameter for charge >= 4." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001712
@@ -10783,7 +10764,7 @@ name: ProteomeDiscoverer:SEQUEST:FT High Confidence XCorr Charge1
 def: "FT high confidence XCorr parameter for charge = 1." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001713
@@ -10791,7 +10772,7 @@ name: ProteomeDiscoverer:SEQUEST:FT High Confidence XCorr Charge2
 def: "FT high confidence XCorr parameter for charge = 2." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001714
@@ -10799,7 +10780,7 @@ name: ProteomeDiscoverer:SEQUEST:FT High Confidence XCorr Charge3
 def: "FT high confidence XCorr parameter for charge = 3." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001715
@@ -10807,7 +10788,7 @@ name: ProteomeDiscoverer:SEQUEST:FT High Confidence XCorr Charge4
 def: "FT high confidence XCorr parameter for charge >= 4." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001716
@@ -10815,7 +10796,7 @@ name: ProteomeDiscoverer:SEQUEST:FT Medium Confidence XCorr Charge1
 def: "FT medium confidence XCorr parameter for charge = 1." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001717
@@ -10823,7 +10804,7 @@ name: ProteomeDiscoverer:SEQUEST:FT Medium Confidence XCorr Charge2
 def: "FT medium confidence XCorr parameter for charge = 2." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001718
@@ -10831,7 +10812,7 @@ name: ProteomeDiscoverer:SEQUEST:FT Medium Confidence XCorr Charge3
 def: "FT medium confidence XCorr parameter for charge = 3." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001719
@@ -10839,7 +10820,7 @@ name: ProteomeDiscoverer:SEQUEST:FT Medium Confidence XCorr Charge4
 def: "FT medium confidence XCorr parameter for charge >= 4." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001720
@@ -10847,7 +10828,7 @@ name: ProteomeDiscoverer:1. Dynamic Modification
 def: "OBSOLETE ProteomeDiscoverer's 1st dynamic post-translational modification (PTM) input parameter." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001721
@@ -10855,7 +10836,7 @@ name: ProteomeDiscoverer:2. Dynamic Modification
 def: "OBSOLETE ProteomeDiscoverer's 2nd dynamic post-translational modification (PTM) input parameter." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001722
@@ -10863,7 +10844,7 @@ name: ProteomeDiscoverer:3. Dynamic Modification
 def: "OBSOLETE ProteomeDiscoverer's 3rd dynamic post-translational modification (PTM) input parameter." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001723
@@ -10871,7 +10852,7 @@ name: ProteomeDiscoverer:4. Dynamic Modification
 def: "OBSOLETE ProteomeDiscoverer's 4th dynamic post-translational modification (PTM) input parameter." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001724
@@ -10879,7 +10860,7 @@ name: ProteomeDiscoverer:Static Modification for X
 def: "Static Modification for X." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001725
@@ -10887,7 +10868,7 @@ name: ProteomeDiscoverer:Initial minimal peptide probability
 def: "Minimal initial peptide probability to contribute to analysis." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001726
@@ -10895,7 +10876,7 @@ name: ProteomeDiscoverer:Minimal peptide probability
 def: "Minimum adjusted peptide probability contributing to protein probability." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001727
@@ -10903,7 +10884,7 @@ name: ProteomeDiscoverer:Minimal peptide weight
 def: "Minimum peptide weight contributing to protein probability." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001728
@@ -10911,7 +10892,7 @@ name: ProteomeDiscoverer:Number of input1 spectra
 def: "Number of spectra from 1+ precursor ions." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001729
@@ -10919,7 +10900,7 @@ name: ProteomeDiscoverer:Number of input2 spectra
 def: "Number of spectra from 2+ precursor ions." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001730
@@ -10927,7 +10908,7 @@ name: ProteomeDiscoverer:Number of input3 spectra
 def: "Number of spectra from 3+ precursor ions." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001731
@@ -10935,7 +10916,7 @@ name: ProteomeDiscoverer:Number of input4 spectra
 def: "Number of spectra from 4+ precursor ions." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001732
@@ -10943,7 +10924,7 @@ name: ProteomeDiscoverer:Number of input5 spectra
 def: "Number of spectra from 5+ precursor ions." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001733
@@ -10951,7 +10932,7 @@ name: ProteomeDiscoverer:Number of predicted correct proteins
 def: "Total number of predicted correct protein ids (sum of probabilities)." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001734
@@ -10959,7 +10940,7 @@ name: ProteomeDiscoverer:Organism
 def: "OBSOLETE Sample organism (used for annotation purposes)." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001735
@@ -10967,7 +10948,7 @@ name: ProteomeDiscoverer:Reference Database
 def: "OBSOLETE Full path database name." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001736
@@ -10975,7 +10956,7 @@ name: ProteomeDiscoverer:Residue substitution list
 def: "Residues considered equivalent when comparing peptides." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001737
@@ -10983,7 +10964,7 @@ name: ProteomeDiscoverer:Source file extension
 def: "OBSOLETE File type (if not pepXML)." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001738
@@ -10991,7 +10972,7 @@ name: ProteomeDiscoverer:Source Files
 def: "OBSOLETE Input pepXML files." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001739
@@ -10999,7 +10980,7 @@ name: ProteomeDiscoverer:Source Files old
 def: "OBSOLETE Input pepXML files (old)." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001740
@@ -11007,7 +10988,7 @@ name: ProteomeDiscoverer:WinCyg reference database
 def: "Windows full path for database." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001741
@@ -11015,7 +10996,7 @@ name: ProteomeDiscoverer:WinCyg source files
 def: "Windows pepXML file names." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001742
@@ -11029,7 +11010,7 @@ name: ProteomeDiscoverer:Mascot:Weight of A Ions
 def: "Determines if to use A ions for spectrum matching." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001744
@@ -11037,7 +11018,7 @@ name: ProteomeDiscoverer:Mascot:Weight of B Ions
 def: "Determines if to use B ions for spectrum matching." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001745
@@ -11045,7 +11026,7 @@ name: ProteomeDiscoverer:Mascot:Weight of C Ions
 def: "Determines if to use C ions for spectrum matching." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001746
@@ -11053,7 +11034,7 @@ name: ProteomeDiscoverer:Mascot:Weight of D Ions
 def: "Determines if to use D ions for spectrum matching." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001747
@@ -11061,7 +11042,7 @@ name: ProteomeDiscoverer:Mascot:Weight of V Ions
 def: "Determines if to use V ions for spectrum matching." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001748
@@ -11069,7 +11050,7 @@ name: ProteomeDiscoverer:Mascot:Weight of W Ions
 def: "Determines if to use W ions for spectrum matching." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001749
@@ -11077,7 +11058,7 @@ name: ProteomeDiscoverer:Mascot:Weight of X Ions
 def: "Determines if to use X ions for spectrum matching." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001750
@@ -11085,7 +11066,7 @@ name: ProteomeDiscoverer:Mascot:Weight of Y Ions
 def: "Determines if to use Y ions for spectrum matching." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001751
@@ -11093,7 +11074,7 @@ name: ProteomeDiscoverer:Mascot:Weight of Z Ions
 def: "Determines if to use z ions for spectrum matching." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001752
@@ -11101,7 +11082,7 @@ name: ProteomeDiscoverer:Spectrum Selector:Use New Precursor Reevaluation
 def: "Determines if to use precursor reevaluation." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001753
@@ -11109,7 +11090,7 @@ name: ProteomeDiscoverer:Spectrum Selector:SN Threshold FTonly
 def: "Signal-to-Noise ratio below which peaks are removed (in FT mode only)." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001754
@@ -11117,7 +11098,7 @@ name: ProteomeDiscoverer:Mascot:Please Do not Touch this
 def: "Unknown Mascot parameter which ProteomeDiscoverer uses for mascot searches." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001755
@@ -11125,7 +11106,7 @@ name: contact phone number
 def: "Phone number of the contact person or organization." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000585 ! contact attribute
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001756
@@ -11133,7 +11114,7 @@ name: contact fax number
 def: "Fax number for the contact person or organization." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000585 ! contact attribute
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001757
@@ -11141,7 +11122,7 @@ name: contact toll-free phone number
 def: "Toll-free phone number of the contact person or organization." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000585 ! contact attribute
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001758
@@ -11149,7 +11130,7 @@ name: Mascot:SigThresholdType
 def: "Significance threshold type used in Mascot reporting (either 'identity' or 'homology')." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002095 ! Mascot input parameter
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001759
@@ -11157,7 +11138,7 @@ name: Mascot:ProteinGrouping
 def: "Strategy used by Mascot to group proteins with same peptide matches (one of 'none', 'Occam's razor' or 'family clustering')." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002095 ! Mascot input parameter
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001760
@@ -11165,7 +11146,7 @@ name: Percolator:features
 def: "List of Percolator features that were used in processing the peptide matches. Typical Percolator features are 'retentionTime', 'dM', 'mScore', 'lgDScore', 'mrCalc', 'charge' and 'dMppm'." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002107 ! Percolator input parameter
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001761
@@ -11365,7 +11346,7 @@ name: Mascot:PreferredTaxonomy
 def: "NCBI TaxID taxonomy ID to prefer when two or more proteins match the same set of peptides or when protein entry in database represents multiple sequences." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002095 ! Mascot input parameter
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001795
@@ -11457,7 +11438,7 @@ name: technical replicate
 def: "The study variable is 'technical replicate'. The string value denotes the category of technical replicate, e.g. 'run generated from same sample'." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001807 ! study variable attribute
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001809
@@ -11495,7 +11476,7 @@ name: generic experimental condition
 def: "The experimental condition is given in the value of this term." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001807 ! study variable attribute
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001815
@@ -11503,7 +11484,7 @@ name: time series, time point X
 def: "The experimental design followed a time series design. The time point of this run is given in the value of this term." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1001807 ! study variable attribute
-relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001816
@@ -11511,7 +11492,7 @@ name: dilution series, concentration X
 def: "The experimental design followed a dilution series design. The concentration of this run is given in the value of this term." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001807 ! study variable attribute
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001817
@@ -11591,7 +11572,7 @@ name: SRM transition ID
 def: "Identifier for an SRM transition in an external document describing additional information about the transition." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001828 ! feature attribute
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001830
@@ -11612,7 +11593,7 @@ name: quantitation software comment or customizations
 def: "Quantitation software comment or any customizations to the default setup of the software." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001129 ! quantification information
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001833
@@ -11662,7 +11643,7 @@ name: LC-MS feature intensity
 def: "Maximum peak intensity of the LC-MS feature." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002735 ! feature-level quantification datatype
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001841
@@ -11670,7 +11651,7 @@ name: LC-MS feature volume
 def: "Real (intensity times area) volume of the LC-MS feature." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002735 ! feature-level quantification datatype
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001842
@@ -11678,7 +11659,7 @@ name: sequence-level spectral count
 def: "The number of MS2 spectra identified for a raw peptide sequence without PTMs and charge state in spectral counting." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002737 ! peptide-level quantification datatype
-relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001843
@@ -11686,7 +11667,7 @@ name: MS1 feature maximum intensity
 def: "Maximum intensity of MS1 feature." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002735 ! feature-level quantification datatype
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001844
@@ -11694,7 +11675,7 @@ name: MS1 feature area
 def: "Area of MS1 feature." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002735 ! feature-level quantification datatype
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001845
@@ -11702,7 +11683,7 @@ name: peak area
 def: "OBSOLETE Area of MS1 peak (e.g. SILAC, 15N)." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001846
@@ -11710,7 +11691,7 @@ name: isotopic pattern area
 def: "Area of all peaks belonging to the isotopic pattern of light or heavy peak (e.g. 15N)." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001847
@@ -11718,7 +11699,7 @@ name: reporter ion intensity
 def: "Intensity of MS2 reporter ion (e.g. iTraq)." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001848
@@ -11732,7 +11713,7 @@ name: sum of MatchedFeature values
 def: "OBSOLETE Peptide quantification value calculated as sum of MatchedFeature quantification values." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002735 ! feature-level quantification datatype
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001850
@@ -11740,7 +11721,7 @@ name: normalized peptide value
 def: "Normalized peptide value." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002737 ! peptide-level quantification datatype
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001851
@@ -11748,7 +11729,7 @@ name: protein value: sum of peptide values
 def: "Protein quantification value calculated as sum of peptide values." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002738 ! protein-level quantification datatype
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001852
@@ -11756,7 +11737,7 @@ name: normalized protein value
 def: "Normalized protein value." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002738 ! protein-level quantification datatype
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001853
@@ -11764,7 +11745,7 @@ name: max fold change
 def: "Global datatype: Maximum of all pair-wise fold changes of group means (e.g. Progenesis)." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001854
@@ -11772,7 +11753,7 @@ name: ANOVA p-value
 def: "Global datatype: p-value of ANOVA of group means (e.g. Progenesis)." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002072 ! p-value
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001855
@@ -11780,7 +11761,7 @@ name: t-test p-value
 def: "P-value of t-Test of two groups." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002072 ! p-value
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001856
@@ -11788,7 +11769,7 @@ name: reporter ion raw value
 def: "Intensity (or area) of MS2 reporter ion (e.g. iTraq)." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001857
@@ -11796,7 +11777,7 @@ name: reporter ion normalized value
 def: "Normalized value of MS2 reporter ion (e.g. iTraq)." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001858
@@ -11804,7 +11785,7 @@ name: XIC area
 def: "Area of the extracted ion chromatogram (e.g. of a transition in SRM)." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001859
@@ -11812,7 +11793,7 @@ name: normalized XIC area
 def: "Normalized area of the extracted ion chromatogram (e.g. of a transition in SRM)." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001860
@@ -11820,13 +11801,13 @@ name: protein value: mean of peptide ratios
 def: "Protein quantification value calculated as mean of peptide ratios." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002738 ! protein-level quantification datatype
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001861
 name: quantification data processing
 def: "Terms used to describe types of quantification data processing." [PSI:MS]
-relationship: part_of: MS:1001000 ! spectrum interpretation
+relationship: part_of MS:1001000 ! spectrum interpretation
 
 [Term]
 id: MS:1001862
@@ -11870,8 +11851,8 @@ name: distinct peptide-level q-value
 def: "Estimation of the q-value for distinct peptides once redundant identifications of the same peptide have been removed (id est multiple PSMs, possibly with different mass modifications, mapping to the same sequence have been collapsed to one entry)." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002484 ! peptide-level statistical threshold
-relationship: has_domain: MS:1002305 ! value between 0 and 1 inclusive
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001869
@@ -11879,8 +11860,8 @@ name: protein-level q-value
 def: "Estimation of the q-value for proteins." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001116 ! single protein identification statistic
-relationship: has_domain: MS:1002305 ! value between 0 and 1 inclusive
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001870
@@ -11888,8 +11869,8 @@ name: peptide sequence-level p-value
 def: "Estimation of the p-value for distinct peptides once redundant identifications of the same peptide have been removed (id est multiple PSMs have been collapsed to one entry)." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001092 ! peptide sequence-level identification statistic
-relationship: has_domain: MS:1002305 ! value between 0 and 1 inclusive
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001871
@@ -11897,8 +11878,8 @@ name: protein-level p-value
 def: "Estimation of the p-value for proteins." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001116 ! single protein identification statistic
-relationship: has_domain: MS:1002305 ! value between 0 and 1 inclusive
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001872
@@ -11906,8 +11887,8 @@ name: peptide sequence-level e-value
 def: "Estimation of the e-value for distinct peptides once redundant identifications of the same peptide have been removed (id est multiple PSMs have been collapsed to one entry)." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001092 ! peptide sequence-level identification statistic
-relationship: has_domain: MS:1002306 ! value greater than zero
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_domain MS:1002306 ! value greater than zero
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001873
@@ -11915,8 +11896,8 @@ name: protein-level e-value
 def: "Estimation of the e-value for proteins." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001116 ! single protein identification statistic
-relationship: has_domain: MS:1002306 ! value greater than zero
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_domain MS:1002306 ! value greater than zero
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001874
@@ -11925,7 +11906,7 @@ def: "OBSOLETE A smoothing of the distribution of q-values calculated for PSMs f
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1001153 ! search engine specific score
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001875
@@ -11933,7 +11914,7 @@ name: modification motif
 def: "The regular expression describing the sequence motif for a modification." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001056 ! modification specificity rule
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001876
@@ -11962,8 +11943,8 @@ name: offset voltage
 def: "The potential difference between two adjacent interface voltages affecting in-source collision induced dissociation." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000482 ! source attribute
-relationship: has_units: UO:0000218 ! volt
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units UO:0000218 ! volt
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001880
@@ -11981,7 +11962,7 @@ is_a: MS:1000560 ! mass spectrometer file format
 id: MS:1001882
 name: transition validation attribute
 def: "Attributes of the quality of a transition that affect its selection as appropriate." [PSI:MS]
-relationship: part_of: MS:1000908 ! transition
+relationship: part_of MS:1000908 ! transition
 
 [Term]
 id: MS:1001883
@@ -11989,7 +11970,7 @@ name: coefficient of variation
 def: "Variation of a set of signal measurements calculated as the standard deviation relative to the mean." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1001882 ! transition validation attribute
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001884
@@ -11997,7 +11978,7 @@ name: signal-to-noise ratio
 def: "Unitless number providing the ratio of the total measured intensity of a signal relative to the estimated noise level for that signal." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1001882 ! transition validation attribute
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001885
@@ -12005,7 +11986,7 @@ name: command-line parameters
 def: "Parameters string passed to a command-line interface software application, omitting the executable name." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000630 ! data processing parameter
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001886
@@ -12038,7 +12019,7 @@ name: Progenesis:protein normalised abundance
 def: "The data type normalised abundance for proteins produced by Progenesis LC-MS." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002738 ! protein-level quantification datatype
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001891
@@ -12046,7 +12027,7 @@ name: Progenesis:peptide normalised abundance
 def: "The data type normalised abundance for peptides produced by Progenesis LC-MS." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002737 ! peptide-level quantification datatype
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001892
@@ -12054,7 +12035,7 @@ name: Progenesis:protein raw abundance
 def: "The data type raw abundance for proteins produced by Progenesis LC-MS." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002738 ! protein-level quantification datatype
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001893
@@ -12062,7 +12043,7 @@ name: Progenesis:peptide raw abundance
 def: "The data type raw abundance for peptide produced by Progenesis LC-MS." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002737 ! peptide-level quantification datatype
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001894
@@ -12070,7 +12051,7 @@ name: Progenesis:confidence score
 def: "The data type confidence score produced by Progenesis LC-MS." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001895
@@ -12078,7 +12059,7 @@ name: Progenesis:peptide count
 def: "The data type peptide count produced by Progenesis LC-MS." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002737 ! peptide-level quantification datatype
-relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001896
@@ -12086,7 +12067,7 @@ name: Progenesis:feature intensity
 def: "The data type feature intensity produced by Progenesis LC-MS." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002735 ! feature-level quantification datatype
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001897
@@ -12094,7 +12075,7 @@ name: MaxQuant:peptide counts (unique)
 def: "The data type peptide counts (unique) produced by MaxQuant." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002737 ! peptide-level quantification datatype
-relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001898
@@ -12102,7 +12083,7 @@ name: MaxQuant:peptide counts (all)
 def: "The data type peptide counts (all) produced by MaxQuant." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002737 ! peptide-level quantification datatype
-relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001899
@@ -12110,7 +12091,7 @@ name: MaxQuant:peptide counts (razor+unique)
 def: "The data type peptide counts (razor+unique) produced by MaxQuant." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002737 ! peptide-level quantification datatype
-relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001900
@@ -12118,7 +12099,7 @@ name: MaxQuant:sequence length
 def: "The data type sequence length produced by MaxQuant." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002737 ! peptide-level quantification datatype
-relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001901
@@ -12126,7 +12107,7 @@ name: MaxQuant:PEP
 def: "The data type PEP (posterior error probability) produced by MaxQuant." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001902
@@ -12134,7 +12115,7 @@ name: MaxQuant:LFQ intensity
 def: "The data type LFQ intensity produced by MaxQuant." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001903
@@ -12142,7 +12123,7 @@ name: MaxQuant:feature intensity
 def: "The data type feature intensity produced by MaxQuant." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002735 ! feature-level quantification datatype
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001904
@@ -12150,7 +12131,7 @@ name: MaxQuant:MS/MS count
 def: "The data type MS2 count produced by MaxQuant." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
-relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001905
@@ -12158,7 +12139,7 @@ name: emPAI value
 def: "The emPAI value of protein abundance, produced from the emPAI algorithm." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002738 ! protein-level quantification datatype
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001906
@@ -12166,7 +12147,7 @@ name: APEX value
 def: "The APEX value of protein abundance, produced from the APEX software." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002738 ! protein-level quantification datatype
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001907
@@ -12174,9 +12155,9 @@ name: retention time window width
 def: "The full width of a retention time window for a chromatographic peak." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000915 ! retention time window attribute
-relationship: has_units: UO:0000010 ! second
-relationship: has_units: UO:0000031 ! minute
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units UO:0000010 ! second
+relationship: has_units UO:0000031 ! minute
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001908
@@ -12216,8 +12197,8 @@ name: S-lens voltage
 def: "Potential difference setting of the Thermo Scientific S-lens stacked-ring ion guide in volts." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000482 ! source attribute
-relationship: has_units: UO:0000218 ! volt
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units UO:0000218 ! volt
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001914
@@ -12230,28 +12211,28 @@ id: MS:1001915
 name: leukocyte elastase
 def: "Enzyme leukocyte elastase (EC 3.4.21.37)." [BRENDA:3.4.21.37]
 is_a: MS:1001045 ! cleavage agent name
-relationship: has_regexp: MS:1001957 ! (?<=[ALIV])(?!P)
+relationship: has_regexp MS:1001957 ! (?<=[ALIV])(?!P)
 
 [Term]
 id: MS:1001916
 name: proline endopeptidase
 def: "Enzyme proline endopeptidase (EC 3.4.21.26)." [BRENDA:3.4.21.26]
 is_a: MS:1001045 ! cleavage agent name
-relationship: has_regexp: MS:1001958 ! (?<=[HKR]P)(?!P)
+relationship: has_regexp MS:1001958 ! (?<=[HKR]P)(?!P)
 
 [Term]
 id: MS:1001917
 name: glutamyl endopeptidase
 def: "Enzyme glutamyl endopeptidase (EC 3.4.21.19)." [BRENDA:3.4.21.19]
 is_a: MS:1001045 ! cleavage agent name
-relationship: has_regexp: MS:1001959 ! (?<=[^E]E)
+relationship: has_regexp MS:1001959 ! (?<=[^E]E)
 
 [Term]
 id: MS:1001918
 name: 2-iodobenzoate
 def: "Chemical iodobenzoate. Cleaves after W." [PubChem_Compound:4739928]
 is_a: MS:1001045 ! cleavage agent name
-relationship: has_regexp: MS:1001960 ! (?<=W)
+relationship: has_regexp MS:1001960 ! (?<=W)
 
 [Term]
 id: MS:1001919
@@ -12259,7 +12240,7 @@ name: ProteomeXchange accession number
 def: "Main identifier of a ProteomeXchange dataset." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001921
@@ -12267,7 +12248,7 @@ name: ProteomeXchange accession number version number
 def: "Version number of a ProteomeXchange accession number." [PSI:PI]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
-relationship: has_value_type: xsd\:nonNegativeInteger ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001922
@@ -12275,8 +12256,8 @@ name: Digital Object Identifier (DOI)
 def: "DOI unique identifier of a publication." [PSI:PI, http://dx.doi.org]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
-relationship: has_regexp: MS:1002480 ! (10[.][0-9]\{4,\}(?:[.][0-9]+)*/(?:(?![\"&\'<>])[^ \t\\r\n\\v\\f])+)
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_regexp MS:1002480 ! (10[.][0-9]\{4,\}(?:[.][0-9]+)*/(?:(?![\"&\'<>])[^ \t\\r\n\\v\\f])+)
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001923
@@ -12284,7 +12265,7 @@ name: external reference keyword
 def: "Free text attribute that can enrich the information about an entity." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002840 ! external reference data
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001924
@@ -12292,7 +12273,7 @@ name: journal article keyword
 def: "Keyword present in a scientific publication." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001923 ! external reference keyword
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001925
@@ -12300,7 +12281,7 @@ name: submitter keyword
 def: "Keyword assigned by the data submitter." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001923 ! external reference keyword
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001926
@@ -12308,7 +12289,7 @@ name: curator keyword
 def: "Keyword assigned by a data curator." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001923 ! external reference keyword
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001927
@@ -12316,7 +12297,7 @@ name: Tranche file hash
 def: "Hash assigned by the Tranche resource to an individual file." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001928
@@ -12324,7 +12305,7 @@ name: Tranche project hash
 def: "Hash assigned by the Tranche resource to a whole project." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001929
@@ -12332,7 +12313,7 @@ name: PRIDE experiment URI
 def: "URI that allows the access to one experiment in the PRIDE database." [PSI:PI]
 xref: value-type:xsd\:anyURI "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
-relationship: has_value_type: xsd\:anyURI ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:anyURI ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001930
@@ -12340,63 +12321,63 @@ name: PRIDE project URI
 def: "URI that allows the access to one project in the PRIDE database." [PSI:PI]
 xref: value-type:xsd\:anyURI "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
-relationship: has_value_type: xsd\:anyURI ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:anyURI ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001931
 name: source interface
 def: "The source interface." [PSI:MS]
-relationship: part_of: MS:1000458 ! source
+relationship: part_of MS:1000458 ! source
 
 [Term]
 id: MS:1001932
 name: source interface model
 def: "The source interface model." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
-relationship: part_of: MS:1001931 ! source interface
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: part_of MS:1001931 ! source interface
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001933
 name: source sprayer
 def: "The source sprayer." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
-relationship: part_of: MS:1000458 ! source
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: part_of MS:1000458 ! source
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001934
 name: source sprayer type
 def: "The source sprayer type." [PSI:MS]
-relationship: part_of: MS:1001933 ! source sprayer
+relationship: part_of MS:1001933 ! source sprayer
 
 [Term]
 id: MS:1001935
 name: source sprayer manufacturer
 def: "The source sprayer manufacturer." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
-relationship: part_of: MS:1001933 ! source sprayer
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: part_of MS:1001933 ! source sprayer
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001936
 name: source sprayer model
 def: "The source sprayer model." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
-relationship: part_of: MS:1001933 ! source sprayer
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: part_of MS:1001933 ! source sprayer
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001937
 name: sample plate
 def: "Plate where the sample solution is spotted in a MALDI or similar instrument." [PSI:MS]
-relationship: part_of: MS:1000458 ! source
+relationship: part_of MS:1000458 ! source
 
 [Term]
 id: MS:1001938
 name: sample plate type
 def: "The sample plate type." [PSI:MS]
-relationship: part_of: MS:1001937 ! sample plate
+relationship: part_of MS:1001937 ! sample plate
 
 [Term]
 id: MS:1001939
@@ -12414,7 +12395,7 @@ is_a: MS:1001938 ! sample plate type
 id: MS:1001941
 name: electrospray supply type
 def: "Whether the sprayer is fed or is loaded with sample once." [PSI:MS]
-relationship: part_of: MS:1000458 ! source
+relationship: part_of MS:1000458 ! source
 
 [Term]
 id: MS:1001942
@@ -12434,8 +12415,8 @@ name: Collision cell exit potential
 def: "Potential difference between Q2 and Q3 in a triple quadrupole instrument in volts." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000510 ! precursor activation attribute
-relationship: has_units: UO:0000218 ! volt
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units UO:0000218 ! volt
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001945
@@ -12479,7 +12460,7 @@ name: PEAKS:peptideScore
 def: "The PEAKS peptide '-10lgP Score'." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001951
@@ -12487,7 +12468,7 @@ name: PEAKS:proteinScore
 def: "The PEAKS protein '-10lgP Score'." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001952
@@ -12495,23 +12476,23 @@ name: ZCore:probScore
 def: "The ZCore probability score." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001953
 name: source interface manufacturer
 def: "The source interface manufacturer." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
-relationship: part_of: MS:1001931 ! source interface
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: part_of MS:1001931 ! source interface
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001954
 name: acquisition parameter
 def: "Parameters used in the mass spectrometry acquisition." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
-relationship: part_of: MS:1001458 ! spectrum generation information
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: part_of MS:1001458 ! spectrum generation information
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001955
@@ -12554,8 +12535,8 @@ id: MS:1001961
 name: peptide spectrum match scoring algorithm
 def: "Algorithm used to score the match between a spectrum and a peptide ion." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
-relationship: part_of: MS:1001458 ! spectrum generation information
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: part_of MS:1001458 ! spectrum generation information
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001962
@@ -12563,7 +12544,7 @@ name: Mascot:C13 counts
 def: "C13 peaks to use in peak detection." [PSI:MS]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1002095 ! Mascot input parameter
-relationship: has_value_type: xsd\:nonNegativeInteger ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001963
@@ -12571,7 +12552,7 @@ name: ProteinExtractor:Weighting
 def: "Weighting factor for protein list compilation by ProteinExtractor." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001964
@@ -12579,7 +12560,7 @@ name: ProteinScape:second round Mascot
 def: "Flag indicating a second round search with Mascot." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002100 ! ProteinScape input parameter
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001965
@@ -12587,7 +12568,7 @@ name: ProteinScape:second round Phenyx
 def: "Flag indicating a second round search with Phenyx." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002100 ! ProteinScape input parameter
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001966
@@ -12601,8 +12582,8 @@ name: product ion drift time
 def: "OBSOLETE The ion drift time of an MS2 product ion." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002222 ! SRM transition attribute
-relationship: has_units: UO:0000028 ! millisecond
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units UO:0000028 ! millisecond
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001968
@@ -12616,8 +12597,8 @@ name: phosphoRS score
 def: "phosphoRS score for PTM site location at the PSM-level." [DOI:10.1021/pr200611n, PMID:22073976]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001968 ! PTM localization PSM-level statistic
-relationship: has_regexp: MS:1002505 ! regular expression for modification localization scoring
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001970
@@ -12625,8 +12606,8 @@ name: phosphoRS sequence probability
 def: "Probability that the respective isoform is correct." [DOI:10.1021/pr200611n, PMID:22073976]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001968 ! PTM localization PSM-level statistic
-relationship: has_regexp: MS:1002505 ! regular expression for modification localization scoring
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001971
@@ -12634,8 +12615,8 @@ name: phosphoRS site probability
 def: "Estimate of the probability that the respective site is truly phosphorylated." [DOI:10.1021/pr200611n, PMID:22073976]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001968 ! PTM localization PSM-level statistic
-relationship: has_regexp: MS:1002505 ! regular expression for modification localization scoring
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001972
@@ -12643,7 +12624,7 @@ name: PTM scoring algorithm version
 def: "Version of the post-translational modification scoring algorithm." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001471 ! peptide modification details
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001973
@@ -12658,8 +12639,8 @@ def: "Score specific to DeBunker." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001968 ! PTM localization PSM-level statistic
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_regexp: MS:1002505 ! regular expression for modification localization scoring
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001975
@@ -12667,10 +12648,10 @@ name: delta m/z
 def: "The difference between a theoretically calculated m/z and the corresponding experimentally measured m/z. It can be expressed as absolute or relative value." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001405 ! spectrum identification result details
-relationship: has_units: UO:0000166 ! parts per notation unit
-relationship: has_units: UO:0000187 ! percent
-relationship: has_units: UO:0000221 ! dalton
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_units UO:0000166 ! parts per notation unit
+relationship: has_units UO:0000187 ! percent
+relationship: has_units UO:0000221 ! dalton
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001976
@@ -12678,10 +12659,10 @@ name: delta M
 def: "The difference between a theoretically calculated molecular mass M and the corresponding experimentally measured M. It can be expressed as absolute or relative value." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001405 ! spectrum identification result details
-relationship: has_units: UO:0000166 ! parts per notation unit
-relationship: has_units: UO:0000187 ! percent
-relationship: has_units: UO:0000221 ! dalton
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_units UO:0000166 ! parts per notation unit
+relationship: has_units UO:0000187 ! percent
+relationship: has_units UO:0000221 ! dalton
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001977
@@ -12695,8 +12676,8 @@ name: MSQuant:PTM-score
 def: "The PTM score from MSQuant software." [DOI:10.1021/pr900721e, PMID:19888749]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001968 ! PTM localization PSM-level statistic
-relationship: has_regexp: MS:1002505 ! regular expression for modification localization scoring
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001979
@@ -12704,8 +12685,8 @@ name: MaxQuant:PTM Score
 def: "The PTM score from MaxQuant software." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001968 ! PTM localization PSM-level statistic
-relationship: has_regexp: MS:1002505 ! regular expression for modification localization scoring
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001980
@@ -12713,8 +12694,8 @@ name: MaxQuant:Phospho (STY) Probabilities
 def: "The Phospho (STY) Probabilities from MaxQuant software." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001968 ! PTM localization PSM-level statistic
-relationship: has_regexp: MS:1002505 ! regular expression for modification localization scoring
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001981
@@ -12722,7 +12703,7 @@ name: MaxQuant:Phospho (STY) Score Diffs
 def: "The Phospho (STY) Score Diffs from MaxQuant software." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001968 ! PTM localization PSM-level statistic
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001982
@@ -12730,8 +12711,8 @@ name: MaxQuant:P-site localization probability
 def: "The P-site localization probability value from MaxQuant software." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001968 ! PTM localization PSM-level statistic
-relationship: has_regexp: MS:1002505 ! regular expression for modification localization scoring
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001983
@@ -12739,8 +12720,8 @@ name: MaxQuant:PTM Delta Score
 def: "The PTM Delta Score value from MaxQuant software (Difference between highest scoring site and second highest)." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001968 ! PTM localization PSM-level statistic
-relationship: has_regexp: MS:1002505 ! regular expression for modification localization scoring
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001984
@@ -12754,8 +12735,8 @@ name: Ascore
 def: "A-score for PTM site location at the PSM-level." [DOI:10.1038/nbt1240, PMID:16964243]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001968 ! PTM localization PSM-level statistic
-relationship: has_regexp: MS:1002505 ! regular expression for modification localization scoring
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001986
@@ -12763,8 +12744,8 @@ name: H-Score
 def: "H-Score for peptide phosphorylation site location." [DOI:10.1021/pr1006813, PMID:20836569]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001968 ! PTM localization PSM-level statistic
-relationship: has_regexp: MS:1002505 ! regular expression for modification localization scoring
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001987
@@ -12856,7 +12837,7 @@ name: MS1 label-based raw feature quantitation
 def: "MS1 label-based raw feature quantitation." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002018 ! MS1 label-based analysis
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002002
@@ -12864,7 +12845,7 @@ name: MS1 label-based peptide level quantitation
 def: "MS1 label-based peptide level quantitation." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002018 ! MS1 label-based analysis
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002003
@@ -12872,7 +12853,7 @@ name: MS1 label-based protein level quantitation
 def: "MS1 label-based protein level quantitation." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002018 ! MS1 label-based analysis
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002004
@@ -12880,7 +12861,7 @@ name: MS1 label-based proteingroup level quantitation
 def: "MS1 label-based proteingroup level quantitation." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002018 ! MS1 label-based analysis
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002005
@@ -12892,7 +12873,7 @@ is_a: MS:1000901 ! retention time normalization standard
 id: MS:1002006
 name: SRM transition type
 def: "The type of the transitions, e.g. target or decoy." [PSI:MS]
-relationship: part_of: MS:1000908 ! transition
+relationship: part_of MS:1000908 ! transition
 
 [Term]
 id: MS:1002007
@@ -12930,8 +12911,8 @@ name: Mascot:PTM site assignment confidence
 def: "Relative probability that PTM site assignment is correct, derived from the Mascot score difference between matches to the same spectrum (Mascot Delta Score)." [http://www.matrixscience.com/help/pt_mods_help.html#SITE]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001968 ! PTM localization PSM-level statistic
-relationship: has_units: UO:0000187 ! percent
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_units UO:0000187 ! percent
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002013
@@ -12939,8 +12920,8 @@ name: collision energy ramp start
 def: "Collision energy at the start of the collision energy ramp." [PSI:PI]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000045 ! collision energy
-relationship: has_units: UO:0000266 ! electronvolt
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units UO:0000266 ! electronvolt
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002014
@@ -12948,8 +12929,8 @@ name: collision energy ramp end
 def: "Collision energy at the end of the collision energy ramp." [PSI:PI]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000045 ! collision energy
-relationship: has_units: UO:0000266 ! electronvolt
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units UO:0000266 ! electronvolt
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002015
@@ -12957,7 +12938,7 @@ name: spectral count peptide level quantitation
 def: "Spectral count peptide level quantitation." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001836 ! spectral counting quantitation analysis
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002016
@@ -12965,7 +12946,7 @@ name: spectral count protein level quantitation
 def: "Spectral count protein level quantitation." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001836 ! spectral counting quantitation analysis
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002017
@@ -12973,7 +12954,7 @@ name: spectral count proteingroup level quantitation
 def: "Spectral count proteingroup level quantitation." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001836 ! spectral counting quantitation analysis
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002018
@@ -12987,7 +12968,7 @@ name: label-free raw feature quantitation
 def: "Label-free raw feature quantitation." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001834 ! LC-MS label-free quantitation analysis
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002020
@@ -12995,7 +12976,7 @@ name: label-free peptide level quantitation
 def: "Label-free peptide level quantitation." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001834 ! LC-MS label-free quantitation analysis
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002021
@@ -13003,7 +12984,7 @@ name: label-free protein level quantitation
 def: "Label-free protein level quantitation." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001834 ! LC-MS label-free quantitation analysis
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002022
@@ -13011,7 +12992,7 @@ name: label-free proteingroup level quantitation
 def: "Label-free proteingroup level quantitation." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001834 ! LC-MS label-free quantitation analysis
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002023
@@ -13025,7 +13006,7 @@ name: MS2 tag-based feature level quantitation
 def: "MS2 tag-based feature level quantitation." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002023 ! MS2 tag-based analysis
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002025
@@ -13033,7 +13014,7 @@ name: MS2 tag-based peptide level quantitation
 def: "MS2 tag-based peptide level quantitation." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002023 ! MS2 tag-based analysis
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002026
@@ -13041,7 +13022,7 @@ name: MS2 tag-based protein level quantitation
 def: "MS2 tag-based protein level quantitation." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002023 ! MS2 tag-based analysis
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002027
@@ -13049,7 +13030,7 @@ name: MS2 tag-based proteingroup level quantitation
 def: "MS2 tag-based proteingroup level quantitation." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002023 ! MS2 tag-based analysis
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002028
@@ -13057,7 +13038,7 @@ name: nucleic acid base modification
 def: "Nucleic acid base modification (substitution, insertion or deletion)." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001471 ! peptide modification details
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002029
@@ -13065,7 +13046,7 @@ name: original nucleic acid sequence
 def: "Specification of the original nucleic acid sequence, prior to a modification. The value slot should hold the DNA or RNA sequence." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001471 ! peptide modification details
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002030
@@ -13073,7 +13054,7 @@ name: modified nucleic acid sequence
 def: "Specification of the modified nucleic acid sequence. The value slot should hold the DNA or RNA sequence." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001471 ! peptide modification details
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002031
@@ -13081,7 +13062,7 @@ name: PASSEL transition group browser URI
 def: "URI to retrieve transition group data for a PASSEL (PeptideAtlas SRM Experiment Library) experiment." [PSI:PI]
 xref: value-type:xsd\:anyURI "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
-relationship: has_value_type: xsd\:anyURI ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:anyURI ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002032
@@ -13089,7 +13070,7 @@ name: PeptideAtlas dataset URI
 def: "URI that allows access to a PeptideAtlas dataset." [PSI:PI]
 xref: value-type:xsd\:anyURI "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
-relationship: has_value_type: xsd\:anyURI ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:anyURI ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002033
@@ -13132,7 +13113,7 @@ id: MS:1002039
 name: inlet attribute
 def: "Inlet properties that are associated with a value." [PSI:MS]
 is_a: MS:1000547 ! object attribute
-relationship: part_of: MS:1000458 ! source
+relationship: part_of MS:1000458 ! source
 
 [Term]
 id: MS:1002040
@@ -13141,9 +13122,9 @@ def: "The temperature of the inlet of a mass spectrometer." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000482 ! source attribute
 is_a: MS:1002039 ! inlet attribute
-relationship: has_units: UO:0000012 ! kelvin
-relationship: has_units: UO:0000027 ! degree Celsius
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units UO:0000012 ! kelvin
+relationship: has_units UO:0000027 ! degree Celsius
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002041
@@ -13151,9 +13132,9 @@ name: source temperature
 def: "The temperature of the source of a mass spectrometer." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000482 ! source attribute
-relationship: has_units: UO:0000012 ! kelvin
-relationship: has_units: UO:0000027 ! degree Celsius
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units UO:0000012 ! kelvin
+relationship: has_units UO:0000027 ! degree Celsius
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002042
@@ -13161,9 +13142,9 @@ name: modulation time
 def: "The duration of a complete cycle of modulation in a comprehensive two-dimensional separation system, equals the length of a second dimension chromatogram, i.e., the time between two successive injections into the second column." [http://chromatographyonline.findanalytichem.com/lcgc/Column:+Coupling+Matters/Nomenclature-and-Conventions-in-Comprehensive-Mult/ArticleStandard/Article/detail/58429]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000857 ! run attribute
-relationship: has_units: UO:0000010 ! second
-relationship: has_units: UO:0000031 ! minute
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_units UO:0000010 ! second
+relationship: has_units UO:0000031 ! minute
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002043
@@ -13177,7 +13158,7 @@ name: ProteinProspector:score
 def: "The ProteinProspector result 'Score'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002045
@@ -13185,7 +13166,7 @@ name: ProteinProspector:expectation value
 def: "The ProteinProspector result 'Expectation value'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002046
@@ -13193,7 +13174,7 @@ name: native source path
 def: "The original source path used for directory-based sources." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001458 ! spectrum generation information
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002047
@@ -13213,7 +13194,7 @@ name: MS-GF:RawScore
 def: "MS-GF raw score." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002050
@@ -13221,7 +13202,7 @@ name: MS-GF:DeNovoScore
 def: "MS-GF de novo score." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002051
@@ -13229,7 +13210,7 @@ name: MS-GF:Energy
 def: "MS-GF energy score." [PSI:PI]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type: xsd\:nonNegativeInteger ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002052
@@ -13238,8 +13219,8 @@ def: "MS-GF spectral E-value." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002353 ! PSM-level e-value
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_order: MS:1002109 ! lower score better
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_order MS:1002109 ! lower score better
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002053
@@ -13248,8 +13229,8 @@ def: "MS-GF E-value." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002353 ! PSM-level e-value
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_order: MS:1002109 ! lower score better
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_order MS:1002109 ! lower score better
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002054
@@ -13258,7 +13239,7 @@ def: "MS-GF Q-value." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002354 ! PSM-level q-value
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002055
@@ -13266,7 +13247,7 @@ name: MS-GF:PepQValue
 def: "MS-GF peptide-level Q-value." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002056
@@ -13274,7 +13255,7 @@ name: MS-GF:PEP
 def: "MS-GF posterior error probability." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002057
@@ -13323,7 +13304,7 @@ name: peptide consensus RT
 def: "Peptide consensus retention time." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002737 ! peptide-level quantification datatype
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002065
@@ -13331,7 +13312,7 @@ name: peptide consensus m/z
 def: "Peptide consensus mass/charge ratio." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002737 ! peptide-level quantification datatype
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002066
@@ -13339,7 +13320,7 @@ name: ratio calculation method
 def: "Method used to calculate the ratio." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002067
@@ -13347,7 +13328,7 @@ name: protein value: median of peptide ratios
 def: "Protein quantification value calculated as median of peptide ratios." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002738 ! protein-level quantification datatype
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002068
@@ -13361,7 +13342,7 @@ name: metabolic labelling purity
 def: "Metabolic labelling: Description of labelling purity. Usually the purity of feeding material (e.g. 95%), or the inclusion rate derived from isotopic peak pattern shape." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001055 ! modification parameters
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002070
@@ -13369,7 +13350,7 @@ name: t-test
 def: "Perform a t-test (two groups). Specify in string value, whether paired / unpaired, variance equal / different, one- / two-sided version is performed." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001861 ! quantification data processing
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002071
@@ -13377,7 +13358,7 @@ name: ANOVA-test
 def: "Perform an ANOVA-test (more than two groups). Specify in string value, which version is performed." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001861 ! quantification data processing
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002072
@@ -13385,8 +13366,8 @@ name: p-value
 def: "P-value as result of one of the processing steps described. Specify in the description, which processing step it was." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
-relationship: has_domain: MS:1002305 ! value between 0 and 1 inclusive
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002073
@@ -13424,7 +13405,7 @@ name: ProteomeDiscoverer:1. Static Modification
 def: "OBSOLETE ProteomeDiscoverer's 1st static post-translational modification (PTM) input parameter." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002079
@@ -13432,7 +13413,7 @@ name: ProteomeDiscoverer:2. Static Modification
 def: "OBSOLETE ProteomeDiscoverer's 2nd static post-translational modification (PTM) input parameter." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002080
@@ -13440,8 +13421,8 @@ name: ProteomeDiscoverer:Spectrum Selector:Precursor Clipping Range Before
 def: "Precursor clipping range before." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_units: UO:0000221 ! dalton
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_units UO:0000221 ! dalton
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002081
@@ -13449,8 +13430,8 @@ name: ProteomeDiscoverer:Spectrum Selector:Precursor Clipping Range After
 def: "Precursor clipping range after." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_units: UO:0000221 ! dalton
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_units UO:0000221 ! dalton
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002082
@@ -13458,9 +13439,9 @@ name: first column elution time
 def: "The time of elution from the first chromatographic column in the chromatographic separation step, relative to the start of chromatography on the first column." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000503 ! scan attribute
-relationship: has_units: UO:0000010 ! second
-relationship: has_units: UO:0000031 ! minute
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units UO:0000010 ! second
+relationship: has_units UO:0000031 ! minute
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002083
@@ -13468,9 +13449,9 @@ name: second column elution time
 def: "The time of elution from the second chromatographic column in the chromatographic separation step, relative to the start of the chromatography on the second column." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000503 ! scan attribute
-relationship: has_units: UO:0000010 ! second
-relationship: has_units: UO:0000031 ! minute
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units UO:0000010 ! second
+relationship: has_units UO:0000031 ! minute
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002084
@@ -13508,7 +13489,7 @@ name: ProteomeDiscoverer:Peptide Without Protein XCorr Threshold
 def: "XCorr threshold for storing peptides that do not belong to a protein." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002090
@@ -13516,7 +13497,7 @@ name: Calculate Probability Scores
 def: "Flag indicating that a probability score for the assessment that a reported peptide match is a random occurrence is calculated." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002094 ! common search engine input parameter
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002091
@@ -13524,7 +13505,7 @@ name: ProteomeDiscoverer:Maximum Delta Cn
 def: "Delta Cn threshold for filtering out PSM's." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002092
@@ -13532,7 +13513,7 @@ name: Percolator:Validation based on
 def: "Algorithm (e.g. q-value or PEP) used for calculation of the validation score using Percolator." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002107 ! Percolator input parameter
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002093
@@ -13622,13 +13603,13 @@ is_a: MS:1002105 ! software specific input parameter
 id: MS:1002108
 name: higher score better
 def: "Indicates that a higher score is better." [PSI:PI]
-relationship: part_of: MS:1001153 ! search engine specific score
+relationship: part_of MS:1001153 ! search engine specific score
 
 [Term]
 id: MS:1002109
 name: lower score better
 def: "Indicates that a lower score is better." [PSI:PI]
-relationship: part_of: MS:1001153 ! search engine specific score
+relationship: part_of MS:1001153 ! search engine specific score
 
 [Term]
 id: MS:1002110
@@ -13727,7 +13708,7 @@ def: "OBSOLETE FDRScore values specifically obtained for distinct combinations o
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1001153 ! search engine specific score
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002126
@@ -13898,7 +13879,7 @@ name: protein level PSM counts
 def: "The number of spectra identified for this protein in spectral counting." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002738 ! protein-level quantification datatype
-relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002154
@@ -14261,7 +14242,7 @@ name: PAnalyzer:conclusive protein
 def: "A protein identified by at least one unique (distinct, discrete) peptide (peptides are considered different only if they can be distinguished by evidence in mass spectrum)." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001600 ! protein inference confidence category
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002214
@@ -14269,7 +14250,7 @@ name: PAnalyzer:indistinguishable protein
 def: "A member of a group of proteins sharing all peptides that are exclusive to the group (peptides are considered different only if they can be distinguished by evidence in mass spectrum)." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001600 ! protein inference confidence category
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002215
@@ -14277,7 +14258,7 @@ name: PAnalyzer:non-conclusive protein
 def: "A protein sharing all its matched peptides with either conclusive or indistinguishable proteins (peptides are considered different only if they can be distinguished by evidence in mass spectrum)." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001600 ! protein inference confidence category
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002216
@@ -14285,7 +14266,7 @@ name: PAnalyzer:ambiguous group member
 def: "A protein sharing at least one peptide not matched to either conclusive or indistinguishable proteins (peptides are considered different only if they can be distinguished by evidence in mass spectrum)." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001600 ! protein inference confidence category
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002217
@@ -14293,7 +14274,7 @@ name: decoy peptide
 def: "A putative identified peptide issued from a decoy sequence database." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001105 ! peptide sequence-level identification attribute
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002218
@@ -14301,8 +14282,8 @@ name: percent collision energy ramp start
 def: "Collision energy at the start of the collision energy ramp in percent, normalized to the mass of the ion." [PSI:PI]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000138 ! normalized collision energy
-relationship: has_units: UO:0000187 ! percent
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units UO:0000187 ! percent
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002219
@@ -14310,8 +14291,8 @@ name: percent collision energy ramp end
 def: "Collision energy at the end of the collision energy ramp in percent, normalized to the mass of the ion." [PSI:PI]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000138 ! normalized collision energy
-relationship: has_units: UO:0000187 ! percent
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units UO:0000187 ! percent
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002220
@@ -14331,7 +14312,7 @@ id: MS:1002222
 name: SRM transition attribute
 def: "Attribute associated with a SRM transition." [PSI:MS]
 is_a: MS:1000455 ! ion selection attribute
-relationship: part_of: MS:1000908 ! transition
+relationship: part_of MS:1000908 ! transition
 
 [Term]
 id: MS:1002223
@@ -14339,7 +14320,7 @@ name: precursor ion detection probability
 def: "Probability of detecting precursor when parent protein is present." [PSI:PI]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002222 ! SRM transition attribute
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002224
@@ -14347,27 +14328,27 @@ name: product ion detection probability
 def: "Probability of detecting product ion when precursor ion is present." [PSI:PI]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002222 ! SRM transition attribute
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002225
 name: average product ion intensity
 def: "Average value of product ion intensity in a collection of identified spectra." [PSI:PI]
 is_a: MS:1001226 ! product ion intensity
-relationship: has_units: MS:1000131 ! number of detector counts
-relationship: has_units: MS:1000132 ! percent of base peak
-relationship: has_units: MS:1000814 ! counts per second
-relationship: has_units: MS:1000905 ! percent of base peak times 100
+relationship: has_units MS:1000131 ! number of detector counts
+relationship: has_units MS:1000132 ! percent of base peak
+relationship: has_units MS:1000814 ! counts per second
+relationship: has_units MS:1000905 ! percent of base peak times 100
 
 [Term]
 id: MS:1002226
 name: product ion intensity standard deviation
 def: "Standard deviation of product ion intensity in a collection of identified spectra." [PSI:PI]
 is_a: MS:1001226 ! product ion intensity
-relationship: has_units: MS:1000131 ! number of detector counts
-relationship: has_units: MS:1000132 ! percent of base peak
-relationship: has_units: MS:1000814 ! counts per second
-relationship: has_units: MS:1000905 ! percent of base peak times 100
+relationship: has_units MS:1000131 ! number of detector counts
+relationship: has_units MS:1000132 ! percent of base peak
+relationship: has_units MS:1000814 ! counts per second
+relationship: has_units MS:1000905 ! percent of base peak times 100
 
 [Term]
 id: MS:1002227
@@ -14375,7 +14356,7 @@ name: number of product ion observations
 def: "The number of times the specific product ion has been observed in a series of SRM experiments." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002222 ! SRM transition attribute
-relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002228
@@ -14383,7 +14364,7 @@ name: number of precursor ion observations
 def: "The number of times the specific precursor ion has been observed in a series of SRM experiments." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002222 ! SRM transition attribute
-relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002229
@@ -14391,7 +14372,7 @@ name: ProteomeDiscoverer:Mascot:Significance Middle
 def: "Calculated relaxed significance when performing a decoy search for high-confidence peptides." [PSI:PI]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002230
@@ -14399,7 +14380,7 @@ name: ProteomeDiscoverer:Mascot:Significance High
 def: "Calculated relaxed significance when performing a decoy search for medium-confidence peptides." [PSI:PI]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002231
@@ -14412,7 +14393,7 @@ id: MS:1002232
 name: ProteomeDiscoverer:Default FDR calculator
 def: "The default FDR calculator as globally unique identifier (GUID)." [PSI:PI]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_regexp: MS:1002231 ! regular expressions for a GUID
+relationship: has_regexp MS:1002231 ! regular expressions for a GUID
 
 [Term]
 id: MS:1002233
@@ -14420,7 +14401,7 @@ name: ProteomeDiscoverer:SEQUEST:Low resolution spectra contained
 def: "Flag indicating if low-resolution spectra are taken into consideration." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002234
@@ -14428,8 +14409,8 @@ name: selected precursor m/z
 def: "Mass-to-charge ratio of a precursor ion selected for fragmentation." [PSI:PI]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000455 ! ion selection attribute
-relationship: has_units: MS:1000040 ! m/z
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units MS:1000040 ! m/z
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002235
@@ -14437,7 +14418,7 @@ name: ProteoGrouper:PDH score
 def: "A score assigned to a single protein accession (modelled as ProteinDetectionHypothesis in mzIdentML), based on summed peptide level scores." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002236
@@ -14445,7 +14426,7 @@ name: ProteoGrouper:PAG score
 def: "A score assigned to a protein group (modelled as ProteinAmbiguityGroup in mzIdentML), based on all summed peptide level scores that have been assigned to the group as unique or razor peptides." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002368 ! search engine specific score for protein groups
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002237
@@ -14519,7 +14500,7 @@ name: SEQUEST:spscore
 def: "The SEQUEST result 'SpScore'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002249
@@ -14527,7 +14508,7 @@ name: SEQUEST:sprank
 def: "The SEQUEST result 'SpRank'." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002250
@@ -14535,7 +14516,7 @@ name: SEQUEST:deltacnstar
 def: "The SEQUEST result 'DeltaCnStar'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002251
@@ -14549,8 +14530,8 @@ name: Comet:xcorr
 def: "The Comet result 'XCorr'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_order: MS:1002108 ! higher score better
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_order MS:1002108 ! higher score better
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002253
@@ -14558,7 +14539,7 @@ name: Comet:deltacn
 def: "The Comet result 'DeltaCn'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002254
@@ -14566,7 +14547,7 @@ name: Comet:deltacnstar
 def: "The Comet result 'DeltaCnStar'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002255
@@ -14574,7 +14555,7 @@ name: Comet:spscore
 def: "The Comet result 'SpScore'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002256
@@ -14582,7 +14563,7 @@ name: Comet:sprank
 def: "The Comet result 'SpRank'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002257
@@ -14590,7 +14571,7 @@ name: Comet:expectation value
 def: "The Comet result 'Expectation value'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001153 ! search engine specific score
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002258
@@ -14598,7 +14579,7 @@ name: Comet:matched ions
 def: "The Comet result 'Matched Ions'." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002259
@@ -14606,7 +14587,7 @@ name: Comet:total ions
 def: "The Comet result 'Total Ions'." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002260
@@ -14614,7 +14595,7 @@ name: PSM:FDR threshold
 def: "False-discovery rate threshold for peptide-spectrum matches." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002483 ! PSM-level statistical threshold
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002261
@@ -14628,8 +14609,8 @@ name: Byonic:Score
 def: "The Byonic score is the primary indicator of PSM correctness. The Byonic score reflects the absolute quality of the peptide-spectrum match, not the relative quality compared to other candidate peptides. Byonic scores range from 0 to about 1000, with 300 a good score, 400 a very good score, and PSMs with scores over 500 almost sure to be correct." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_order: MS:1002108 ! higher score better
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_order MS:1002108 ! higher score better
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002263
@@ -14637,8 +14618,8 @@ name: Byonic:Delta Score
 def: "The drop in Byonic score from the top-scoring peptide to the next peptide with distinct sequence. In this computation, the same peptide with different modifications is not considered distinct." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_order: MS:1002108 ! higher score better
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_order MS:1002108 ! higher score better
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002264
@@ -14646,8 +14627,8 @@ name: Byonic:DeltaMod Score
 def: "The drop in Byonic score from the top-scoring peptide to the next peptide different in any way, including placement of modifications. DeltaMod gives an indication of whether modifications are confidently localized; DeltaMod over 10.0 means that there is high likelihood that all modification placements are correct." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_order: MS:1002108 ! higher score better
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_order MS:1002108 ! higher score better
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002265
@@ -14655,8 +14636,8 @@ name: Byonic:PEP
 def: "Byonic posterior error probability." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_order: MS:1002109 ! lower score better
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_order MS:1002109 ! lower score better
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002266
@@ -14664,8 +14645,8 @@ name: Byonic:Peptide LogProb
 def: "The log p-value of the PSM. This is the log of the probability that the PSM with such a score and delta would arise by chance in a search of this size (the size of the protein database, as expanded by the modification rules). A log p-value of -3.0 should happen by chance on only one of a thousand spectra. Caveat: it is very hard to compute a p-value that works for all searches and all spectra, so read Byonic p-values with a certain amount of skepticism." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_order: MS:1002109 ! lower score better
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_order MS:1002109 ! lower score better
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002267
@@ -14674,8 +14655,8 @@ def: "The log p-value of the protein." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_order: MS:1002109 ! lower score better
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_order MS:1002109 ! lower score better
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002268
@@ -14684,8 +14665,8 @@ def: "Best (most negative) log p-value of an individual PSM." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001116 ! single protein identification statistic
 is_a: MS:1001153 ! search engine specific score
-relationship: has_order: MS:1002109 ! lower score better
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_order MS:1002109 ! lower score better
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002269
@@ -14693,8 +14674,8 @@ name: Byonic:Best Score
 def: "Best (largest) Byonic score of a PSM." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_order: MS:1002108 ! higher score better
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_order MS:1002108 ! higher score better
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002270
@@ -14720,8 +14701,8 @@ name: detector potential
 def: "Detector potential difference in volts." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000481 ! detector attribute
-relationship: has_units: UO:0000218 ! volt
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units UO:0000218 ! volt
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002274
@@ -14800,7 +14781,7 @@ id: MS:1002286
 name: Trans-Proteomic Pipeline software
 def: "A software program that is a component of the Trans-Proteomic Pipeline." [PSI:PI]
 is_a: MS:1001456 ! analysis software
-relationship: part_of: MS:1002285 ! Trans-Proteomic Pipeline
+relationship: part_of MS:1002285 ! Trans-Proteomic Pipeline
 
 [Term]
 id: MS:1002287
@@ -14904,13 +14885,13 @@ name: Bruker Container nativeID format
 def: "Native identifier (UUID)." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000767 ! native spectrum identifier format
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002304
 name: domain range
 def: "Domain range of a numerical value." [PSI:PI]
-relationship: part_of: MS:0000000 ! Proteomics Standards Initiative Mass Spectrometry Vocabularies
+relationship: part_of MS:0000000 ! Proteomics Standards Initiative Mass Spectrometry Vocabularies
 
 [Term]
 id: MS:1002305
@@ -14942,8 +14923,8 @@ name: Byonic: Peptide AbsLogProb
 def: "The absolute value of the log-base10 of the Byonic posterior error probability (PEP) of the PSM." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_order: MS:1002108 ! higher score better
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_order MS:1002108 ! higher score better
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002310
@@ -14951,8 +14932,8 @@ name: Byonic: Protein AbsLogProb
 def: "The absolute value of the log-base10 of the Byonic posterior error probability (PEP) of the protein." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_order: MS:1002108 ! higher score better
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_order MS:1002108 ! higher score better
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002311
@@ -14960,8 +14941,8 @@ name: Byonic: Peptide AbsLogProb2D
 def: "The absolute value of the log-base10 Byonic two-dimensional posterior error probability (PEP) of the PSM. The two-dimensional PEP takes into account protein ranking information as well as PSM information." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_order: MS:1002108 ! higher score better
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_order MS:1002108 ! higher score better
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002312
@@ -14993,7 +14974,7 @@ name: ProteomeDiscoverer:Amanda:high confidence threshold
 def: "Strict confidence probability score." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002317
@@ -15001,7 +14982,7 @@ name: ProteomeDiscoverer:Amanda:middle confidence threshold
 def: "Relaxed confidence probability score." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002318
@@ -15009,7 +14990,7 @@ name: ProteomeDiscoverer:automatic workload
 def: "Flag indicating automatic estimation of the workload level." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002319
@@ -15017,7 +14998,7 @@ name: Amanda:AmandaScore
 def: "The Amanda score of the scoring function for a PSM." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002320
@@ -15025,7 +15006,7 @@ name: ProteomeDiscoverer:max differential modifications
 def: "Maximum dynamic modifications per PSM." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002321
@@ -15033,7 +15014,7 @@ name: ProteomeDiscoverer:max equal modifications
 def: "Maximum equal modifications per PSM." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002322
@@ -15041,7 +15022,7 @@ name: ProteomeDiscoverer:min peptide length
 def: "Minimum peptide length." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002323
@@ -15049,7 +15030,7 @@ name: ProteomeDiscoverer:max peptide length
 def: "Maximum peptide length." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002324
@@ -15057,7 +15038,7 @@ name: ProteomeDiscoverer:max number neutral loss
 def: "Maximum number of same neutral losses." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002325
@@ -15065,7 +15046,7 @@ name: ProteomeDiscoverer:max number neutral loss modifications
 def: "Max number of same neutral losses of modifications." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002326
@@ -15073,7 +15054,7 @@ name: ProteomeDiscoverer:use flanking ions
 def: "Flag for usage of flanking ions." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002327
@@ -15081,7 +15062,7 @@ name: ProteomeDiscoverer:max number of same modifs
 def: "The maximum number of possible equal modifications per PSM." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002328
@@ -15089,7 +15070,7 @@ name: ProteomeDiscoverer:perform deisotoping
 def: "Defines whether a simple deisotoping shall be performed." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002329
@@ -15097,7 +15078,7 @@ name: ProteomeDiscoverer:ion settings
 def: "Specifies the fragment ions and neutral losses that are calculated." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002330
@@ -15105,7 +15086,7 @@ name: ProteomeDiscoverer:3. Static Modification
 def: "OBSOLETE ProteomeDiscoverer's 3rd static post-translational modification (PTM) input parameter." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002331
@@ -15113,7 +15094,7 @@ name: ProteomeDiscoverer:5. Dynamic Modification
 def: "OBSOLETE ProteomeDiscoverer's 5th dynamic post-translational modification (PTM) input parameter." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002332
@@ -15157,8 +15138,8 @@ name: Andromeda:score
 def: "The probability based score of the Andromeda search engine." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_order: MS:1002108 ! higher score better
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_order MS:1002108 ! higher score better
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002339
@@ -15166,7 +15147,7 @@ name: site:global FDR
 def: "Estimation of global false discovery rate of peptides with a post-translational modification." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001405 ! spectrum identification result details
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002340
@@ -15174,7 +15155,7 @@ name: ProteomeXchange project tag
 def: "Tag that can be added to a ProteomeXchange dataset, to enable the grouping of datasets. One tag can be used for indicating that a given dataset is part of a bigger project, like e.g. the Human Proteome Project." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002341
@@ -15182,7 +15163,7 @@ name: second-pass peptide identification
 def: "A putative identified peptide found in a second-pass search of protein sequences selected from a first-pass search." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001105 ! peptide sequence-level identification attribute
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002342
@@ -15239,8 +15220,8 @@ name: PSM-level global FDR
 def: "Estimation of the global false discovery rate of peptide spectrum matches." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002701 ! PSM-level result list statistic
-relationship: has_domain: MS:1002305 ! value between 0 and 1 inclusive
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002351
@@ -15248,8 +15229,8 @@ name: PSM-level local FDR
 def: "Estimation of the local false discovery rate of peptide spectrum matches." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002347 ! PSM-level identification statistic
-relationship: has_domain: MS:1002305 ! value between 0 and 1 inclusive
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002352
@@ -15257,8 +15238,8 @@ name: PSM-level p-value
 def: "Estimation of the p-value for peptide spectrum matches." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002347 ! PSM-level identification statistic
-relationship: has_domain: MS:1002305 ! value between 0 and 1 inclusive
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002353
@@ -15266,8 +15247,8 @@ name: PSM-level e-value
 def: "Estimation of the e-value for peptide spectrum matches." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002347 ! PSM-level identification statistic
-relationship: has_domain: MS:1002306 ! value greater than zero
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_domain MS:1002306 ! value greater than zero
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002354
@@ -15275,8 +15256,8 @@ name: PSM-level q-value
 def: "Estimation of the q-value for peptide spectrum matches." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002347 ! PSM-level identification statistic
-relationship: has_domain: MS:1002305 ! value between 0 and 1 inclusive
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002355
@@ -15285,8 +15266,8 @@ def: "mzidLibrary FDRScore for peptide spectrum matches." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_domain: MS:1002349 ! value greater than zero but less than or equal to 1
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_domain MS:1002349 ! value greater than zero but less than or equal to 1
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002356
@@ -15295,8 +15276,8 @@ def: "mzidLibrary Combined FDRScore for peptide spectrum matches specifically ob
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_domain: MS:1002349 ! value greater than zero but less than or equal to 1
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_domain MS:1002349 ! value greater than zero but less than or equal to 1
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002357
@@ -15304,8 +15285,8 @@ name: PSM-level probability
 def: "Probability that the reported peptide ion is truly responsible for some or all of the components of the specified mass spectrum." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002347 ! PSM-level identification statistic
-relationship: has_domain: MS:1002305 ! value between 0 and 1 inclusive
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002358
@@ -15319,8 +15300,8 @@ name: peptide sequence-level local FDR
 def: "Estimation of the local false discovery rate for distinct peptides once redundant identifications of the same peptide have been removed (id est multiple PSMs have been collapsed to one entry)." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001092 ! peptide sequence-level identification statistic
-relationship: has_domain: MS:1002305 ! value between 0 and 1 inclusive
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002360
@@ -15329,8 +15310,8 @@ def: "MzidLibrary FDRScore for distinct peptides once redundant identifications 
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002358 ! search engine specific peptide sequence-level identification statistic
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_domain: MS:1002349 ! value greater than zero but less than or equal to one
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_domain MS:1002349 ! value greater than zero but less than or equal to one
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002361
@@ -15339,8 +15320,8 @@ def: "Combined FDRScore for peptides once redundant identifications of the same 
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002358 ! search engine specific peptide sequence-level identification statistic
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_domain: MS:1002349 ! value greater than zero but less than or equal to one
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_domain MS:1002349 ! value greater than zero but less than or equal to one
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002362
@@ -15348,8 +15329,8 @@ name: peptide sequence-level probability
 def: "Probability that the reported distinct peptide sequence (irrespective of mass modifications) has been correctly identified via the referenced PSMs." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001092 ! peptide sequence-level identification statistic
-relationship: has_domain: MS:1002305 ! value between 0 and 1 inclusive
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002363
@@ -15363,7 +15344,7 @@ name: protein-level local FDR
 def: "Estimation of the local false discovery rate of proteins." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001116 ! single protein identification statistic
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002365
@@ -15371,8 +15352,8 @@ name: FDRScore for proteins
 def: "MzidLibrary FDRScore for proteins specifically obtained for distinct combinations of single, pairs or triplets of search engines making a given PSM, used for integrating results from these distinct pools." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_domain: MS:1002349 ! value greater than zero but less than or equal to one
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_domain MS:1002349 ! value greater than zero but less than or equal to one
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002366
@@ -15380,8 +15361,8 @@ name: combined FDRScore for proteins
 def: "MzidLibrary Combined FDRScore for proteins." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_domain: MS:1002349 ! value greater than zero but less than or equal to one
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_domain MS:1002349 ! value greater than zero but less than or equal to one
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002367
@@ -15389,8 +15370,8 @@ name: probability for proteins
 def: "Probability that a specific protein sequence has been correctly identified from the PSM and distinct peptide evidence, and based on the available protein sequences presented to the analysis software." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001116 ! single protein identification statistic
-relationship: has_domain: MS:1002305 ! value between 0 and 1 inclusive
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002368
@@ -15404,7 +15385,7 @@ name: protein group-level global FDR
 def: "Estimation of the global false discovery rate of protein groups." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002706 ! protein group-level result list statistic
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002370
@@ -15412,7 +15393,7 @@ name: protein group-level local FDR
 def: "Estimation of the local false discovery rate of protein groups." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002348 ! protein group-level identification statistic
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002371
@@ -15420,8 +15401,8 @@ name: protein group-level p-value
 def: "Estimation of the p-value for protein groups." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002348 ! protein group-level identification statistic
-relationship: has_domain: MS:1002305 ! value between 0 and 1 inclusive
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002372
@@ -15429,8 +15410,8 @@ name: protein group-level e-value
 def: "Estimation of the e-value for protein groups." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002348 ! protein group-level identification statistic
-relationship: has_domain: MS:1002306 ! value greater than zero
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_domain MS:1002306 ! value greater than zero
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002373
@@ -15438,8 +15419,8 @@ name: protein group-level q-value
 def: "Estimation of the q-value for protein groups." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002348 ! protein group-level identification statistic
-relationship: has_domain: MS:1002305 ! value between 0 and 1 inclusive
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002374
@@ -15447,8 +15428,8 @@ name: protein group-level FDRScore
 def: "mzidLibrary FDRScore for protein groups." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002368 ! search engine specific score for protein groups
-relationship: has_domain: MS:1002349 ! value greater than zero but less than or equal to one
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_domain MS:1002349 ! value greater than zero but less than or equal to one
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002375
@@ -15456,8 +15437,8 @@ name: protein group-level combined FDRScore
 def: "mzidLibrary Combined FDRScore for proteins specifically obtained for distinct combinations of single, pairs or triplets of search engines making a given PSM, used for integrating results from these distinct pools." [PMID:19253293]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002368 ! search engine specific score for protein groups
-relationship: has_domain: MS:1002349 ! value greater than zero but less than or equal to one
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_domain MS:1002349 ! value greater than zero but less than or equal to one
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002376
@@ -15465,8 +15446,8 @@ name: protein group-level probability
 def: "Probability that at least one of the members of a group of protein sequences has been correctly identified from the PSM and distinct peptide evidence, and based on the available protein sequences presented to the analysis software." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002348 ! protein group-level identification statistic
-relationship: has_domain: MS:1002305 ! value between 0 and 1 inclusive
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002377
@@ -15474,7 +15455,7 @@ name: ProteomeDiscoverer:Relaxed Score Threshold
 def: "Specifies the threshold value for relaxed scoring." [PSI:PI]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002378
@@ -15482,7 +15463,7 @@ name: ProteomeDiscoverer:Strict Score Threshold
 def: "Specifies the threshold value for strict scoring." [PSI:PI]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002379
@@ -15490,7 +15471,7 @@ name: ProteomeDiscoverer:Peptide Without Protein Cut Off Score
 def: "Cut off score for storing peptides that do not belong to a protein." [PSI:PI]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002380
@@ -15498,7 +15479,7 @@ name: false localization rate
 def: "Estimation of the false localization rate for modification site assignment." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001405 ! spectrum identification result details
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002381
@@ -15567,7 +15548,7 @@ name: PIA:FDRScore calculated
 def: "Indicates whether the FDR score was calculated for the input file." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002389 ! PIA workflow parameter
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002391
@@ -15575,7 +15556,7 @@ name: PIA:Combined FDRScore calculated
 def: "Indicates whether the combined FDR score was calculated for the PIA compilation." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002389 ! PIA workflow parameter
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002392
@@ -15583,7 +15564,7 @@ name: PIA:PSM sets created
 def: "Indicates whether PSM sets were created." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002389 ! PIA workflow parameter
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002393
@@ -15591,7 +15572,7 @@ name: PIA:used top identifications for FDR
 def: "The number of top identifications per spectrum used for the FDR calculation, 0 means all." [PSI:PI]
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1002389 ! PIA workflow parameter
-relationship: has_value_type: xsd\:positiveInteger ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002394
@@ -15599,8 +15580,8 @@ name: PIA:protein score
 def: "The score given to a protein by any protein inference." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_order: MS:1002108 ! higher score better
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_order MS:1002108 ! higher score better
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002395
@@ -15608,7 +15589,7 @@ name: PIA:protein inference
 def: "The used algorithm for the protein inference using PIA." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002389 ! PIA workflow parameter
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002396
@@ -15616,7 +15597,7 @@ name: PIA:protein inference filter
 def: "A filter used by PIA for the protein inference." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002389 ! PIA workflow parameter
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002397
@@ -15624,7 +15605,7 @@ name: PIA:protein inference scoring
 def: "The used scoring method for the protein inference using PIA." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002389 ! PIA workflow parameter
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002398
@@ -15632,7 +15613,7 @@ name: PIA:protein inference used score
 def: "The used base score for the protein inference using PIA." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002389 ! PIA workflow parameter
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002399
@@ -15640,7 +15621,7 @@ name: PIA:protein inference used PSMs
 def: "The method to determine the PSMs used for scoring by the protein inference." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002389 ! PIA workflow parameter
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002400
@@ -15648,7 +15629,7 @@ name: PIA:filter
 def: "A filter used for the report generation." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002389 ! PIA workflow parameter
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002401
@@ -15674,7 +15655,7 @@ name: count of identified proteins
 def: "The number of proteins that have been identified, which must match the number of groups that pass the threshold in the file." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002704 ! protein-level result list attribute
-relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002405
@@ -15688,7 +15669,7 @@ name: count of identified clusters
 def: "The number of protein clusters that have been identified, which must match the number of clusters that pass the threshold in the file." [DOI:10.1002/pmic.201400080, PMID:25092112]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002405 ! protein group-level result list attribute
-relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002407
@@ -15696,7 +15677,7 @@ name: cluster identifier
 def: "An identifier applied to protein groups to indicate that they are linked by shared peptides." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002698 ! protein cluster identification attribute
-relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002408
@@ -15704,7 +15685,7 @@ name: number of distinct protein sequences
 def: "The number of protein clusters that have been identified, which must match the number of clusters that pass the threshold in the file." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002405 ! protein group-level result list attribute
-relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002409
@@ -15731,7 +15712,7 @@ name: total XIC area
 def: "Summed area of all the extracted ion chromatogram for the peptide (e.g. of all the transitions in SRM)." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002737 ! peptide-level quantification datatype
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002413
@@ -15739,7 +15720,7 @@ name: product background
 def: "The background area for the quantified transition." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002414
@@ -15753,7 +15734,7 @@ name: protein group passes threshold
 def: "A Boolean attribute to determine whether the protein group has passed the threshold indicated in the file." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002346 ! protein group-level identification attribute
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002416
@@ -15785,7 +15766,7 @@ name: PASSEL experiment URI
 def: "URI that allows access to a PASSEL experiment." [PSI:PI]
 xref: value-type:xsd\:anyURI "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
-relationship: has_value_type: xsd\:anyURI ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:anyURI ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002421
@@ -15799,7 +15780,7 @@ name: Paragon: sample type
 def: "The Paragon method setting indicating the type of sample at the high level, generally meaning the type of quantitation labelling or lack thereof. 'Identification' is indicated for samples without any labels for quantitation." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002421 ! Paragon input parameter
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002423
@@ -15807,7 +15788,7 @@ name: Paragon: cysteine alkylation
 def: "The Paragon method setting indicating the actual cysteine alkylation agent; 'None' is indicated if there was no cysteine alkylation." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002421 ! Paragon input parameter
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002424
@@ -15815,7 +15796,7 @@ name: Paragon: instrument setting
 def: "The Paragon method setting (translating to a large number of lower level settings) indicating the instrument used or a category of instrument." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002421 ! Paragon input parameter
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002425
@@ -15823,7 +15804,7 @@ name: Paragon: search effort
 def: "The Paragon method setting that controls the two major modes of search effort of the Paragon algorithm: the Rapid mode uses a conventional database search, while the Thorough mode uses a hybrid search, starting with the same approach as the Rapid mode but then follows it with a separate tag-based approach enabling a more extensive search." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002421 ! Paragon input parameter
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002426
@@ -15831,7 +15812,7 @@ name: Paragon: ID focus
 def: "A Paragon method setting that allows the inclusion of large sets of features such as biological modification or substitutions." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002421 ! Paragon input parameter
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002427
@@ -15839,7 +15820,7 @@ name: Paragon: FDR analysis
 def: "The Paragon method setting that controls whether FDR analysis is conducted." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002421 ! Paragon input parameter
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002428
@@ -15847,7 +15828,7 @@ name: Paragon: quantitation
 def: "The Paragon method setting that controls whether quantitation analysis is conducted." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002421 ! Paragon input parameter
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002429
@@ -15855,7 +15836,7 @@ name: Paragon: background correction
 def: "The Paragon method setting that controls whether the 'Background Correction' analysis is conducted; this processing estimates a correction to the attenuation in extremity ratios that can occur in isobaric quantatitation workflows on complex samples." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002421 ! Paragon input parameter
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002430
@@ -15863,7 +15844,7 @@ name: Paragon: bias correction
 def: "The Paragon method setting that controls whether 'Bias Correction' is invoked in quantitation analysis; this correction is a normalization to set the central tendency of protein ratios to unity." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002421 ! Paragon input parameter
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002431
@@ -15871,7 +15852,7 @@ name: Paragon: channel to use as denominator in ratios
 def: "The Paragon method setting that controls which label channel is used as the denominator in calculating relative expression ratios." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002421 ! Paragon input parameter
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002432
@@ -15885,7 +15866,7 @@ name: Paragon: modified data dictionary or parameter translation
 def: "This metric detects if any changes have been made to the originally installed key control files for the software; if no changes have been made, then the software version and settings are sufficient to enable exact reproduction; if changes have been made, then the modified ParameterTranslation- and ProteinPilot DataDictionary-XML files much also be provided in order to exactly reproduce a result." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002432 ! search engine specific input metadata
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002434
@@ -15893,7 +15874,7 @@ name: number of spectra searched
 def: "Number of spectra in a search." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1001249 ! search input details
-relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002435
@@ -15901,7 +15882,7 @@ name: data processing start time
 def: "The time that a data processing action was started." [PSI:MS]
 xref: value-type:xsd\:dateTime "The allowed value-type for this CV term."
 is_a: MS:1000630 ! data processing parameter
-relationship: has_value_type: xsd\:dateTime ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:dateTime ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002436
@@ -15909,7 +15890,7 @@ name: Paragon: digestion
 def: "The Paragon method setting indicating the actual digestion agent - unlike other search tools, this setting does not include options that control partial specificity like 'semitrypsin'; if trypsin is used, trypsin is set, and partially conforming peptides are found in the Thorough mode of search; 'None' should be indicated only if there was really no digestion done." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001249 ! search input details
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002437
@@ -15917,13 +15898,13 @@ name: number of decoy sequences
 def: "The number of decoy sequences, if the concatenated target-decoy approach is used." [PSI:PI]
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1001011 ! search database details
-relationship: has_value_type: xsd\:positiveInteger ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002438
 name: spectrum identification list result details
 def: "Information about the list of PSMs (SpectrumIdentificationList)." [PSI:PI]
-relationship: part_of: MS:1001000 ! spectrum interpretation
+relationship: part_of MS:1001000 ! spectrum interpretation
 
 [Term]
 id: MS:1002439
@@ -15979,7 +15960,7 @@ name: Paragon:special factor
 def: "The Paragon method setting indicating a list of one or more 'special factors', which generally capture secondary effects (relative to other settings) as a set of probabilities of modification features that override the assumed levels. For example the 'gel-based ID' special factor causes an increase probability of oxidation on several resides because of the air exposure impact on a gel, in addition to other effects." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002421 ! Paragon input parameter
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002448
@@ -15987,7 +15968,7 @@ name: PEAKS:inChorusPeptideScore
 def: "The PEAKS inChorus peptide score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002449
@@ -15995,7 +15976,7 @@ name: PEAKS:inChorusProteinScore
 def: "The PEAKS inChorus protein score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002450
@@ -16066,7 +16047,7 @@ id: MS:1002460
 name: protein group-level global FNR
 def: "Estimation of the global false negative rate of protein groups." [PSI:PI]
 is_a: MS:1002706 ! protein group-level result list statistic
-relationship: has_domain: MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
 
 [Term]
 id: MS:1002461
@@ -16079,7 +16060,7 @@ id: MS:1002462
 name: peptide sequence-level global FNR
 def: "Estimation of the global false negative rate for distinct peptides once redundant identifications of the same peptide have been removed (id est multiple PSMs have been collapsed to one entry)." [PSI:PI]
 is_a: MS:1002703 ! peptide sequence-level result list statistic
-relationship: has_domain: MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
 
 [Term]
 id: MS:1002463
@@ -16092,7 +16073,7 @@ id: MS:1002464
 name: PSM-level global FNR
 def: "Estimation of the global false negative rate of peptide spectrum matches." [PSI:PI]
 is_a: MS:1002701 ! PSM-level result list statistic
-relationship: has_domain: MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
 
 [Term]
 id: MS:1002465
@@ -16106,8 +16087,8 @@ name: PeptideShaker PSM score
 def: "The probability based PeptideShaker PSM score." [PSI:PI]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_order: MS:1002108 ! higher score better
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_order MS:1002108 ! higher score better
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002467
@@ -16115,8 +16096,8 @@ name: PeptideShaker PSM confidence
 def: "The probability based PeptideShaker PSM confidence." [PSI:PI]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_order: MS:1002108 ! higher score better
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_order MS:1002108 ! higher score better
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002468
@@ -16125,8 +16106,8 @@ def: "The probability based PeptideShaker peptide score." [PSI:PI]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002358 ! search engine specific peptide sequence-level identification statistic
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_order: MS:1002108 ! higher score better
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_order MS:1002108 ! higher score better
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002469
@@ -16134,8 +16115,8 @@ name: PeptideShaker peptide confidence
 def: "The probability based PeptideShaker peptide confidence." [PSI:PI]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_order: MS:1002108 ! higher score better
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_order MS:1002108 ! higher score better
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002470
@@ -16144,8 +16125,8 @@ def: "The probability based PeptideShaker protein group score." [PSI:PI]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
 is_a: MS:1002368 ! search engine specific score for protein groups
-relationship: has_order: MS:1002108 ! higher score better
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_order MS:1002108 ! higher score better
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002471
@@ -16153,8 +16134,8 @@ name: PeptideShaker protein group confidence
 def: "The probability based PeptideShaker protein group confidence." [PSI:PI]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_order: MS:1002108 ! higher score better
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_order MS:1002108 ! higher score better
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002472
@@ -16174,8 +16155,8 @@ name: ProteoAnnotator:non-canonical gene model score
 def: "The sum of peptide-level scores for peptides mapped only to non-canonical gene models within the group." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002368 ! search engine specific score for protein groups
-relationship: has_order: MS:1002108 ! higher score better
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_order MS:1002108 ! higher score better
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002475
@@ -16183,7 +16164,7 @@ name: ProteoAnnotator:count alternative peptides
 def: "The count of the number of peptide sequences mapped to non-canonical gene models only within the group." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002368 ! search engine specific score for protein groups
-relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002476
@@ -16192,8 +16173,8 @@ def: "Drift time of an ion or spectrum of ions as measured in an ion mobility ma
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000455 ! ion selection attribute
 is_a: MS:1002892 ! ion mobility attribute
-relationship: has_units: UO:0000028 ! millisecond
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units UO:0000028 ! millisecond
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002477
@@ -16201,9 +16182,9 @@ name: mean ion mobility drift time array
 def: "Array of population mean ion mobility values from a drift time device, reported in seconds (or milliseconds), corresponding to a spectrum of individual peaks encoded with an m/z array." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002893 ! ion mobility array
-relationship: has_units: UO:0000028 ! millisecond
-relationship: has_units: UO:0000010 ! second
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units UO:0000028 ! millisecond
+relationship: has_units UO:0000010 ! second
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002478
@@ -16216,7 +16197,7 @@ is_a: MS:1000513 ! binary data array
 id: MS:1002479
 name: regular expression
 def: "Regular expression." [PSI:PI]
-relationship: part_of: MS:0000000 ! Proteomics Standards Initiative Mass Spectrometry Vocabularies
+relationship: part_of MS:0000000 ! Proteomics Standards Initiative Mass Spectrometry Vocabularies
 
 [Term]
 id: MS:1002480
@@ -16266,7 +16247,7 @@ name: MassIVE dataset identifier
 def: "Dataset identifier issued by the MassIVE repository. A dataset can refer to either a single sample as part of a study, or all samples that are part of the study corresponding to a publication." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002488
@@ -16274,14 +16255,14 @@ name: MassIVE dataset URI
 def: "URI that allows the access to one dataset in the MassIVE repository. A dataset can refer to either a single sample as part of a study, or all samples that are part of the study corresponding to a publication." [PSI:PI]
 xref: value-type:xsd\:anyURI "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
-relationship: has_value_type: xsd\:anyURI ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:anyURI ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002489
 name: special processing
 def: "Details describing a special processing." [PSI:PI]
 is_a: MS:1001080 ! search type
-relationship: part_of: MS:1001000 ! spectrum interpretation
+relationship: part_of MS:1001000 ! spectrum interpretation
 
 [Term]
 id: MS:1002490
@@ -16349,7 +16330,7 @@ name: peptide passes threshold
 def: "A Boolean attribute to determine whether the peptide has passed the threshold indicated in the file." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001105 ! peptide sequence-level identification attribute
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002501
@@ -16375,7 +16356,7 @@ name: modification index
 def: "The order of modifications to be referenced elsewhere in the document." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1001055 ! modification parameters
-relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002505
@@ -16395,8 +16376,8 @@ name: modification rescoring:false localization rate
 def: "Mod position score: false localization rate." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002506 ! modification position score
-relationship: has_regexp: MS:1002505 ! regular expression for modification localization scoring
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002508
@@ -16410,7 +16391,7 @@ name: cross-link donor
 def: "The Cross-linking donor, assigned according to the following rules: the export software SHOULD use the following rules to choose the cross-link donor as the: longer peptide, then higher peptide neutral mass, then alphabetical order." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002508 ! cross-linking attribute
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002510
@@ -16418,7 +16399,7 @@ name: cross-link acceptor
 def: "Cross-linking acceptor, assigned according to the following rules: the export software SHOULD use the following rules to choose the cross-link donor as the: longer peptide, then higher peptide neutral mass, then alphabetical order." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002508 ! cross-linking attribute
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002511
@@ -16426,7 +16407,7 @@ name: cross-link spectrum identification item
 def: "Cross-linked spectrum identification item." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002508 ! cross-linking attribute
-relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002512
@@ -16434,7 +16415,7 @@ name: cross-linking score
 def: "Cross-linking scoring value." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002513
@@ -16442,7 +16423,7 @@ name: molecules per cell
 def: "The absolute abundance of protein in a cell." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002514
@@ -16456,7 +16437,7 @@ name: internal peptide reference used
 def: "States whether an internal peptide reference is used or not in absolute quantitation analysis." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001832 ! quantitation software comment or customizations
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002516
@@ -16464,7 +16445,7 @@ name: internal protein reference used
 def: "States whether an internal protein reference is used or not in absolute quantitation analysis." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001832 ! quantitation software comment or customizations
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002517
@@ -16472,7 +16453,7 @@ name: internal reference abundance
 def: "The absolute abundance of the spiked in reference peptide or protein used for absolute quantitation analysis." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002518
@@ -16480,7 +16461,7 @@ name: Progenesis:protein group normalised abundance
 def: "The data type normalised abundance for protein groups produced by Progenesis LC-MS." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002739 ! protein group-level quantification datatype
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002519
@@ -16488,7 +16469,7 @@ name: Progenesis:protein group raw abundance
 def: "The data type raw abundance for protein groups produced by Progenesis LC-MS." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002739 ! protein group-level quantification datatype
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002520
@@ -16496,7 +16477,7 @@ name: peptide group ID
 def: "Peptide group identifier for peptide-level stats." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001105 ! peptide sequence-level identification attribute
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002521
@@ -16510,7 +16491,7 @@ name: ProteomeDiscoverer:1. Static Terminal Modification
 def: "Determine 1st static terminal post-translational modifications (PTMs)." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002523
@@ -16588,8 +16569,8 @@ name: ProLuCID:xcorr
 def: "The ProLuCID result 'XCorr'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_order: MS:1002108 ! higher score better
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_order MS:1002108 ! higher score better
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002535
@@ -16597,7 +16578,7 @@ name: ProLuCID:deltacn
 def: "The ProLuCID result 'DeltaCn'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002536
@@ -16605,8 +16586,8 @@ name: D-Score
 def: "D-Score for PTM site location at the PSM-level." [PMID:23307401]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001968 ! PTM localization PSM-level statistic
-relationship: has_regexp: MS:1002505 ! regular expression for modification localization scoring
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002537
@@ -16614,8 +16595,8 @@ name: MD-Score
 def: "MD-Score for PTM site location at the PSM-level." [PMID:21057138]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001968 ! PTM localization PSM-level statistic
-relationship: has_regexp: MS:1002505 ! regular expression for modification localization scoring
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002538
@@ -16623,7 +16604,7 @@ name: PTM localization confidence metric
 def: "Localization confidence metric for a post translational modification (PTM)." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001405 ! spectrum identification result details
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002539
@@ -16631,7 +16612,7 @@ name: PeptideShaker PTM confidence type
 def: "PeptideShaker quality criteria for the confidence of PTM localizations." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002538 ! PTM localization confidence metric
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002540
@@ -16639,7 +16620,7 @@ name: PeptideShaker PSM confidence type
 def: "PeptideShaker quality criteria for the confidence of PSM's." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002347 ! PSM-level identification statistic
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002541
@@ -16647,7 +16628,7 @@ name: PeptideShaker peptide confidence type
 def: "PeptideShaker quality criteria for the confidence of peptide identifications." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002358 ! search engine specific peptide sequence-level identification statistic
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002542
@@ -16655,7 +16636,7 @@ name: PeptideShaker protein confidence type
 def: "PeptideShaker quality criteria for the confidence of protein identifications." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001116 ! single protein identification statistic
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002543
@@ -16675,8 +16656,8 @@ name: xi:score
 def: "The xi result 'Score'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_order: MS:1002108 ! higher score better
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_order MS:1002108 ! higher score better
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002546
@@ -16709,8 +16690,8 @@ name: peptide:phosphoRS score
 def: "phosphoRS score for PTM site location at the peptide-level." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002549 ! PTM localization distinct peptide-level statistic
-relationship: has_regexp: MS:1002505 ! regular expression for modification localization scoring
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002551
@@ -16718,8 +16699,8 @@ name: peptide:Ascore
 def: "A-score for PTM site location at the peptide-level." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002549 ! PTM localization distinct peptide-level statistic
-relationship: has_regexp: MS:1002505 ! regular expression for modification localization scoring
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002552
@@ -16727,8 +16708,8 @@ name: peptide:H-Score
 def: "H-Score for peptide phosphorylation site location at the peptide-level." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002549 ! PTM localization distinct peptide-level statistic
-relationship: has_regexp: MS:1002505 ! regular expression for modification localization scoring
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002553
@@ -16736,8 +16717,8 @@ name: peptide:D-Score
 def: "D-Score for PTM site location at the peptide-level." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002549 ! PTM localization distinct peptide-level statistic
-relationship: has_regexp: MS:1002505 ! regular expression for modification localization scoring
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002554
@@ -16745,8 +16726,8 @@ name: peptide:MD-Score
 def: "MD-Score for PTM site location at the peptide-level." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002549 ! PTM localization distinct peptide-level statistic
-relationship: has_regexp: MS:1002505 ! regular expression for modification localization scoring
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002555
@@ -16760,7 +16741,7 @@ name: Ascore threshold
 def: "Threshold for Ascore PTM site location score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002555 ! PTM localization score threshold
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002557
@@ -16768,7 +16749,7 @@ name: D-Score threshold
 def: "Threshold for D-score PTM site location score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002555 ! PTM localization score threshold
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002558
@@ -16776,7 +16757,7 @@ name: MD-Score threshold
 def: "Threshold for MD-score PTM site location score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002555 ! PTM localization score threshold
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002559
@@ -16784,7 +16765,7 @@ name: H-Score threshold
 def: "Threshold for H-score PTM site location score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002555 ! PTM localization score threshold
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002560
@@ -16792,7 +16773,7 @@ name: DeBunker:score threshold
 def: "Threshold for DeBunker PTM site location score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002555 ! PTM localization score threshold
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002561
@@ -16800,7 +16781,7 @@ name: Mascot:PTM site assignment confidence threshold
 def: "Threshold for Mascot PTM site assignment confidence." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002555 ! PTM localization score threshold
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002562
@@ -16808,7 +16789,7 @@ name: MSQuant:PTM-score threshold
 def: "Threshold for MSQuant:PTM-score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002555 ! PTM localization score threshold
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002563
@@ -16816,7 +16797,7 @@ name: MaxQuant:PTM Score threshold
 def: "Threshold for MaxQuant:PTM Score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002555 ! PTM localization score threshold
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002564
@@ -16824,7 +16805,7 @@ name: MaxQuant:P-site localization probability threshold
 def: "Threshold for MaxQuant:P-site localization probability." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002555 ! PTM localization score threshold
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002565
@@ -16832,7 +16813,7 @@ name: MaxQuant:PTM Delta Score threshold
 def: "Threshold for MaxQuant:PTM Delta Score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002555 ! PTM localization score threshold
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002566
@@ -16840,7 +16821,7 @@ name: MaxQuant:Phospho (STY) Probabilities threshold
 def: "Threshold for MaxQuant:Phospho (STY) Probabilities." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002555 ! PTM localization score threshold
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002567
@@ -16848,7 +16829,7 @@ name: phosphoRS score threshold
 def: "Threshold for phosphoRS score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002555 ! PTM localization score threshold
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002568
@@ -16856,7 +16837,7 @@ name: phosphoRS site probability threshold
 def: "Threshold for phosphoRS site probability." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002555 ! PTM localization score threshold
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002569
@@ -16864,7 +16845,7 @@ name: ProteomeDiscoverer:Number of Spectra Processed At Once
 def: "Number of spectra processed at once in a ProteomeDiscoverer search." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002570
@@ -16872,7 +16853,7 @@ name: sequence multiply subsumable protein
 def: "A protein for which the matched peptide sequences are the same, or a subset of, the matched peptide sequences for two or more other proteins combined. These other proteins need not all be in the same group." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001101 ! protein group or subset relationship
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002571
@@ -16880,7 +16861,7 @@ name: spectrum multiply subsumable protein
 def: "A protein for which the matched spectra are the same, or a subset of, the matched spectra for two or more other proteins combined. These other proteins need not all be in the same group." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001101 ! protein group or subset relationship
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002572
@@ -17050,7 +17031,7 @@ name: splash key
 def: "Spectral Hash key, an unique identifier for spectra." [PMID:27824832]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001405 ! spectrum identification result details
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002600
@@ -17252,7 +17233,7 @@ name: jPOST dataset identifier
 def: "Dataset identifier issued by the jPOST repository. A dataset can refer to either a single sample as part of a study, or all samples that are part of the study corresponding to a publication." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002633
@@ -17260,7 +17241,7 @@ name: jPOST dataset URI
 def: "URI that allows the access to one dataset in the jPOST repository. A dataset can refer to either a single sample as part of a study, or all samples that are part of the study corresponding to a publication." [PSI:PI]
 xref: value-type:xsd\:anyURI "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
-relationship: has_value_type: xsd\:anyURI ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:anyURI ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002634
@@ -17286,7 +17267,7 @@ name: chromosome name
 def: "The name or number of the chromosome to which a given peptide has been mapped." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002636 ! proteogenomics attribute
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002638
@@ -17294,7 +17275,7 @@ name: chromosome strand
 def: "The strand (+ or -) to which the peptide has been mapped." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002636 ! proteogenomics attribute
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002639
@@ -17302,7 +17283,7 @@ name: peptide start on chromosome
 def: "OBSOLETE The overall start position on the chromosome to which a peptide has been mapped i.e. the position of the first base of the first codon, using a zero-based counting system." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002636 ! proteogenomics attribute
-relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002640
@@ -17310,7 +17291,7 @@ name: peptide end on chromosome
 def: "The overall end position on the chromosome to which a peptide has been mapped i.e. the position of the third base of the last codon, using a zero-based counting system." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002636 ! proteogenomics attribute
-relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002641
@@ -17318,7 +17299,7 @@ name: peptide exon count
 def: "The number of exons to which the peptide has been mapped." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002636 ! proteogenomics attribute
-relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002642
@@ -17326,7 +17307,7 @@ name: peptide exon nucleotide sizes
 def: "A comma separated list of the number of DNA bases within each exon to which a peptide has been mapped. Assuming standard operation of a search engine, the peptide exon sizes should sum to exactly three times the peptide length." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002636 ! proteogenomics attribute
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002643
@@ -17334,7 +17315,7 @@ name: peptide start positions on chromosome
 def: "A comma separated list of start positions within exons to which the peptide has been mapped, relative to peptide-chromosome start, assuming a zero-based counting system. The first value MUST match the value in peptide start on chromosome." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002636 ! proteogenomics attribute
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002644
@@ -17342,7 +17323,7 @@ name: genome reference version
 def: "The reference genome and versioning string as used for mapping. All coordinates are within this frame of reference." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002636 ! proteogenomics attribute
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002645
@@ -17355,7 +17336,7 @@ is_a: MS:1001457 ! data processing software
 id: MS:1002646
 name: native spectrum identifier format, combined spectra
 def: "Describes how the native spectrum identifiers that have been combined prior to searching or interpretation are formated." [PSI:PI]
-relationship: part_of: MS:1000577 ! source data file
+relationship: part_of MS:1000577 ! source data file
 
 [Term]
 id: MS:1002647
@@ -17363,7 +17344,7 @@ name: Thermo nativeID format, combined spectra
 def: "Thermo comma separated list of spectra that have been combined prior to searching or interpretation." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002646 ! native spectrum identifier format, combined spectra
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002648
@@ -17371,7 +17352,7 @@ name: Waters nativeID format, combined spectra
 def: "Waters comma separated list of spectra that have been combined prior to searching or interpretation." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002646 ! native spectrum identifier format, combined spectra
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002649
@@ -17379,7 +17360,7 @@ name: WIFF nativeID format, combined spectra
 def: "WIFF comma separated list of spectra that have been combined prior to searching or interpretation." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002646 ! native spectrum identifier format, combined spectra
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002650
@@ -17387,7 +17368,7 @@ name: Bruker/Agilent YEP nativeID format, combined spectra
 def: "Bruker/Agilent comma separated list of spectra that have been combined prior to searching or interpretation." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002646 ! native spectrum identifier format, combined spectra
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002651
@@ -17395,7 +17376,7 @@ name: Bruker BAF nativeID format, combined spectra
 def: "Bruker BAF comma separated list of spectra that have been combined prior to searching or interpretation." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002646 ! native spectrum identifier format, combined spectra
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002652
@@ -17403,7 +17384,7 @@ name: Bruker FID nativeID format, combined spectra
 def: "Bruker FID comma separated list of spectra that have been combined prior to searching or interpretation." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002646 ! native spectrum identifier format, combined spectra
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002653
@@ -17411,7 +17392,7 @@ name: multiple peak list nativeID format, combined spectra
 def: "Comma separated list of spectra that have been combined prior to searching or interpretation." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002646 ! native spectrum identifier format, combined spectra
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002654
@@ -17419,7 +17400,7 @@ name: single peak list nativeID format, combined spectra
 def: "Comma separated list of spectra that have been combined prior to searching or interpretation." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002646 ! native spectrum identifier format, combined spectra
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002655
@@ -17427,7 +17408,7 @@ name: scan number only nativeID format, combined spectra
 def: "Comma separated list of spectra that have been combined prior to searching or interpretation." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002646 ! native spectrum identifier format, combined spectra
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002656
@@ -17435,7 +17416,7 @@ name: spectrum identifier nativeID format, combined spectra
 def: "Comma separated list of spectra that have been combined prior to searching or interpretation." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002646 ! native spectrum identifier format, combined spectra
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002657
@@ -17443,13 +17424,13 @@ name: mzML unique identifier, combined spectra
 def: "Comma separated list of spectra that have been combined prior to searching or interpretation." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002646 ! native spectrum identifier format, combined spectra
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002658
 name: identification parameter
 def: "Identification parameter for the search engine run." [PSI:PI]
-relationship: part_of: MS:1001000 ! spectrum interpretation
+relationship: part_of MS:1001000 ! spectrum interpretation
 
 [Term]
 id: MS:1002659
@@ -17476,8 +17457,8 @@ name: Morpheus:Morpheus score
 def: "Morpheus score for PSMs." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_order: MS:1002108 ! higher score better
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_order MS:1002108 ! higher score better
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002663
@@ -17485,8 +17466,8 @@ name: Morpheus:summed Morpheus score
 def: "Summed Morpheus score for protein groups." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002368 ! search engine specific score for protein groups
-relationship: has_order: MS:1002108 ! higher score better
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_order MS:1002108 ! higher score better
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002664
@@ -17494,8 +17475,8 @@ name: interaction score derived from cross-linking
 def: "Parent term for interaction scores derived from cross-linking." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002675 ! cross-linking result details
-relationship: has_regexp: MS:1002665 ! ([:digit:]+[.][a|b]:[:digit:]+:[:digit:]+[.][:digit:]+([Ee][+-][0-9]+)*:(true|false]\{1\}))
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_regexp MS:1002665 ! ([:digit:]+[.][a|b]:[:digit:]+:[:digit:]+[.][:digit:]+([Ee][+-][0-9]+)*:(true|false]\{1\}))
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002665
@@ -17521,7 +17502,7 @@ name: frag: iTRAQ 4plex reporter ion
 def: "Standard reporter ion for iTRAQ 4Plex. The value slot holds the integer mass of the iTRAQ 4Plex reporter ion, e.g. 114." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002307 ! fragmentation ion type
-relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002669
@@ -17529,7 +17510,7 @@ name: frag: iTRAQ 8plex reporter ion
 def: "Standard reporter ion for iTRAQ 8Plex. The value slot holds the integer mass of the iTRAQ 8Plex reporter ion, e.g. 113." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002307 ! fragmentation ion type
-relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002670
@@ -17537,7 +17518,7 @@ name: frag: TMT reporter ion
 def: "Standard reporter ion for TMT. The value slot holds the integer mass of the TMT reporter ion and can be suffixed with either N or C, indicating whether the mass difference is encoded at a Nitrogen or Carbon atom, e.g. 127N." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002307 ! fragmentation ion type
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002671
@@ -17545,7 +17526,7 @@ name: frag: TMT ETD reporter ion
 def: "Standard reporter ion for TMT with ETD fragmentation. The value slot holds the integer mass of the TMT ETD reporter ion and can be suffixed with either N or C, indicating whether the mass difference is encoded at a Nitrogen or Carbon atom, e.g. 127C." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002307 ! fragmentation ion type
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002672
@@ -17569,7 +17550,7 @@ is_a: MS:1000121 ! SCIEX instrument model
 id: MS:1002675
 name: cross-linking result details
 def: "This subsection describes terms which can describe details of cross-linking results." [PSI:PI]
-relationship: part_of: MS:1001000 ! spectrum interpretation
+relationship: part_of MS:1001000 ! spectrum interpretation
 
 [Term]
 id: MS:1002676
@@ -17577,9 +17558,9 @@ name: protein-pair-level global FDR
 def: "Estimation of the global false discovery rate of proteins-pairs in cross-linking experiments." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002664 ! interaction score derived from cross-linking
-relationship: has_domain: MS:1002305 ! value between 0 and 1 inclusive
-relationship: has_regexp: MS:1002665 ! ([:digit:]+[.][a|b]:[:digit:]+:[:digit:]+[.][:digit:]+([Ee][+-][0-9]+)*:(true|false]\{1\}))
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_regexp MS:1002665 ! ([:digit:]+[.][a|b]:[:digit:]+:[:digit:]+[.][:digit:]+([Ee][+-][0-9]+)*:(true|false]\{1\}))
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002677
@@ -17587,9 +17568,9 @@ name: residue-pair-level global FDR
 def: "Estimation of the global false discovery rate of residue-pairs in cross-linking experiments." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002664 ! interaction score derived from cross-linking
-relationship: has_domain: MS:1002305 ! value between 0 and 1 inclusive
-relationship: has_regexp: MS:1002665 ! ([:digit:]+[.][a|b]:[:digit:]+:[:digit:]+[.][:digit:]+([Ee][+-][0-9]+)*:(true|false]\{1\}))
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_regexp MS:1002665 ! ([:digit:]+[.][a|b]:[:digit:]+:[:digit:]+[.][:digit:]+([Ee][+-][0-9]+)*:(true|false]\{1\}))
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002678
@@ -17609,8 +17590,8 @@ name: supplemental collision energy
 def: "Energy for an ion experiencing supplemental collision with a stationary gas particle resulting in dissociation of the ion." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000510 ! precursor activation attribute
-relationship: has_units: UO:0000266 ! electronvolt
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units UO:0000266 ! electronvolt
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002681
@@ -17619,8 +17600,8 @@ def: "OpenXQuest's combined score for a cross-link spectrum match." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1001153 ! search engine specific score
-relationship: has_order: MS:1002108 ! higher score better
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_order MS:1002108 ! higher score better
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002682
@@ -17629,8 +17610,8 @@ def: "OpenXQuest's cross-correlation of cross-linked ions subscore." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1001153 ! search engine specific score
-relationship: has_order: MS:1002108 ! higher score better
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_order MS:1002108 ! higher score better
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002683
@@ -17639,8 +17620,8 @@ def: "OpenXQuest's cross-correlation of unlinked ions subscore." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1001153 ! search engine specific score
-relationship: has_order: MS:1002108 ! higher score better
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_order MS:1002108 ! higher score better
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002684
@@ -17649,9 +17630,9 @@ def: "OpenXQuest's match-odds subscore." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1001153 ! search engine specific score
-relationship: has_order: MS:1002108 ! higher score better
-relationship: has_domain: MS:1002306 ! value greater than zero
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_order MS:1002108 ! higher score better
+relationship: has_domain MS:1002306 ! value greater than zero
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002685
@@ -17660,9 +17641,9 @@ def: "OpenXQuest's sum of matched peak intensity subscore." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1001153 ! search engine specific score
-relationship: has_order: MS:1002108 ! higher score better
-relationship: has_domain: MS:1002306 ! value greater than zero
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_order MS:1002108 ! higher score better
+relationship: has_domain MS:1002306 ! value greater than zero
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002686
@@ -17671,9 +17652,9 @@ def: "OpenXQuest's weighted percent of total ion current subscore." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1001153 ! search engine specific score
-relationship: has_order: MS:1002108 ! higher score better
-relationship: has_domain: MS:1002305 ! value between 0 and 1 inclusive
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_order MS:1002108 ! higher score better
+relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002687
@@ -17800,7 +17781,7 @@ id: MS:1002708
 name: LysargiNase
 def: "Metalloproteinase found in Methanosarcina acetivorans that cleaves on the N-terminal side of lysine and arginine residues." [PMID:25419962]
 is_a: MS:1001045 ! cleavage agent name
-relationship: has_regexp: MS:1002707 ! (?=[KR])
+relationship: has_regexp MS:1002707 ! (?=[KR])
 
 [Term]
 id: MS:1002709
@@ -17818,21 +17799,21 @@ id: MS:1002711
 name: list of strings
 def: "A list of xsd:string." []
 is_a: MS:1002710 ! list of type
-relationship: has_value_type: xsd\:string
+relationship: has_value_type xsd\:string ! None
 
 [Term]
 id: MS:1002712
 name: list of integers
 def: "A list of xsd:integer." []
 is_a: MS:1002710 ! list of type
-relationship: has_value_type: xsd\:integer
+relationship: has_value_type xsd\:integer ! None
 
 [Term]
 id: MS:1002713
 name: list of floats
 def: "A list of xsd:float." []
 is_a: MS:1002710 ! list of type
-relationship: has_value_type: xsd\:float
+relationship: has_value_type xsd\:float ! None
 
 [Term]
 id: MS:1002719
@@ -17853,8 +17834,8 @@ def: "MSPathFinder spectral E-value." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002353 ! PSM-level e-value
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_order: MS:1002109 ! lower score better
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_order MS:1002109 ! lower score better
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002722
@@ -17863,8 +17844,8 @@ def: "MSPathFinder E-value." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002353 ! PSM-level e-value
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_order: MS:1002109 ! lower score better
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_order MS:1002109 ! lower score better
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002723
@@ -17873,7 +17854,7 @@ def: "MSPathFinder Q-value." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002354 ! PSM-level q-value
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002724
@@ -17881,7 +17862,7 @@ name: MSPathFinder:PepQValue
 def: "MSPathFinder peptide-level Q-value." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002725
@@ -17889,7 +17870,7 @@ name: MSPathFinder:RawScore
 def: "MSPathFinder raw score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002726
@@ -17939,7 +17920,7 @@ name: peptide-level spectral count
 def: "The number of MS2 spectra identified for a peptide sequence specified by the amino acid one-letter codes plus optional PTMs in spectral counting." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002737 ! peptide-level quantification datatype
-relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002734
@@ -17947,7 +17928,7 @@ name: peptide ion-level spectral count
 def: "The number of MS2 spectra identified for a molecular ion defined by the peptide sequence represented by the amino acid one-letter codes, plus optional PTMs plus optional charged aducts plus the charge state, in spectral counting." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002737 ! peptide-level quantification datatype
-relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002735
@@ -18006,7 +17987,7 @@ def: "A data array of parallel, independent m/z values for a sampling of noise a
 xref: binary-data-type:MS\:1000521 "32-bit float"
 xref: binary-data-type:MS\:1000523 "64-bit float"
 is_a: MS:1000513 ! binary data array
-relationship: has_units: MS:1000040 ! m/z
+relationship: has_units MS:1000040 ! m/z
 
 [Term]
 id: MS:1002744
@@ -18015,7 +17996,7 @@ def: "A data array of intensity values for the amplitude of noise variation supe
 xref: binary-data-type:MS\:1000521 "32-bit float"
 xref: binary-data-type:MS\:1000523 "64-bit float"
 is_a: MS:1000513 ! binary data array
-relationship: has_units: MS:1000131 ! number of detector counts
+relationship: has_units MS:1000131 ! number of detector counts
 
 [Term]
 id: MS:1002745
@@ -18049,7 +18030,7 @@ name: Mascot:IntegratedSpectralLibrarySearch
 def: "Means that Mascot has integrated the search results of database and spectral library search into a single data set." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002095 ! Mascot input parameter
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002750
@@ -18080,8 +18061,8 @@ id: MS:1002754
 name: MSPepSearch:score
 def: "MSPepSearch score (0 for entirely dissimilar and 1000 for identical observed spectrum and library spectrum." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_order: MS:1002108 ! higher score better
-relationship: has_domain: MS:1002753 ! value between 0 and 1000 inclusive
+relationship: has_order MS:1002108 ! higher score better
+relationship: has_domain MS:1002753 ! value between 0 and 1000 inclusive
 
 [Term]
 id: MS:1002755
@@ -18411,7 +18392,7 @@ is_a: MS:1000353 ! adduct ion
 id: MS:1002809
 name: adduct ion attribute
 def: "Nonphysical characteristic attributed to an adduct ion." [PSI:MS]
-relationship: part_of: MS:1000353 ! adduct ion
+relationship: part_of MS:1000353 ! adduct ion
 
 [Term]
 id: MS:1002810
@@ -18419,7 +18400,7 @@ name: adduct ion X m/z
 def: "Theoretical m/z of the X component in the adduct M+X or M-X. This term was formerly called 'adduct ion mass', but it is not really a mass. It corresponds to the column mislabelled as 'mass' at https://fiehnlab.ucdavis.edu/staff/kind/Metabolomics/MS-Adduct-Calculator." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1003056 ! adduct ion property
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002811
@@ -18427,7 +18408,7 @@ name: adduct ion isotope
 def: "Isotope of the matrix molecule M of an adduct formation." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1003056 ! adduct ion property
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002812
@@ -18441,8 +18422,8 @@ name: adduct ion formula
 def: "Adduct formation formula of the form M+X or M-X, as constrained by the provided regular expression." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002809 ! adduct ion attribute
-relationship: has_regexp: MS:1002812 ! (\[[:digit:]{0,1}M([+][:digit:]{0,1}(H|K|(Na)|(Li)|(Cl)|(Br)|(NH3)|(NH4)|(CH3OH)|(IsoProp)|(DMSO)|(FA)|(Hac)|(TFA)|(NaCOOH)|(HCOOH)|(CF3COOH)|(ACN))){0,}([-][:digit:]{0,1}(H|(H2O)|(CH2)|(CH4)|(NH3)|(CO)|(CO2)|(COCH2)|(HCOOH)|(C2H4)|(C4H8)|(C3H2O3)|(C5H8O4)|(C6H10O4)|(C6H10O5)|(C6H8O6))){0,}\][:digit:]{0,1}[+-])
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_regexp MS:1002812 ! (\[[:digit:]{0,1}M([+][:digit:]{0,1}(H|K|(Na)|(Li)|(Cl)|(Br)|(NH3)|(NH4)|(CH3OH)|(IsoProp)|(DMSO)|(FA)|(Hac)|(TFA)|(NaCOOH)|(HCOOH)|(CF3COOH)|(ACN))){0,}([-][:digit:]{0,1}(H|(H2O)|(CH2)|(CH4)|(NH3)|(CO)|(CO2)|(COCH2)|(HCOOH)|(C2H4)|(C4H8)|(C3H2O3)|(C5H8O4)|(C6H10O4)|(C6H10O5)|(C6H8O6))){0,}\][:digit:]{0,1}[+-])
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002814
@@ -18457,8 +18438,8 @@ def: "Ion mobility measurement for an ion or spectrum of ions as measured in an 
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000455 ! ion selection attribute
 is_a: MS:1002892 ! ion mobility attribute
-relationship: has_units: MS:1002814 ! volt-second per square centimeter
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units MS:1002814 ! volt-second per square centimeter
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002816
@@ -18466,9 +18447,9 @@ name: mean ion mobility array
 def: "Array of population mean ion mobility values (K or K0) based on ion separation in gaseous phase due to different ion mobilities under an electric field based on ion size, m/z and shape, corresponding to a spectrum of individual peaks encoded with an m/z array." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002893 ! ion mobility array
-relationship: has_units: UO:0000028 ! millisecond
-relationship: has_units: UO:0000010 ! second
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units UO:0000028 ! millisecond
+relationship: has_units UO:0000010 ! second
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002817
@@ -18488,7 +18469,7 @@ name: Bruker TDF nativeID format, combined spectra
 def: "Bruker TDF comma separated list of spectra that have been combined prior to searching or interpretation." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002646 ! native spectrum identifier format, combined spectra
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002820
@@ -18540,8 +18521,8 @@ name: MetaMorpheus:score
 def: "MetaMorpheus score for PSMs." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_order: MS:1002108 ! higher score better
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_order MS:1002108 ! higher score better
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002828
@@ -18549,8 +18530,8 @@ name: MetaMorpheus:protein score
 def: "MetaMorpheus score for protein groups." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002368 ! search engine specific score for protein groups
-relationship: has_order: MS:1002108 ! higher score better
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_order MS:1002108 ! higher score better
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002829
@@ -18558,7 +18539,7 @@ name: XCMS:into
 def: "Feature intensity produced by XCMS findPeaks() from integrated peak intensity." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002735 ! feature-level quantification datatype
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002830
@@ -18566,7 +18547,7 @@ name: XCMS:intf
 def: "Feature intensity produced by XCMS findPeaks() from baseline corrected integrated peak intensity." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002735 ! feature-level quantification datatype
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002831
@@ -18574,7 +18555,7 @@ name: XCMS:maxo
 def: "Feature intensity produced by XCMS findPeaks() from maximum peak intensity." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002735 ! feature-level quantification datatype
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002832
@@ -18582,7 +18563,7 @@ name: XCMS:area
 def: "Feature intensity produced by XCMS findPeaks() from feature area that is not normalized by the scan rate." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002735 ! feature-level quantification datatype
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002833
@@ -18596,7 +18577,7 @@ name: ProteomeDiscoverer:Delta Score
 def: "The Delta Score reported by Proteome Discoverer version 2." [PSI:PI]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002835
@@ -18610,7 +18591,7 @@ name: iProX dataset identifier
 def: "Dataset identifier issued by the iProX repository. A dataset can refer to either a single sample as part of a study, or all samples that are part of the study corresponding to a publication." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002837
@@ -18618,7 +18599,7 @@ name: iProX dataset URI
 def: "URI that allows the access to one dataset in the iProX repository. A dataset can refer to either a single sample as part of a study, or all samples that are part of the study corresponding to a publication." [PSI:PI]
 xref: value-type:xsd\:anyURI "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
-relationship: has_value_type: xsd\:anyURI ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:anyURI ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002838
@@ -18636,7 +18617,7 @@ is_a: MS:1000530 ! file format conversion
 id: MS:1002840
 name: external reference data
 def: "Data belonging to an external reference." [PSI:MS]
-relationship: part_of: MS:0000000 ! Proteomics Standards Initiative Mass Spectrometry Vocabularies
+relationship: part_of MS:0000000 ! Proteomics Standards Initiative Mass Spectrometry Vocabularies
 
 [Term]
 id: MS:1002841
@@ -18644,7 +18625,7 @@ name: external HDF5 dataset
 def: "The HDF5 dataset location containing the binary data, relative to the dataset containing the mzML. Also indicates that there is no data in the <binary> section of the BinaryDataArray." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002840 ! external reference data
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002842
@@ -18652,8 +18633,8 @@ name: external offset
 def: "The position in the external data where the array begins." [PSI:PI]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1002840 ! external reference data
-relationship: has_units: UO:0000189 ! Count
-relationship: has_value_type: xsd\:nonNegativeInteger ! The allowed value-type for this CV term.
+relationship: has_units UO:0000189 ! Count
+relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002843
@@ -18661,8 +18642,8 @@ name: external array length
 def: "Describes how many fields an array contains." [PSI:PI]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1002840 ! external reference data
-relationship: has_units: UO:0000189 ! Count
-relationship: has_value_type: xsd\:nonNegativeInteger ! The allowed value-type for this CV term.
+relationship: has_units UO:0000189 ! Count
+relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002844
@@ -18676,7 +18657,7 @@ name: Associated file URI
 def: "URI of one external file associated to the PRIDE experiment (maybe through a PX submission)." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002844 ! Experiment additional parameter
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002846
@@ -18684,7 +18665,7 @@ name: Associated raw file URI
 def: "URI of one raw data file associated to the PRIDE experiment (maybe through a PX submission)." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002845 ! Associated file URI
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002847
@@ -18692,7 +18673,7 @@ name: ProteomeCentral dataset URI
 def: "URI associated to one PX submission in ProteomeCentral." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002844 ! Experiment additional parameter
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002848
@@ -18700,7 +18681,7 @@ name: Result file URI
 def: "URI of one file labeled as 'Result', associated to one PX submission." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002845 ! Associated file URI
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002849
@@ -18708,7 +18689,7 @@ name: Search engine output file URI
 def: "URI of one search engine output file associated to one PX submission." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002845 ! Associated file URI
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002850
@@ -18716,7 +18697,7 @@ name: Peak list file URI
 def: "URI of one of one search engine output file associated to one PX submission." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002845 ! Associated file URI
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002851
@@ -18724,7 +18705,7 @@ name: Other type file URI
 def: "URI of one file labeled as 'Other', associated to one PX submission." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002845 ! Associated file URI
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002852
@@ -18732,7 +18713,7 @@ name: Dataset FTP location
 def: "FTP location of one entire PX data set." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002844 ! Experiment additional parameter
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002853
@@ -18776,7 +18757,7 @@ name: Additional associated raw file URI
 def: "Additional URI of one raw data file associated to the PRIDE experiment (maybe through a PX submission). The URI is provided via an additional resource to PRIDE." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002845 ! Associated file URI
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002860
@@ -18784,7 +18765,7 @@ name: Gel image file URI
 def: "URI of one gel image file associated to one PX submission." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002845 ! Associated file URI
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002861
@@ -18792,7 +18773,7 @@ name: Reprocessed complete dataset
 def: "All the raw files included in the original dataset (or group of original datasets) have been reanalysed." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002844 ! Experiment additional parameter
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002862
@@ -18800,7 +18781,7 @@ name: Reprocessed subset dataset
 def: "A subset of the raw files included in the original dataset (or group of original datasets) has been reanalysed." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002844 ! Experiment additional parameter
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002863
@@ -18826,7 +18807,7 @@ name: Reference
 def: "Literature reference associated with one dataset (including the authors, title, year and journal details). The value field can be used for the PubMedID, or to specify if one manuscript is just submitted or accepted, but it does not have a PubMedID yet." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002844 ! Experiment additional parameter
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002867
@@ -18867,7 +18848,7 @@ name: Panorama Public dataset identifier
 def: "Dataset identifier issued by the Panorama Public repository. A dataset can refer to either a single sample as part of a study, or all samples that are part of the study corresponding to a publication." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002873
@@ -18875,7 +18856,7 @@ name: Panorama Public dataset URI
 def: "URI that allows the access to one dataset in the Panorama Public repository. A dataset can refer to either a single sample as part of a study, or all samples that are part of the study corresponding to a publication." [PSI:PI]
 xref: value-type:xsd\:anyURI "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
-relationship: has_value_type: xsd\:anyURI ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:anyURI ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002874
@@ -18961,7 +18942,7 @@ name: Progenesis QI normalised abundance
 def: "The normalised abundance produced by Progenesis QI LC-MS." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002886 ! small molecule quantification datatype
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002888
@@ -18975,7 +18956,7 @@ name: Progenesis MetaScope score
 def: "The confidence score produced by Progenesis QI." [PSI:PI]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002888 ! small molecule confidence measure
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002890
@@ -18983,7 +18964,7 @@ name: fragmentation score
 def: "The fragmentation confidence score." [PSI:PI]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002888 ! small molecule confidence measure
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002891
@@ -18991,7 +18972,7 @@ name: isotopic fit score
 def: "The isotopic fit confidence score." [PSI:PI]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002888 ! small molecule confidence measure
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002892
@@ -19012,7 +18993,7 @@ name: InChIKey
 def: "Unique chemical structure identifier for chemical compounds." [PMID:273343401]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001405 ! spectrum identification result details
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002895
@@ -19026,7 +19007,7 @@ name: compound identification confidence level
 def: "Confidence level for annotation of identified compounds as defined by the Metabolomics Standards Initiative (MSI). The value slot can have the values 'Level 0' until 'Level 4'." [PMID:29748461]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002895 ! small molecule identification attribute
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002897
@@ -19034,7 +19015,7 @@ name: isotopomer peak
 def: "OBSOLETE Identifies a peak when no de-isotoping has been performed. The value slot reports the isotopomer peak, e.g. '2H', '13C', '15N', '18O', '31P'." [PSI:PI]
 xref: value-type:xsd:string "The allowed value-type for this CV term."
 is_a: MS:1000231 ! peak
-relationship: has_value_type: xsd:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002898
@@ -19096,8 +19077,8 @@ name: proteoform-level global FDR
 def: "Estimation of the global false discovery rate of proteoforms." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002905 ! proteoform-level identification statistic
-relationship: has_domain: MS:1002305 ! value between 0 and 1 inclusive
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002908
@@ -19105,8 +19086,8 @@ name: proteoform-level local FDR
 def: "Estimation of the local false discovery rate of proteoforms." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002905 ! proteoform-level identification statistic
-relationship: has_domain: MS:1002305 ! value between 0 and 1 inclusive
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002909
@@ -19120,7 +19101,7 @@ name: proteoform-level global FDR threshold
 def: "Threshold for the global false discovery rate of proteoforms." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002909 ! proteoform-level statistical threshold
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002911
@@ -19128,7 +19109,7 @@ name: proteoform-level local FDR threshold
 def: "Threshold for the local false discovery rate of proteoforms." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002909 ! proteoform-level statistical threshold
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002912
@@ -19154,7 +19135,7 @@ name: TopPIC:error tolerance
 def: "Error tolerance for precursor and fragment masses in PPM." [PSI:PI]
 xref: value-type:xsd\:integer "The allowed value-type for this CV term."
 is_a: MS:1002912 ! TopPIC input parameter
-relationship: has_value_type: xsd\:integer ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002916
@@ -19162,7 +19143,7 @@ name: TopPIC:max shift
 def: "Maximum value of the mass shift (in Dalton) of an unexpected modification." [PSI:PI]
 xref: value-type:xsd\:integer "The allowed value-type for this CV term."
 is_a: MS:1002912 ! TopPIC input parameter
-relationship: has_value_type: xsd\:integer ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002917
@@ -19170,7 +19151,7 @@ name: TopPIC:min shift
 def: "Minimum value of the mass shift (in Dalton) of an unexpected modification." [PSI:PI]
 xref: value-type:xsd\:integer "The allowed value-type for this CV term."
 is_a: MS:1002912 ! TopPIC input parameter
-relationship: has_value_type: xsd\:integer ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002918
@@ -19178,7 +19159,7 @@ name: TopPIC:shift num
 def: "Maximum number of unexpected modifications in a proteoform spectrum match." [PSI:PI]
 xref: value-type:xsd\:integer "The allowed value-type for this CV term."
 is_a: MS:1002912 ! TopPIC input parameter
-relationship: has_value_type: xsd\:integer ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002919
@@ -19186,7 +19167,7 @@ name: TopPIC:spectral cutoff type
 def: "Spectrum-level cutoff type for filtering identified proteoform spectrum matches." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002912 ! TopPIC input parameter
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002920
@@ -19194,7 +19175,7 @@ name: TopPIC:spectral cutoff value
 def: "Spectrum-level cutoff value for filtering identified proteoform spectrum matches." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002912 ! TopPIC input parameter
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002921
@@ -19202,7 +19183,7 @@ name: TopPIC:proteoform-level cutoff type
 def: "Proteoform-level cutoff type for filtering identified proteoform spectrum matches." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002912 ! TopPIC input parameter
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002922
@@ -19210,7 +19191,7 @@ name: TopPIC:proteoform-level cutoff value
 def: "Proteoform-level cutoff value for filtering identified proteoform spectrum matches." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002912 ! TopPIC input parameter
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002923
@@ -19218,7 +19199,7 @@ name: TopPIC:generating function
 def: "P-value and E-value estimation using generating function." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002912 ! TopPIC input parameter
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002924
@@ -19226,7 +19207,7 @@ name: TopPIC:combined spectrum number
 def: "Number of combined spectra." [PSI:PI]
 xref: value-type:xsd\:integer "The allowed value-type for this CV term."
 is_a: MS:1002912 ! TopPIC input parameter
-relationship: has_value_type: xsd\:integer ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002925
@@ -19240,7 +19221,7 @@ name: TopPIC:thread number
 def: "Number of threads used in TopPIC." [PSI:PI]
 xref: value-type:xsd\:integer "The allowed value-type for this CV term."
 is_a: MS:1002912 ! TopPIC input parameter
-relationship: has_value_type: xsd\:integer ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002927
@@ -19248,7 +19229,7 @@ name: TopPIC:use TopFD feature
 def: "Proteoform identification using TopFD feature file." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002912 ! TopPIC input parameter
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002928
@@ -19257,8 +19238,8 @@ def: "TopPIC spectrum-level E-value." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1002353 ! PSM-level e-value
-relationship: has_order: MS:1002109 ! lower score better
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_order MS:1002109 ! lower score better
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002929
@@ -19267,7 +19248,7 @@ def: "TopPIC spectrum-level FDR." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1002351 ! PSM-level local FDR
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002930
@@ -19276,7 +19257,7 @@ def: "TopPIC proteoform-level FDR." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002908 ! proteoform-level local FDR
 is_a: MS:1002906 ! search engine specific score for proteoforms
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002931
@@ -19285,7 +19266,7 @@ def: "TopPIC spectrum-level p-value." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1002352 ! PSM-level p-value
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002932
@@ -19293,7 +19274,7 @@ name: TopPIC:MIScore
 def: "Modification identification score." [PMID:27291504]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001968 ! PTM localization PSM-level statistic
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002933
@@ -19301,7 +19282,7 @@ name: TopPIC:MIScore threshold
 def: "TopPIC:MIScore threshold." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002555 ! PTM localization score threshold
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002934
@@ -19327,7 +19308,7 @@ name: TopMG:error tolerance
 def: "Error tolerance for precursor and fragment masses in PPM." [PSI:PI]
 xref: value-type:xsd\:integer "The allowed value-type for this CV term."
 is_a: MS:1002934 ! TopMG input parameter
-relationship: has_value_type: xsd\:integer ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002938
@@ -19335,7 +19316,7 @@ name: TopMG:max shift
 def: "Maximum value of the mass shift (in Dalton)." [PSI:PI]
 xref: value-type:xsd\:integer "The allowed value-type for this CV term."
 is_a: MS:1002934 ! TopMG input parameter
-relationship: has_value_type: xsd\:integer ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002939
@@ -19343,7 +19324,7 @@ name: TopMG:spectral cutoff type
 def: "Spectrum-level cutoff type for filtering identified proteoform spectrum matches." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002934 ! TopMG input parameter
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002940
@@ -19351,7 +19332,7 @@ name: TopMG:spectral cutoff value
 def: "Spectrum-level cutoff value for filtering identified proteoform spectrum matches." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002934 ! TopMG input parameter
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002941
@@ -19359,7 +19340,7 @@ name: TopMG:proteoform-level cutoff type
 def: "Proteoform-level cutoff type for filtering identified proteoform spectrum matches." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002934 ! TopMG input parameter
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002942
@@ -19367,7 +19348,7 @@ name: TopMG:proteoform-level cutoff value
 def: "Proteoform-level cutoff value for filtering identified proteoform spectrum matches." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002934 ! TopMG input parameter
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002943
@@ -19381,7 +19362,7 @@ name: TopMG:thread number
 def: "Number of threads used in TopMG." [PSI:PI]
 xref: value-type:xsd\:integer "The allowed value-type for this CV term."
 is_a: MS:1002934 ! TopMG input parameter
-relationship: has_value_type: xsd\:integer ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002945
@@ -19389,7 +19370,7 @@ name: TopMG:use TopFD feature
 def: "Proteoform identification using TopFD feature file." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002934 ! TopMG input parameter
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002946
@@ -19397,7 +19378,7 @@ name: TopMG:proteoform graph gap size
 def: "Gap size in constructing proteoform graph." [PSI:PI]
 xref: value-type:xsd\:integer "The allowed value-type for this CV term."
 is_a: MS:1002934 ! TopMG input parameter
-relationship: has_value_type: xsd\:integer ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002947
@@ -19405,7 +19386,7 @@ name: TopMG:variable PTM number
 def: "Maximum number of variable PTMs." [PSI:PI]
 xref: value-type:xsd\:integer "The allowed value-type for this CV term."
 is_a: MS:1002934 ! TopMG input parameter
-relationship: has_value_type: xsd\:integer ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002948
@@ -19413,7 +19394,7 @@ name: TopMG:variable PTM number in proteoform graph gap
 def: "Maximum number of variable PTMs in a proteoform graph gap." [PSI:PI]
 xref: value-type:xsd\:integer "The allowed value-type for this CV term."
 is_a: MS:1002934 ! TopMG input parameter
-relationship: has_value_type: xsd\:integer ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002949
@@ -19421,7 +19402,7 @@ name: TopMG:use ASF-DIAGONAL
 def: "Protein filtering using ASF-DIAGONAL method." [PMID:29327814]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002934 ! TopMG input parameter
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002950
@@ -19430,8 +19411,8 @@ def: "TopMG spectrum-level E-value." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002353 ! PSM-level e-value
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_order: MS:1002109 ! lower score better
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_order MS:1002109 ! lower score better
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002951
@@ -19440,7 +19421,7 @@ def: "TopMG spectrum-level FDR." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002351 ! PSM-level local FDR
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002952
@@ -19449,7 +19430,7 @@ def: "TopMG proteoform-level FDR." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002908 ! proteoform-level local FDR
 is_a: MS:1002906 ! search engine specific score for proteoforms
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002953
@@ -19458,7 +19439,7 @@ def: "TopMG spectrum-level p-value." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002352 ! PSM-level p-value
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002954
@@ -19466,8 +19447,8 @@ name: collisional cross sectional area
 def: "Structural molecular descriptor for the effective interaction area between the ion and neutral gas measured in ion mobility mass spectrometry." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1000861 ! molecular entity property
-relationship: has_units: UO:0000324 ! square angstrom
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_units UO:0000324 ! square angstrom
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002955
@@ -19475,7 +19456,7 @@ name: hr-ms compound identification confidence level
 def: "Refined High Resolution mass spectrometry confidence level for annotation of identified compounds as proposed by Schymanski et al. The value slot can have the values 'Level 1', 'Level 2', 'Level 2a', 'Level 2b', 'Level 3', 'Level 4', and 'Level 5'." [PMID:24476540]
 xref: value-type:xsd:string "The allowed value-type for this CV term."
 is_a: MS:1002895 ! small molecule identification attribute
-relationship: has_value_type: xsd:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002956
@@ -19483,7 +19464,7 @@ name: isotopic ion MS peak
 def: "A mass spectrometry peak that represents one or more isotopic ions. The value slot contains a description of the represented isotope set, e.g. 'M+1 peak'." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000231 ! peak
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002957
@@ -19491,7 +19472,7 @@ name: isotopomer MS peak
 def: "The described isotopomer mass spectrometric signal. The value slot contains a description of the represented isotopomer, e.g. '13C peak', '15N peak', '2H peak', '18O peak' or '31P peak'." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002956 ! isotopic ion MS peak
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002958
@@ -19499,7 +19480,7 @@ name: isotopologue MS peak
 def: "The described isotopologue mass spectrometric signal. The value slot contains a description of the represented isotopologue, e.g. '13C1 peak' or '15N1 peak'." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002956 ! isotopic ion MS peak
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002959
@@ -19507,7 +19488,7 @@ name: isomer
 def: "One of several species (or molecular entities) that have the same atomic composition (molecular formula) but different line formulae or different stereochemical formulae." [https://goldbook.iupac.org/html/I/I03289.html]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000859 ! molecule
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002960
@@ -19515,7 +19496,7 @@ name: isotopomer
 def: "An isomer that differs from another only in the spatial distribution of the constitutive isotopic atoms." [https://goldbook.iupac.org/html/I/I03352.html]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002959 ! isomer
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002961
@@ -19523,7 +19504,7 @@ name: isotopologue
 def: "A molecular entity that differs only in isotopic composition (number of isotopic substitutions)." [https://goldbook.iupac.org/html/I/I03351.html]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002959 ! isomer
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002962
@@ -19702,8 +19683,8 @@ name: IdentiPy:RHNS
 def: "The IdentiPy result 'RHNS'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001153 ! search engine specific score
-relationship: has_order: MS:1002108 ! higher score better
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_order MS:1002108 ! higher score better
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002989
@@ -19711,8 +19692,8 @@ name: IdentiPy:hyperscore
 def: "The IdentiPy result 'hyperscore'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001153 ! search engine specific score
-relationship: has_order: MS:1002108 ! higher score better
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_order MS:1002108 ! higher score better
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002990
@@ -19732,9 +19713,9 @@ name: Andromeda:PEP
 def: "Posterior error probability of the best identified peptide of the Andromeda search engine." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_domain: MS:1002305 ! value between 0 and 1 inclusive
-relationship: has_order: MS:1002108 ! higher score better
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_order MS:1002108 ! higher score better
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002996
@@ -19748,7 +19729,7 @@ name: ProteomeXchange dataset identifier reanalysis number
 def: "Index number of a reanalysis within a ProteomeXchange reprocessed dataset identifier container (RPXD)." [PSI:PI]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
-relationship: has_value_type: xsd\:nonNegativeInteger ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002998
@@ -19804,8 +19785,8 @@ name: mean inverse reduced ion mobility array
 def: "Array of population mean ion mobility values based on ion separation in gaseous phase due to different ion mobilities under an electric field based on ion size, m/z and shape, normalized for the local conditions and reported in volt-second per square centimeter, corresponding to a spectrum of individual peaks encoded with an m/z array." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002893 ! ion mobility array
-relationship: has_units: MS:1002814 ! volt-second per square centimeter
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units MS:1002814 ! volt-second per square centimeter
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003007
@@ -19813,9 +19794,9 @@ name: raw ion mobility array
 def: "Array of raw ion mobility values (K or K0) based on ion separation in gaseous phase due to different ion mobilities under an electric field based on ion size, m/z and shape, corresponding to a spectrum of individual peaks encoded with an m/z array." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002893 ! ion mobility array
-relationship: has_units: UO:0000028 ! millisecond
-relationship: has_units: UO:0000010 ! second
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units UO:0000028 ! millisecond
+relationship: has_units UO:0000010 ! second
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003008
@@ -19823,8 +19804,8 @@ name: raw inverse reduced ion mobility array
 def: "Array of raw ion mobility values based on ion separation in gaseous phase due to different ion mobilities under an electric field based on ion size, m/z and shape, normalized for the local conditions and reported in volt-second per square centimeter, corresponding to a spectrum of individual peaks encoded with an m/z array." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002893 ! ion mobility array
-relationship: has_units: MS:1002814 ! volt-second per square centimeter
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units MS:1002814 ! volt-second per square centimeter
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003009
@@ -19850,7 +19831,7 @@ id: MS:1003012
 name: KSDP score
 def: "Kernel mass spectral dot product scoring function." [PMID:15044235]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_order: MS:1002108 ! higher score better
+relationship: has_order MS:1002108 ! higher score better
 
 [Term]
 id: MS:1003013
@@ -19877,9 +19858,9 @@ def: "Fraction of peptide evidence attributable to a protein or a set of indisti
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002490 ! peptide-level scoring
 is_a: MS:1001153 ! search engine specific score
-relationship: has_order: MS:1002108 ! higher score better
-relationship: has_domain: MS:1002305 ! value between 0 and 1 inclusive
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_order MS:1002108 ! higher score better
+relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003017
@@ -19888,9 +19869,9 @@ def: "Fraction of peptide evidence attributable to a group of proteins." [PSI:PI
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002490 ! peptide-level scoring
 is_a: MS:1001153 ! search engine specific score
-relationship: has_order: MS:1002108 ! higher score better
-relationship: has_domain: MS:1002305 ! value between 0 and 1 inclusive
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_order MS:1002108 ! higher score better
+relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003018
@@ -19937,14 +19918,14 @@ def: "The OpenPepXL score for a cross-link spectrum match." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1001153 ! search engine specific score
-relationship: has_order: MS:1002108 ! higher score better
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_order MS:1002108 ! higher score better
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003025
 name: named element
 def: "A named element that is an attribute in a proteomics standards file." [PSI:PI]
-relationship: part_of: MS:0000000 ! Proteomics Standards Initiative Mass Spectrometry Vocabularies
+relationship: part_of MS:0000000 ! Proteomics Standards Initiative Mass Spectrometry Vocabularies
 
 [Term]
 id: MS:1003026
@@ -19976,7 +19957,7 @@ name: Mascot:MinNumSigUniqueSeqs
 def: "Minimum number of significant unique sequences required in a protein hit. The setting is only relevant if the protein grouping strategy is 'family clustering'." [PSI:PI]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1002095 ! Mascot input parameter
-relationship: has_value_type: xsd\:nonNegativeInteger ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003031
@@ -19984,7 +19965,7 @@ name: CPTAC accession number
 def: "Main identifier of a CPTAC dataset." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003032
@@ -19992,13 +19973,13 @@ name: compound identification confidence code in MS-DIAL
 def: "The confidence code to describe the confidence of annotated compounds as defined by the MS-DIAL program." [PMID:25938372, http://prime.psc.riken.jp/Metabolomics_Software/MS-DIAL]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002895 ! small molecule identification attribute
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003033
 name: molecular entity attribute
 def: "Non-inherent characteristic attributed to a molecular entity." [PSI:PI]
-relationship: part_of: MS:1000881 ! molecular entity
+relationship: part_of MS:1000881 ! molecular entity
 
 [Term]
 id: MS:1003034
@@ -20100,7 +20081,7 @@ is_a: MS:1000860 ! peptide
 id: MS:1003050
 name: peptidoform attribute
 def: "Non-inherent characteristic attributed to a peptidoform." [PSI:PI]
-relationship: part_of: MS:1003049 ! peptidoform
+relationship: part_of MS:1003049 ! peptidoform
 
 [Term]
 id: MS:1003051
@@ -20112,7 +20093,7 @@ is_a: MS:1003049 ! peptidoform
 id: MS:1003052
 name: peptidoform ion property
 def: "Inherent or measurable characteristic of a peptidoform ion." [PSI:PI]
-relationship: part_of: MS:1003051 ! peptidoform ion
+relationship: part_of MS:1003051 ! peptidoform ion
 
 [Term]
 id: MS:1003053
@@ -20136,7 +20117,7 @@ is_a: MS:1000859 ! molecule
 id: MS:1003056
 name: adduct ion property
 def: "Physical measurable characteristic of an adduct ion." [PSI:PI]
-relationship: part_of: MS:1000353 ! adduct ion
+relationship: part_of MS:1000353 ! adduct ion
 
 [Term]
 id: MS:1003057
@@ -20148,7 +20129,7 @@ is_a: MS:1000503 ! scan attribute
 id: MS:1003058
 name: spectrum property
 def: "Inherent or measurable characteristic of a spectrum." [PSI:PI]
-relationship: part_of: MS:1000442 ! spectrum
+relationship: part_of MS:1000442 ! spectrum
 
 [Term]
 id: MS:1003059
@@ -20268,7 +20249,7 @@ is_a: MS:1000442 ! spectrum
 id: MS:1003078
 name: interpreted spectrum attribute
 def: "Non-inherent characteristic attributed to an interpreted spectrum." [PSI:PI]
-relationship: part_of: MS:1003077 ! interpreted spectrum
+relationship: part_of MS:1003077 ! interpreted spectrum
 
 [Term]
 id: MS:1003079
@@ -20288,8 +20269,8 @@ name: unidentified modification monoisotopic mass delta
 def: "Monoisotopic mass delta in Daltons of an amino acid residue modification whose atomic composition or molecular identity has not been determined. This term should not be used for modifications of known molecular identity such as those available in Unimod, RESID or PSI-MOD. This term MUST NOT be used inside the <Modification> element in mzIdentML." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001471 ! peptide modification details
-relationship: has_units: UO:0000221 ! dalton
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_units UO:0000221 ! dalton
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003082
@@ -20310,7 +20291,7 @@ name: processed data file
 def: "File that contains data that has been substantially processed or transformed from what was originally acquired by an instrument." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000577 ! source data file
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003085
@@ -20319,7 +20300,7 @@ def: "Intensity of the precursor ion in the previous MSn-1 scan (prior in time t
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001141 ! intensity of precursor ion
 is_a: MS:1000499 ! spectrum attribute
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003086
@@ -20328,7 +20309,7 @@ def: "Intensity of the precursor ion current as measured by its apex point over 
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001141 ! intensity of precursor ion
 is_a: MS:1000499 ! spectrum attribute
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003087
@@ -20358,8 +20339,8 @@ is_a: MS:1000572 ! binary data compression type
 id: MS:1003091
 name: binary data compression parameter
 def: "Settable parameter for a binary data compression event." [PSI:MS]
-relationship: part_of: MS:1000442 ! spectrum
-relationship: part_of: MS:1000625 ! chromatogram
+relationship: part_of MS:1000442 ! spectrum
+relationship: part_of MS:1000625 ! chromatogram
 
 [Term]
 id: MS:1003092
@@ -20367,14 +20348,14 @@ name: number of mantissa bits truncated
 def: "Number of extraneous mantissa bits truncated to improve subsequent compression." [PSI:MS]
 xref: value-type:xsd\:positiveInteger "Number of mantissa bits truncated."
 is_a: MS:1003091 ! binary data compression parameter
-relationship: has_value_type: xsd\:positiveInteger ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003093
 name: Lys-N
 def: "Metalloendopeptidase found in the mushroom Grifola frondosa that cleaves proteins on the amino side of lysine residues." [https://en.wikipedia.org/wiki/Lys-N]
 is_a: MS:1001045 ! cleavage agent name
-relationship: has_regexp: MS:1001335 ! (?=K)
+relationship: has_regexp MS:1001335 ! (?=K)
 
 [Term]
 id: MS:1003094
@@ -20400,7 +20381,7 @@ name: MaxQuant protein group-level score
 def: "The probability based MaxQuant protein group score." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002368 ! search engine specific score for protein groups
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003098
@@ -20408,7 +20389,7 @@ name: Andromeda peptide PEP
 def: "Peptide probability from Andromeda." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002358 ! search engine specific peptide sequence-level identification statistic
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003099
@@ -20416,7 +20397,7 @@ name: MaxQuant-DIA peptide PEP
 def: "Peptide probability from MaxQuant-DIA algorithm." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002358 ! search engine specific peptide sequence-level identification statistic
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003100
@@ -20424,7 +20405,7 @@ name: MaxQuant-DIA score
 def: "PSM evidence score from MaxQuant-DIA algorithm." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003101
@@ -20432,7 +20413,7 @@ name: MaxQuant-DIA PEP
 def: "PSM evidence PEP probability from MaxQuant-DIA algorithm." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003102
@@ -20440,7 +20421,7 @@ name: NIST msp comment
 def: "Term for a comment field withing the NIST msp file format" [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000499 ! spectrum attribute
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003103
@@ -20491,8 +20472,8 @@ name: SIM-XL score
 def: "SIM-XL identification search engine score" [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_order: MS:1002108 ! higher score better
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_order MS:1002108 ! higher score better
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003111
@@ -20512,7 +20493,7 @@ name: OpenMS:ConsensusID PEP
 def: "The OpenMS ConsesusID tool posterior error probability" [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003114
@@ -20520,7 +20501,7 @@ name: OpenMS:Best PSM Score
 def: "The score of the best PSM selected by the underlying identification tool" [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002358 ! search engine specific peptide sequence-level identification statistic
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003115
@@ -20528,7 +20509,7 @@ name: OpenMS:Target-decoy PSM q-value
 def: "The OpenMS Target-decoy q-values at PSM level" [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003116
@@ -20536,7 +20517,7 @@ name: OpenMS:Target-decoy peptide q-value
 def: "The OpenMS Target-decoy q-values at peptide sequence level" [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002358 ! search engine specific peptide sequence-level identification statistic
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003117
@@ -20544,7 +20525,7 @@ name: OpenMS:Target-decoy protein q-value
 def: "The OpenMS Target-decoy q-values at protein level" [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003118
@@ -20559,7 +20540,7 @@ name: EPIFANY:Protein posterior probability
 def: "Protein Posterior probability calculated by EPIFANY protein inference algorithm" [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003120
@@ -20567,7 +20548,7 @@ name: OpenMS:LFQ intensity
 def: "The data type LFQ intensity produced by OpenMS." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003121
@@ -20575,7 +20556,7 @@ name: OpenMS:LFQ spectral count
 def: "The data type LFQ spectral count produced by OpenMS." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003122
@@ -20602,8 +20583,8 @@ def: "ProSight spectrum-level Q-value." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002354 ! PSM-level q-value
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_order: MS:1002109 ! lower score better
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_order MS:1002109 ! lower score better
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003126
@@ -20611,8 +20592,8 @@ name: ProSight:spectral P-score
 def: "ProSight spectrum-level P-score." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_order: MS:1002109 ! lower score better
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_order MS:1002109 ! lower score better
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003127
@@ -20621,8 +20602,8 @@ def: "ProSight spectrum-level E-value." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002353 ! PSM-level e-value
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_order: MS:1002109 ! lower score better
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_order MS:1002109 ! lower score better
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003128
@@ -20630,8 +20611,8 @@ name: ProSight:spectral C-score
 def: "ProSight spectrum-level C-score." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_order: MS:1002108 ! higher score better
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_order MS:1002108 ! higher score better
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003129
@@ -20639,9 +20620,9 @@ name: proteoform-level Q-value
 def: "Estimation of the Q-value for proteoforms." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002905 ! proteoform-level identification statistic
-relationship: has_domain: MS:1002305 ! value between 0 and 1 inclusive
-relationship: has_order: MS:1002109 ! lower score better
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_order MS:1002109 ! lower score better
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003130
@@ -20649,8 +20630,8 @@ name: ProSight:proteoform Q-value
 def: "ProSight proteoform-level Q-value." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1003129 ! proteoform-level Q-value
-relationship: has_order: MS:1002109 ! lower score better
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_order MS:1002109 ! lower score better
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003131
@@ -20670,8 +20651,8 @@ name: isoform-level Q-value
 def: "Estimation of the Q-value for isoforms." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1003132 ! isoform-level identification statistic
-relationship: has_domain: MS:1002305 ! value between 0 and 1 inclusive
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003134
@@ -20679,8 +20660,8 @@ name: ProSight:isoform Q-value
 def: "ProSight isoform-level Q-value." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1003133 ! isoform-level Q-value
-relationship: has_order: MS:1002109 ! lower score better
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_order MS:1002109 ! lower score better
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003135
@@ -20688,8 +20669,8 @@ name: ProSight:protein Q-value
 def: "ProSight protein-level Q-value." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001869 ! protein-level q-value
-relationship: has_order: MS:1002109 ! lower score better
-relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
+relationship: has_order MS:1002109 ! lower score better
+relationship: has_value_type xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003136
@@ -20710,7 +20691,7 @@ def: "If true, runs delta m mode in ProSight." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1003136 ! ProSight input parameter
 is_a: MS:1003137 ! TDPortal input parameter
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003139
@@ -20719,7 +20700,7 @@ def: "If true, runs Subsequence Search mode in ProSight." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1003136 ! ProSight input parameter
 is_a: MS:1003137 ! TDPortal input parameter
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003140
@@ -20728,7 +20709,7 @@ def: "If true, runs Annotated Proteoform Search mode in ProSight." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1003136 ! ProSight input parameter
 is_a: MS:1003137 ! TDPortal input parameter
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003141
@@ -20749,7 +20730,7 @@ def: "A data array of mass values." [PSI:MS]
 xref: binary-data-type:MS\:1000521 "32-bit float"
 xref: binary-data-type:MS\:1000523 "64-bit float"
 is_a: MS:1000513 ! binary data array
-relationship: has_units: UO:0000221 ! dalton
+relationship: has_units UO:0000221 ! dalton
 
 [Term]
 id: MS:1003144
@@ -20774,28 +20755,28 @@ id: MS:1003147
 name: PTMProphet probability
 def: "Probability that one mass modification has been correctly localized to a specific residue as computed by PTMProphet." [DOI:10.1021/acs.jproteome.9b00205, PMID:31290668]
 is_a: MS:1001968 ! PTM localization PSM-level statistic
-relationship: has_regexp: MS:1002505 ! regular expression for modification localization scoring
+relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
 
 [Term]
 id: MS:1003148
 name: PTMProphet mean best probability
 def: "PSM-specific average of the m best site probabilities over all potential sites where m is the number of modifications of a specific type, as computed by PTMProphet." [DOI:10.1021/acs.jproteome.9b00205, PMID:31290668]
 is_a: MS:1001968 ! PTM localization PSM-level statistic
-relationship: has_regexp: MS:1002505 ! regular expression for modification localization scoring
+relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
 
 [Term]
 id: MS:1003149
 name: PTMProphet normalized information content
 def: " PTMProphet-computed PSM-specific normalized (0.0 � 1.0) measure of information content across all modifications of a specific type." [DOI:10.1021/acs.jproteome.9b00205, PMID:31290668]
 is_a: MS:1001968 ! PTM localization PSM-level statistic
-relationship: has_regexp: MS:1002505 ! regular expression for modification localization scoring
+relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
 
 [Term]
 id: MS:1003150
 name: PTMProphet information content
 def: " PTMProphet-computed PSM-specific measure of information content per modification type ranging from 0 to m, where m is the number of modifications of a specific type." [DOI:10.1021/acs.jproteome.9b00205, PMID:31290668]
 is_a: MS:1001968 ! PTM localization PSM-level statistic
-relationship: has_regexp: MS:1002505 ! regular expression for modification localization scoring
+relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
 
 [Term]
 id: MS:1003151
@@ -20803,7 +20784,7 @@ name: SHA-256
 def: "SHA-256 (member of Secure Hash Algorithm-2 family) is a cryptographic hash function designed by the National Security Agency (NSA) and published by the NIST as a U. S. government standard. It is also used to verify file integrity." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000561 ! data file checksum type
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003152
@@ -20817,9 +20798,9 @@ name: raw ion mobility drift time array
 def: "Array of raw ion mobility values from a drift time device, reported in seconds (or milliseconds), corresponding to a spectrum of individual peaks encoded with an m/z array." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002893 ! ion mobility array
-relationship: has_units: UO:0000028 ! millisecond
-relationship: has_units: UO:0000010 ! second
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units UO:0000028 ! millisecond
+relationship: has_units UO:0000010 ! second
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003154
@@ -20827,9 +20808,9 @@ name: deconvoluted ion mobility array
 def: "Array of ion mobility values (K or K0) based on ion separation in gaseous phase due to different ion mobilities under an electric field based on ion size, m/z and shape, as an average property of an analyte post peak-detection, weighted charge state reduction, and/or adduct aggregation, corresponding to a spectrum of individual peaks encoded with an m/z array." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002893 ! ion mobility array
-relationship: has_units: UO:0000028 ! millisecond
-relationship: has_units: UO:0000010 ! second
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units UO:0000028 ! millisecond
+relationship: has_units UO:0000010 ! second
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003155
@@ -20837,8 +20818,8 @@ name: deconvoluted inverse reduced ion mobility array
 def: "Array of ion mobility values based on ion separation in gaseous phase due to different ion mobilities under an electric field based on ion size, m/z and shape, normalized for the local conditions and reported in volt-second per square centimeter, as an average property of an analyte post peak-detection, weighted charge state reduction, and/or adduct aggregation, corresponding to a spectrum of individual peaks encoded with an m/z array." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002893 ! ion mobility array
-relationship: has_units: MS:1002814 ! volt-second per square centimeter
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units MS:1002814 ! volt-second per square centimeter
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003156
@@ -20846,9 +20827,9 @@ name: deconvoluted ion mobility drift time array
 def: "Array of mean ion mobility values from a drift time device, reported in seconds (or milliseconds), as an average property of an analyte post peak-detection, weighted charge state reduction, and/or adduct aggregation, corresponding to a spectrum of individual peaks encoded with an m/z array." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002893 ! ion mobility array
-relationship: has_units: UO:0000028 ! millisecond
-relationship: has_units: UO:0000010 ! second
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units UO:0000028 ! millisecond
+relationship: has_units UO:0000010 ! second
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003157
@@ -20856,8 +20837,8 @@ name: scanning quadrupole position lower bound m/z array
 def: "Array of m/z values representing the lower bound m/z of the quadrupole position at each point in the spectrum." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000513 ! binary data array
-relationship: has_units: MS:1000040 ! m/z
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units MS:1000040 ! m/z
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003158
@@ -20865,8 +20846,8 @@ name: scanning quadrupole position upper bound m/z array
 def: "Array of m/z values representing the upper bound m/z of the quadrupole position at each point in the spectrum." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000513 ! binary data array
-relationship: has_units: MS:1000040 ! m/z
-relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
+relationship: has_units MS:1000040 ! m/z
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003159
@@ -20897,7 +20878,7 @@ relationship: has_value_type MS:1002711 ! list of strings
 id: PEFF:0000001
 name: PEFF CV term
 def: "PSI Extended FASTA Format controlled vocabulary term." [PSI:PEFF]
-relationship: part_of: MS:0000000 ! Proteomics Standards Initiative Mass Spectrometry Vocabularies
+relationship: part_of MS:0000000 ! Proteomics Standards Initiative Mass Spectrometry Vocabularies
 
 [Term]
 id: PEFF:0000002
@@ -20917,7 +20898,7 @@ name: DbName
 def: "PEFF keyword for the sequence database name." [PSI:PEFF]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: PEFF:0000002 ! PEFF file header section term
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0000009
@@ -20925,7 +20906,7 @@ name: Prefix
 def: "PEFF keyword for the sequence database prefix." [PSI:PEFF]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: PEFF:0000002 ! PEFF file header section term
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0000010
@@ -20933,7 +20914,7 @@ name: DbDescription
 def: "PEFF keyword for the sequence database short description." [PSI:PEFF]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: PEFF:0000002 ! PEFF file header section term
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0000011
@@ -20941,7 +20922,7 @@ name: Decoy
 def: "PEFF keyword for the specifying whether the sequence database is a decoy database." [PSI:PEFF]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: PEFF:0000002 ! PEFF file header section term
-relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0000012
@@ -20949,7 +20930,7 @@ name: DbSource
 def: "PEFF keyword for the source of the database file." [PSI:PEFF]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: PEFF:0000002 ! PEFF file header section term
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0000013
@@ -20957,7 +20938,7 @@ name: DbVersion
 def: "PEFF keyword for the database version (release date) according to database provider." [PSI:PEFF]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: PEFF:0000002 ! PEFF file header section term
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0000014
@@ -20971,7 +20952,7 @@ name: NumberOfEntries
 def: "PEFF keyword for the sumber of sequence entries in the database." [PSI:PEFF]
 xref: value-type:xsd\:integer "The allowed value-type for this CV term."
 is_a: PEFF:0000002 ! PEFF file header section term
-relationship: has_value_type: xsd\:integer ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0000016
@@ -20979,7 +20960,7 @@ name: Conversion
 def: "PEFF keyword for the description of the conversion from original format to this current one." [PSI:PEFF]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: PEFF:0000002 ! PEFF file header section term
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0000017
@@ -20987,8 +20968,8 @@ name: SequenceType
 def: "PEFF keyword for the molecular type of the sequences." [PSI:PEFF]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: PEFF:0000002 ! PEFF file header section term
-relationship: has_regexp: PEFF:1002002 ! regular expression for PEFF molecular sequence type
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_regexp PEFF:1002002 ! regular expression for PEFF molecular sequence type
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0000018
@@ -20996,7 +20977,7 @@ name: SpecificKey
 def: "PEFF keyword for database specific keywords not included in the current controlled vocabulary." [PSI:PEFF]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: PEFF:0000002 ! PEFF file header section term
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0000019
@@ -21004,7 +20985,7 @@ name: SpecificValue
 def: "PEFF keyword for the specific values for a custom key." [PSI:PEFF]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: PEFF:0000002 ! PEFF file header section term
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0000020
@@ -21012,7 +20993,7 @@ name: DatabaseDescription
 def: "PEFF keyword for the short description of the PEFF file." [PSI:PEFF]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: PEFF:0000002 ! PEFF file header section term
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0000021
@@ -21020,7 +21001,7 @@ name: GeneralComment
 def: "PEFF keyword for a general comment." [PSI:PEFF]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: PEFF:0000002 ! PEFF file header section term
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0000022
@@ -21028,7 +21009,7 @@ name: ProteoformDb
 def: "PEFF keyword that when set to 'true' indicates that the database contains complete proteoforms." [PSI:PEFF]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: PEFF:0000002 ! PEFF file header section term
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0000023
@@ -21036,7 +21017,7 @@ name: OptionalTagDef
 def: "PEFF keyword for the short tag (abbreviation) and longer definition used to annotate a sequence annotation (such as variant or modification) in the OptionalTag location." [PSI:PEFF]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: PEFF:0000002 ! PEFF file header section term
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0000024
@@ -21044,7 +21025,7 @@ name: HasAnnotationIdentifiers
 def: "PEFF keyword that when set to 'true' indicates that entries in the database have identifiers for each annotation." [PSI:PEFF]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: PEFF:0000002 ! PEFF file header section term
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0001001
@@ -21052,7 +21033,7 @@ name: DbUniqueId
 def: "OBSOLETE Sequence database unique identifier." [PSI:PEFF]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0001002
@@ -21060,7 +21041,7 @@ name: PName
 def: "PEFF keyword for the protein full name." [PSI:PEFF]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0001003
@@ -21068,7 +21049,7 @@ name: NcbiTaxId
 def: "PEFF keyword for the NCBI taxonomy identifier." [PSI:PEFF]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0001004
@@ -21076,7 +21057,7 @@ name: TaxName
 def: "PEFF keyword for the taxonomy name (latin or common name)." [PSI:PEFF]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0001005
@@ -21084,7 +21065,7 @@ name: GName
 def: "PEFF keyword for the gene name." [PSI:PEFF]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0001006
@@ -21092,7 +21073,7 @@ name: Length
 def: "PEFF keyword for the sequence length." [PSI:PEFF]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0001007
@@ -21100,7 +21081,7 @@ name: SV
 def: "PEFF keyword for the sequence version." [PSI:PEFF]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0001008
@@ -21108,7 +21089,7 @@ name: EV
 def: "PEFF keyword for the entry version." [PSI:PEFF]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0001009
@@ -21116,7 +21097,7 @@ name: PE
 def: "PEFF keyword for the Protein Evidence; A UniProtKB code 1-5." [PSI:PEFF]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0001010
@@ -21124,8 +21105,8 @@ name: Processed
 def: "PEFF keyword for information on how the full length original protein sequence can be processed into shorter components such as signal peptides and chains." [PSI:PEFF]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-relationship: has_regexp: PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_regexp PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0001011
@@ -21133,8 +21114,8 @@ name: Variant
 def: "OBSOLETE Sequence variation (substitution, insertion, deletion)." [PSI:PEFF]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-relationship: has_regexp: PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_regexp PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0001012
@@ -21142,8 +21123,8 @@ name: ModResPsi
 def: "PEFF keyword for the modified residue with PSI-MOD identifier." [PSI:PEFF]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-relationship: has_regexp: PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_regexp PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0001013
@@ -21151,8 +21132,8 @@ name: ModRes
 def: "PEFF keyword for the modified residue without aPSI-MOD or UniMod identifier." [PSI:PEFF]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-relationship: has_regexp: PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_regexp PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0001014
@@ -21160,7 +21141,7 @@ name: AltAC
 def: "PEFF keyword for the Alternative Accession Code." [PSI:PEFF]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0001015
@@ -21168,8 +21149,8 @@ name: SeqStatus
 def: "PEFF keyword for the sequence status. Complete or Fragment." [PSI:PEFF]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-relationship: has_regexp: PEFF:1002003 ! regular expression for PEFF sequence status
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_regexp PEFF:1002003 ! regular expression for PEFF sequence status
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0001016
@@ -21177,7 +21158,7 @@ name: CC
 def: "PEFF keyword for the entry associated comment." [PSI:PEFF]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0001017
@@ -21185,7 +21166,7 @@ name: KW
 def: "PEFF keyword for the entry associated keyword(s)." [PSI:PEFF]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0001018
@@ -21193,7 +21174,7 @@ name: GO
 def: "PEFF keyword for the Gene Ontology code." [PSI:PEFF]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0001019
@@ -21201,7 +21182,7 @@ name: XRef
 def: "PEFF keyword for the cross-reference to an external resource." [PSI:PEFF]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0001020
@@ -21209,8 +21190,8 @@ name: mature protein
 def: "Portion of a newly synthesized protein that contributes to a final structure after other components such as signal peptides are removed." [PSI:PEFF]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: PEFF:0001032 ! PEFF molecule processing keyword
-relationship: has_regexp: PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_regexp PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0001021
@@ -21218,8 +21199,8 @@ name: signal peptide
 def: "Short peptide present at the N-terminus of a newly synthesized protein that is cleaved off and is not part of the final mature protein." [PSI:PEFF]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: PEFF:0001032 ! PEFF molecule processing keyword
-relationship: has_regexp: PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_regexp PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0001022
@@ -21227,8 +21208,8 @@ name: transit peptide
 def: "Short peptide present at the N-terminus of a newly synthesized protein that helps the protein through the membrane of its destination organelle." [PSI:PEFF]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: PEFF:0001032 ! PEFF molecule processing keyword
-relationship: has_regexp: PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_regexp PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0001023
@@ -21236,8 +21217,8 @@ name: Conflict
 def: "PEFF keyword for the sequence conflict; a UniProtKB term." [PSI:PEFF]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-relationship: has_regexp: PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_regexp PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0001024
@@ -21245,7 +21226,7 @@ name: Crc64
 def: "PEFF keyword for the Sequence checksum in crc64." [PSI:PEFF]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0001025
@@ -21253,7 +21234,7 @@ name: Domain
 def: "PEFF keyword for the sequence range of a domain." [PSI:PEFF]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0001026
@@ -21261,7 +21242,7 @@ name: ID
 def: "PEFF keyword for the UniProtKB specific Protein identifier ID; a UniProtKB term." [PSI:PEFF]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0001027
@@ -21269,8 +21250,8 @@ name: ModResUnimod
 def: "PEFF keyword for the modified residue with UniMod identifier." [PSI:PEFF]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-relationship: has_regexp: PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_regexp PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0001028
@@ -21278,8 +21259,8 @@ name: VariantSimple
 def: "PEFF keyword for the simple sequence variation of a single amino acid change. A change to a stop codon is permitted with a * symbol. More complex variations must be encoded with the VariantComplex term." [PSI:PEFF]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-relationship: has_regexp: PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_regexp PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0001029
@@ -21287,8 +21268,8 @@ name: VariantComplex
 def: "PEFF keyword for a sequence variation that is more complex than a single amino acid change or change to a stop codon." [PSI:PEFF]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-relationship: has_regexp: PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_regexp PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0001030
@@ -21296,7 +21277,7 @@ name: Proteoform
 def: "PEFF keyword for the proteoforms of this protein, constructed as a set of annotation identifiers." [PSI:PEFF]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0001031
@@ -21304,7 +21285,7 @@ name: DisulfideBond
 def: "PEFF keyword for the disulfide bonds in this protein, constructed as a sets of annotation identifiers of two half-cystine modifications." [PSI:PEFF]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0001032
@@ -21318,7 +21299,7 @@ name: Comment
 def: "PEFF keyword for the individual protein entry comment. It is discouraged to put parsable information here. This is only for free-text commentary." [PSI:PEFF]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0001034
@@ -21326,8 +21307,8 @@ name: propeptide
 def: "Short peptide that is cleaved off a newly synthesized protein and generally immediately degraded in the process of protein maturation, and is not a signal peptide or transit peptide." [PSI:PEFF]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: PEFF:0001032 ! PEFF molecule processing keyword
-relationship: has_regexp: PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_regexp PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0001035
@@ -21335,8 +21316,8 @@ name: initiator methionine
 def: "N-terminal methionine residue of a protein that can be co-translationally cleaved." [PSI:PEFF]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: PEFF:0001032 ! PEFF molecule processing keyword
-relationship: has_regexp: PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
-relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
+relationship: has_regexp PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:1002001

--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -21650,6 +21650,13 @@ is_a: MS:1001459 ! file format
 
 [Term]
 id: MS:1003162
+name: PTX-QC
+def: "Proteomics (PTX) - QualityControl (QC) software for QC report generation and visualization." [DOI:10.1021/acs.jproteome.5b00780, PMID:26653327, https://github.com/cbielow/PTXQC/]
+is_a: MS:1001456 ! analysis software
+synonym: "PTXQC" EXACT []
+
+[Term]
+id: MS:1003163
 name: analyte mixture members
 def: "The set of analyte identifiers that compose an interpretation of a spectrum." [PSI:PI]
 is_a: MS:1003078 ! interpreted spectrum attribute

--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -29,6 +29,20 @@ remark: To view a copy of this license, visit https://creativecommons.org/licens
 ontology: ms
 
 [Typedef]
+id: has_domain
+name: has_domain
+
+[Typedef]
+id: has_element_type
+name: has element type
+def: "'Entity A' is a collection of elements of value type element 'Entity B'." []
+is_transitive: true
+
+[Typedef]
+id: has_order
+name: has_order
+
+[Typedef]
 id: has_regexp
 name: has regexp
 
@@ -37,17 +51,15 @@ id: has_units
 name: has_units
 
 [Typedef]
-id: part_of
-name: part_of
+id: has_value_type
+name: has value type
+def: "'Entity A' has value type 'Entity B', such as xsd:float." []
 is_transitive: true
 
 [Typedef]
-id: has_order
-name: has_order
-
-[Typedef]
-id: has_domain
-name: has_domain
+id: part_of
+name: part_of
+is_transitive: true
 
 [Term]
 id: MS:0000000
@@ -60,6 +72,7 @@ name: sample number
 def: "A reference number relevant to the sample under study." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000548 ! sample attribute
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000002
@@ -67,6 +80,7 @@ name: sample name
 def: "A reference string relevant to the sample under study." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000548 ! sample attribute
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000003
@@ -80,7 +94,8 @@ name: sample mass
 def: "Total mass of sample used." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000548 ! sample attribute
-relationship: has_units UO:0000021 ! gram
+relationship: has_units: UO:0000021 ! gram
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000005
@@ -88,7 +103,8 @@ name: sample volume
 def: "Total volume of solution used." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000548 ! sample attribute
-relationship: has_units UO:0000098 ! milliliter
+relationship: has_units: UO:0000098 ! milliliter
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000006
@@ -96,33 +112,30 @@ name: sample concentration
 def: "Concentration of sample in picomol/ul, femtomol/ul or attomol/ul solution used." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000548 ! sample attribute
-relationship: has_units UO:0000175 ! gram per liter
+relationship: has_units: UO:0000175 ! gram per liter
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000007
 name: inlet type
 def: "The nature of the sample inlet." [PSI:MS]
-relationship: part_of MS:1000458 ! source
+relationship: part_of: MS:1000458 ! source
 
 [Term]
 id: MS:1000008
 name: ionization type
 def: "The method by which gas phase ions are generated from the sample." [PSI:MS]
-relationship: part_of MS:1000458 ! source
+relationship: part_of: MS:1000458 ! source
 
 [Term]
 id: MS:1000009
 name: ionization mode
 def: "OBSOLETE Whether positive or negative ions are selected for analysis by the spectrometer." [PSI:MS]
-comment: This term was made obsolete because it was replaced by scan polarity (MS:1000465).
-is_obsolete: true
 
 [Term]
 id: MS:1000010
 name: analyzer type
 def: "OBSOLETE The common name of the particular analyzer stage being described. Synonym of mass analyzer, should be obsoleted." [PSI:MS]
-comment: This former purgatory term was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000011
@@ -130,6 +143,7 @@ name: mass resolution
 def: "Smallest mass difference between two equal magnitude peaks so that the valley between them is a specified fraction of the peak height." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000503 ! scan attribute
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000012
@@ -141,8 +155,6 @@ is_a: MS:1000596 ! measurement method
 id: MS:1000013
 name: resolution type
 def: "OBSOLETE Specify the nature of resolution for the mass analyzer. Resolution is usually either constant with respect to m/z or proportional to m/z." [PSI:MS]
-comment: This former purgatory term was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000014
@@ -150,8 +162,9 @@ name: accuracy
 def: "Accuracy is the degree of conformity of a measured mass to its actual value." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000480 ! mass analyzer attribute
-relationship: has_units MS:1000040 ! m/z
-relationship: has_units UO:0000169 ! parts per million
+relationship: has_units: MS:1000040 ! m/z
+relationship: has_units: UO:0000169 ! parts per million
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000015
@@ -159,7 +172,8 @@ name: scan rate
 def: "Rate in Th/sec for scanning analyzers." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000503 ! scan attribute
-relationship: has_units MS:1000807 ! Th/s
+relationship: has_units: MS:1000807 ! Th/s
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000016
@@ -168,35 +182,31 @@ def: "The time that an analyzer started a scan, relative to the start of the MS 
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000503 ! scan attribute
 is_a: MS:1002345 ! PSM-level attribute
-relationship: has_units UO:0000010 ! second
-relationship: has_units UO:0000031 ! minute
+relationship: has_units: UO:0000010 ! second
+relationship: has_units: UO:0000031 ! minute
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000017
 name: Scan Function
 def: "OBSOLETE Describes the type of mass analysis being performed. Two primary modes are: typical acquisition over a range of masses (Mass Scan), and Selected Ion Detection. The primary difference is that Selected Ion Detection produces a single value for the signal at the selected mass rather than producing a mass spectrum." [PSI:MS]
-comment: OBSOLETE This former purgatory term was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000018
 name: scan direction
 def: "Direction in terms of m/z of the scan for scanning analyzers (low to high, or high to low)." [PSI:MS]
-relationship: part_of MS:1000441 ! scan
+relationship: part_of: MS:1000441 ! scan
 
 [Term]
 id: MS:1000019
 name: scan law
 def: "Describes the function in control of the m/z scan (for scanning instruments). Commonly the scan function is linear, but in principle any function can be used." [PSI:MS]
-relationship: part_of MS:1000441 ! scan
+relationship: part_of: MS:1000441 ! scan
 
 [Term]
 id: MS:1000020
 name: scanning method
 def: "Describes the acquisition data type produced by a tandem mass spectrometry experiment." [PSI:MS]
-comment: OBSOLETE This former purgatory term was made obsolete.
-synonym: "Tandem Scanning Method" RELATED []
-is_obsolete: true
 
 [Term]
 id: MS:1000021
@@ -210,16 +220,16 @@ name: TOF Total Path Length
 def: "The length of the field free drift space in a time of flight mass spectrometer." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000480 ! mass analyzer attribute
-relationship: has_units UO:0000008 ! meter
+relationship: has_units: UO:0000008 ! meter
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000023
 name: isolation width
 def: "OBSOLETE The total width (i.e. not half for plus-or-minus) of the gate applied around a selected precursor ion." [PSI:MS]
-comment: This former purgatory term was made obsolete.
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
-relationship: has_units MS:1000040 ! m/z
-is_obsolete: true
+relationship: has_units: MS:1000040 ! m/z
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000024
@@ -227,28 +237,28 @@ name: final MS exponent
 def: "Final MS level achieved when performing PFF with the ion trap (e.g. MS E10)." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1000480 ! mass analyzer attribute
+relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000025
 name: magnetic field strength
 def: "A property of space that produces a force on a charged particle equal to qv x B where q is the particle charge and v its velocity." [PSI:MS]
-synonym: "B" EXACT []
-synonym: "Magnetic Field" RELATED []
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000480 ! mass analyzer attribute
-relationship: has_units UO:0000228 ! tesla
+relationship: has_units: UO:0000228 ! tesla
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000026
 name: detector type
 def: "Type of detector used in the mass spectrometer." [PSI:MS]
-relationship: part_of MS:1000453 ! detector
+relationship: part_of: MS:1000453 ! detector
 
 [Term]
 id: MS:1000027
 name: detector acquisition mode
 def: "Method by which detector signal is acquired by the data system." [PSI:MS]
-relationship: part_of MS:1000453 ! detector
+relationship: part_of: MS:1000453 ! detector
 
 [Term]
 id: MS:1000028
@@ -256,28 +266,27 @@ name: detector resolution
 def: "The resolving power of the detector to detect the smallest difference between two ions so that the valley between them is a specified fraction of the peak height." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000481 ! detector attribute
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000029
 name: sampling frequency
 def: "The rate of signal sampling (measurement) with respect to time." [PSI:MS]
-synonym: "ADC Sampling Frequency" NARROW []
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000481 ! detector attribute
-relationship: has_units UO:0000106 ! hertz
+relationship: has_units: UO:0000106 ! hertz
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000030
 name: vendor
 def: "OBSOLETE Name of instrument vendor." [PSI:MS]
-comment: This term was made obsolete because it was replaced by instrument model (MS:1000031).
-is_obsolete: true
 
 [Term]
 id: MS:1000031
 name: instrument model
 def: "Instrument model name not including the vendor's name." [PSI:MS]
-relationship: part_of MS:1000463 ! instrument
+relationship: part_of: MS:1000463 ! instrument
 
 [Term]
 id: MS:1000032
@@ -285,6 +294,7 @@ name: customization
 def: "Free text description of a single customization made to the instrument; for several modifications, use several entries." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000496 ! instrument attribute
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000033
@@ -308,47 +318,36 @@ is_a: MS:1000543 ! data processing action
 id: MS:1000036
 name: scan mode
 def: "OBSOLETE." [PSI:MS]
-comment: This term was made obsolete because .
-is_obsolete: true
 
 [Term]
 id: MS:1000037
 name: polarity
 def: "OBSOLETE Terms to describe the polarity setting of the instrument." [PSI:MS]
-comment: This term was made obsolete because it was redundant with the Pato Ontology term polarity (UO:0002186).
-is_obsolete: true
 
 [Term]
 id: MS:1000038
 name: minute
 def: "OBSOLETE Acquisition time in minutes." [PSI:MS]
-comment: This term was made obsolete because it was redundant with Unit Ontology minute (UO:0000031).
-is_obsolete: true
 
 [Term]
 id: MS:1000039
 name: second
 def: "OBSOLETE Acquisition time in seconds." [PSI:MS]
-comment: This term was made obsolete because it was redundant with Unit Ontology second (UO:0000010).
-is_obsolete: true
 
 [Term]
 id: MS:1000040
 name: m/z
 def: "Three-character symbol m/z is used to denote the quantity formed by dividing the mass of an ion in unified atomic mass units by its charge number (regardless of sign). The symbol is written in italicized lower case letters with no spaces. Note 1: The term mass-to-charge-ratio is deprecated. Mass-to-charge ratio has been used for the abscissa of a mass spectrum, although the quantity measured is not the quotient of the ion's mass to its electric charge. The three-character symbol m/z is recommended for the quantity that is the independent variable in a mass spectrum Note 2: The proposed unit thomson (Th) is deprecated." [PSI:MS]
-synonym: "mass-to-charge ratio" EXACT []
-synonym: "Th" EXACT []
-synonym: "thomson" EXACT []
 is_a: UO:0000000 ! unit
 
 [Term]
 id: MS:1000041
 name: charge state
 def: "Number of net charges, positive or negative, on an ion." [PSI:MS]
-synonym: "z" EXACT []
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1000455 ! ion selection attribute
 is_a: MS:1000507 ! ion property
+relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000042
@@ -356,12 +355,13 @@ name: peak intensity
 def: "Intensity of ions as measured by the height or area of a peak in a mass spectrum." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000455 ! ion selection attribute
-relationship: has_units MS:1000131 ! number of detector counts
-relationship: has_units MS:1000132 ! percent of base peak
-relationship: has_units MS:1000814 ! counts per second
-relationship: has_units MS:1000905 ! percent of base peak times 100
-relationship: has_units UO:0000269 ! absorbance unit
-relationship: part_of MS:1000231 ! peak
+relationship: has_units: MS:1000131 ! number of detector counts
+relationship: has_units: MS:1000132 ! percent of base peak
+relationship: has_units: MS:1000814 ! counts per second
+relationship: has_units: MS:1000905 ! percent of base peak times 100
+relationship: has_units: UO:0000269 ! absorbance unit
+relationship: part_of: MS:1000231 ! peak
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000043
@@ -373,8 +373,7 @@ is_a: UO:0000000 ! unit
 id: MS:1000044
 name: dissociation method
 def: "Fragmentation method used for dissociation or fragmentation." [PSI:MS]
-synonym: "Activation Method" RELATED []
-relationship: part_of MS:1000456 ! precursor activation
+relationship: part_of: MS:1000456 ! precursor activation
 
 [Term]
 id: MS:1000045
@@ -382,15 +381,14 @@ name: collision energy
 def: "Energy for an ion experiencing collision with a stationary gas particle resulting in dissociation of the ion." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000510 ! precursor activation attribute
-relationship: has_units UO:0000266 ! electronvolt
+relationship: has_units: UO:0000266 ! electronvolt
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000046
 name: energy unit
 def: "OBSOLETE Energy units are represented in either eV or Joules." [PSI:MS]
-comment: This term was made obsolete because it was redundant with the Unit Ontology term energy unit (UO:0000111).
 is_a: UO:0000000 ! unit
-is_obsolete: true
 
 [Term]
 id: MS:1000047
@@ -434,19 +432,17 @@ name: sample batch
 def: "Sample batch lot identifier." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000548 ! sample attribute
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000054
 name: chromatography
 def: "OBSOLETE Chromatographic conditions used to obtain the sample." [PSI:MS]
-comment: This former purgatory term was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000055
 name: continuous flow fast atom bombardment
 def: "Fast atom bombardment ionization in which the analyte in solution is entrained in a flowing liquid matrix." [PSI:MS]
-synonym: "CF-FAB" EXACT []
 is_a: MS:1000007 ! inlet type
 
 [Term]
@@ -537,58 +533,46 @@ is_a: MS:1000007 ! inlet type
 id: MS:1000070
 name: atmospheric pressure chemical ionization
 def: "Chemical ionization that takes place at atmospheric pressure as opposed to the reduced pressure is normally used for chemical ionization." [PSI:MS]
-synonym: "APCI" EXACT []
 is_a: MS:1000240 ! atmospheric pressure ionization
 
 [Term]
 id: MS:1000071
 name: chemical ionization
 def: "The formation of a new ion by the reaction of a neutral species with an ion. The process may involve transfer of an electron, a proton or other charged species between the reactants. When a positive ion results from chemical ionization the term may be used without qualification. When a negative ion results the term negative ion chemical ionization should be used. Note that this term is not synonymous with chemi-ionization." [PSI:MS]
-synonym: "CI" EXACT []
 is_a: MS:1000008 ! ionization type
 
 [Term]
 id: MS:1000072
 name: Electronic Ionization
 def: "OBSOLETE The ionization of an atom or molecule by electrons that are typically accelerated to energies between 50 and 150 eV. Usually 70 eV electrons are used to produce positive ions. The term 'electron impact' is not recommended." [PSI:MS]
-comment: This term was made obsolete because it was replaced by electron ionization (MS:1000389).
-synonym: "EI" EXACT []
-is_obsolete: true
 
 [Term]
 id: MS:1000073
 name: electrospray ionization
 def: "A process in which ionized species in the gas phase are produced from an analyte-containing solution via highly charged fine droplets, by means of spraying the solution from a narrow-bore needle tip at atmospheric pressure in the presence of a high electric field. When a pressurized gas is used to aid in the formation of a stable spray, the term pneumatically assisted electrospray ionization is used. The term ion spray is not recommended." [PSI:MS]
-synonym: "ESI" EXACT []
 is_a: MS:1000008 ! ionization type
 
 [Term]
 id: MS:1000074
 name: fast atom bombardment ionization
 def: "The ionization of any species by the interaction of a focused beam of neutral atoms having a translational energy of several thousand eV with a sample that is typically dissolved in a solvent matrix. See also secondary ionization." [PSI:MS]
-synonym: "FAB" EXACT []
 is_a: MS:1000008 ! ionization type
 
 [Term]
 id: MS:1000075
 name: matrix-assisted laser desorption ionization
 def: "The formation of gas-phase ions from molecules that are present in a solid or solvent matrix that is irradiated with a pulsed laser. See also laser desorption/ionization." [PSI:MS]
-synonym: "MALDI" EXACT []
 is_a: MS:1000247 ! desorption ionization
 
 [Term]
 id: MS:1000076
 name: negative ion mode
 def: "OBSOLETE." [PSI:MS]
-comment: This term was made obsolete because it was replaced by negative scan (MS:1000129).
-is_obsolete: true
 
 [Term]
 id: MS:1000077
 name: positive ion mode
 def: "OBSOLETE." [PSI:MS]
-comment: This term was made obsolete because it was replaced by positive scan (MS:1000130).
-is_obsolete: true
 
 [Term]
 id: MS:1000078
@@ -600,7 +584,6 @@ is_a: MS:1000291 ! linear ion trap
 id: MS:1000079
 name: fourier transform ion cyclotron resonance mass spectrometer
 def: "A mass spectrometer based on the principle of ion cyclotron resonance in which an ion in a magnetic field moves in a circular orbit at a frequency characteristic of its m/z value. Ions are coherently excited to a larger radius orbit using a pulse of radio frequency energy and their image charge is detected on receiver plates as a time domain signal. Fourier transformation of the time domain signal results in a frequency domain signal which is converted to a mass spectrum based in the inverse relationship between frequency and m/z." [PSI:MS]
-synonym: "FT_ICR" EXACT []
 is_a: MS:1000443 ! mass analyzer type
 
 [Term]
@@ -619,9 +602,6 @@ is_a: MS:1000443 ! mass analyzer type
 id: MS:1000082
 name: quadrupole ion trap
 def: "Quadrupole Ion Trap mass analyzer captures the ions in a three dimensional ion trap and then selectively ejects them by varying the RF and DC potentials." [PSI:MS]
-synonym: "Paul Ion trap" EXACT []
-synonym: "QIT" EXACT []
-synonym: "Quistor" EXACT []
 is_a: MS:1000264 ! ion trap
 
 [Term]
@@ -634,7 +614,6 @@ is_a: MS:1000291 ! linear ion trap
 id: MS:1000084
 name: time-of-flight
 def: "Instrument that separates ions by m/z in a field-free region after acceleration to a fixed acceleration energy." [PSI:MS]
-synonym: "TOF" EXACT []
 is_a: MS:1000443 ! mass analyzer type
 
 [Term]
@@ -647,7 +626,6 @@ is_a: MS:1000012 ! resolution measurement method
 id: MS:1000086
 name: full width at half-maximum
 def: "A measure of resolution represented as width of the peak at half peak height." [PSI:MS]
-synonym: "FWHM" EXACT []
 is_a: MS:1000012 ! resolution measurement method
 
 [Term]
@@ -660,29 +638,21 @@ is_a: MS:1000012 ! resolution measurement method
 id: MS:1000088
 name: constant
 def: "OBSOLETE When resolution is constant with respect to m/z." [PSI:MS]
-comment: This child of the former purgatory term resolution type was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000089
 name: proportional
 def: "OBSOLETE When resolution is proportional with respect to m/z." [PSI:MS]
-comment: This child of the former purgatory term resolution type was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000090
 name: mass scan
 def: "OBSOLETE A variation of instrument where a selected mass is scanned." [PSI:MS]
-comment: This child of the former purgatory term Scan Function was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000091
 name: selected ion detection
 def: "OBSOLETE Please see Single Ion Monitoring." [PSI:MS]
-comment: This child of the former purgatory term Scan Function was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000092
@@ -706,9 +676,7 @@ is_a: MS:1000019 ! scan law
 id: MS:1000095
 name: linear
 def: "OBSOLETE The mass scan is done in linear mode." [PSI:MS]
-comment: This term was made obsolete because it was redundant with the Pato Ontology term linear (UO:0001199).
 is_a: MS:1000019 ! scan law
-is_obsolete: true
 
 [Term]
 id: MS:1000096
@@ -720,58 +688,41 @@ is_a: MS:1000019 ! scan law
 id: MS:1000097
 name: constant neutral mass loss
 def: "OBSOLETE A spectrum formed of all product ions that have been produced with a selected m/z decrement from any precursor ions. The spectrum shown correlates to the precursor ion spectrum. See also neutral loss spectrum." [PSI:MS]
-comment: This former purgatory term was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000098
 name: multiple ion monitoring
 def: "OBSOLETE Data acquired when monitoring the ion current of a few specific m/z values. Remap to MS:1000205 -Selected Ion Monitoring." [PSI:MS]
-comment: This former purgatory term was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000099
 name: multiple reaction monitoring
 def: "OBSOLETE This term is not recommended. See Selected Reaction Monitoring." [PSI:MS]
-comment: This term was made obsolete because it was merged with selected reaction monitoring (MS:1000206).
-synonym: "MRM" EXACT []
-is_obsolete: true
 
 [Term]
 id: MS:1000100
 name: precursor ion scan
 def: "OBSOLETE The specific scan function or process that will record a precursor ion spectrum." [PSI:MS]
-comment: This former purgatory term was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000101
 name: product ion scan
 def: "OBSOLETE The specific scan function or process that records product ion spectrum." [PSI:MS]
-comment: This former purgatory term was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000102
 name: single ion monitoring
 def: "OBSOLETE The operation of a mass spectrometer to monitor a single ion rather than scanning entire mass spectrum." [PSI:MS]
-comment: This term was made obsolete because it was replaced by single ion monitoring (MS:100205).
-is_obsolete: true
 
 [Term]
 id: MS:1000103
 name: single reaction monitoring
 def: "OBSOLETE This term is not recommended. See Selected Reaction Monitoring." [PSI:MS]
-comment: This term was made obsolete because it was replaced by selected reaction monitoring (MS:1000206).
-is_obsolete: true
 
 [Term]
 id: MS:1000104
 name: None ??
 def: "OBSOLETE None." [PSI:MS]
-comment: This term was made obsolete because .
-is_obsolete: true
 
 [Term]
 id: MS:1000105
@@ -789,7 +740,6 @@ is_a: MS:1000021 ! reflectron state
 id: MS:1000107
 name: channeltron
 def: "A horn-shaped (or cone-shaped) continuous dynode particle multiplier. The ion strikes the inner surface of the device and induces the production of secondary electrons that in turn impinge on the inner surfaces to produce more secondary electrons. This avalanche effect produces an increase in signal in the final measured current pulse." [PSI:MS]
-synonym: "Channeltron Detector" EXACT []
 is_a: MS:1000026 ! detector type
 
 [Term]
@@ -802,21 +752,18 @@ is_a: MS:1000346 ! conversion dynode
 id: MS:1000109
 name: conversion dynode photomultiplier
 def: "A detector in which ions strike a conversion dynode to produce electrons that in turn generate photons through a phosphorescent screen that are detected by a photomultiplier." [PSI:MS]
-synonym: "ion-to-photon detector" RELATED []
 is_a: MS:1000346 ! conversion dynode
 
 [Term]
 id: MS:1000110
 name: daly detector
 def: "Detector consisting of a conversion dynode, scintillator and photomultiplier. The metal knob at high potential emits secondary electrons when ions impinge on the surface. The secondary electrons are accelerated onto the scintillator that produces light that is then detected by the photomultiplier detector." [PSI:MS]
-synonym: "Daly" EXACT []
 is_a: MS:1000026 ! detector type
 
 [Term]
 id: MS:1000111
 name: electron multiplier tube
 def: "A device to amplify the current of a beam or packet of charged particles or photons by incidence upon the surface of an electrode to produce secondary electrons." [PSI:MS]
-synonym: "EMT" EXACT []
 is_a: MS:1000253 ! electron multiplier
 
 [Term]
@@ -835,7 +782,6 @@ is_a: MS:1000348 ! focal plane collector
 id: MS:1000114
 name: microchannel plate detector
 def: "A thin plate that contains a closely spaced array of channels that each act as a continuous dynode particle multiplier. A charged particle, fast neutral particle, or photon striking the plate causes a cascade of secondary electrons that ultimately exits the opposite side of the plate." [PSI:MS]
-synonym: "multichannel plate" EXACT []
 is_a: MS:1000345 ! array detector
 
 [Term]
@@ -848,14 +794,12 @@ is_a: MS:1000026 ! detector type
 id: MS:1000116
 name: photomultiplier
 def: "A detector for conversion of the ion/electron signal into photon(s) which are then amplified and detected." [PSI:MS]
-synonym: "PMT" EXACT []
 is_a: MS:1000026 ! detector type
 
 [Term]
 id: MS:1000117
 name: analog-digital converter
 def: "Analog-to-digital converter (abbreviated ADC, A/D or A to D) is an electronic integrated circuit (i/c) that converts continuous signals to discrete digital numbers." [PSI:MS]
-synonym: "ADC" EXACT []
 is_a: MS:1000027 ! detector acquisition mode
 
 [Term]
@@ -868,7 +812,6 @@ is_a: MS:1000027 ! detector acquisition mode
 id: MS:1000119
 name: time-digital converter
 def: "A device for converting a signal of sporadic pluses into a digital representation of their time indices." [PSI:MS]
-synonym: "TDC" EXACT []
 is_a: MS:1000027 ! detector acquisition mode
 
 [Term]
@@ -881,7 +824,6 @@ is_a: MS:1000027 ! detector acquisition mode
 id: MS:1000121
 name: SCIEX instrument model
 def: "The brand of instruments from the joint venture between Applied Biosystems and MDS Analytical Technologies (formerly MDS SCIEX). Previously branded as \"Applied Biosystems|MDS SCIEX\"." [PSI:MS]
-synonym: "Applied Biosystems|MDS SCIEX" RELATED []
 is_a: MS:1000031 ! instrument model
 
 [Term]
@@ -918,15 +860,12 @@ is_a: MS:1000031 ! instrument model
 id: MS:1000127
 name: centroid spectrum
 def: "Processing of profile data to produce spectra that contains discrete peaks of zero width. Often used to reduce the size of dataset." [PSI:MS]
-synonym: "Discrete Mass Spectrum" EXACT []
 is_a: MS:1000525 ! spectrum representation
 
 [Term]
 id: MS:1000128
 name: profile spectrum
 def: "A profile mass spectrum is created when data is recorded with ion current (counts per second) on one axis and mass/charge ratio on another axis." [PSI:MS]
-synonym: "continuous mass spectrum" EXACT []
-synonym: "Continuum Mass Spectrum" EXACT []
 is_a: MS:1000525 ! spectrum representation
 
 [Term]
@@ -955,43 +894,36 @@ name: percent of base peak
 def: "The magnitude of a peak or measurement element expressed in terms of the percentage of the magnitude of the base peak intensity." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000043 ! intensity unit
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000133
 name: collision-induced dissociation
 def: "The dissociation of an ion after collisional excitation. The term collisional-activated dissociation is not recommended." [PSI:MS]
-synonym: "CID" EXACT []
-synonym: "CAD" EXACT []
-synonym: "collisionally activated dissociation" EXACT []
 is_a: MS:1000044 ! dissociation method
 
 [Term]
 id: MS:1000134
 name: plasma desorption
 def: "The ionization of material in a solid sample by bombarding it with ionic or neutral atoms formed as a result of the fission of a suitable nuclide, typically 252Cf. Synonymous with fission fragment ionization." [PSI:MS]
-synonym: "PD" EXACT []
 is_a: MS:1000044 ! dissociation method
 
 [Term]
 id: MS:1000135
 name: post-source decay
 def: "A technique specific to reflectron time-of-flight mass spectrometers where product ions of metastable transitions or collision-induced dissociations generated in the drift tube prior to entering the reflectron are m/z separated to yield product ion spectra." [PSI:MS]
-synonym: "PSD" EXACT []
 is_a: MS:1000044 ! dissociation method
 
 [Term]
 id: MS:1000136
 name: surface-induced dissociation
 def: "Fragmentation that results from the collision of an ion with a surface." [PSI:MS]
-synonym: "SID" EXACT []
 is_a: MS:1000044 ! dissociation method
 
 [Term]
 id: MS:1000137
 name: electron volt
 def: "OBSOLETE A non-SI unit of energy (eV) defined as the energy acquired by a particle containing one unit of charge through a potential difference of one volt. An electron-volt is equal to 1.602 176 53(14) x 10^-19 J." [PSI:MS]
-comment: This term was made obsolete because it was redundant with the Unit Ontology term electron volt (UO:0000266).
-is_obsolete: true
 
 [Term]
 id: MS:1000138
@@ -999,7 +931,8 @@ name: normalized collision energy
 def: "Instrument setting, expressed in percent, for adjusting collisional energies of ions in an effort to provide equivalent excitation of all ions." [PSI:PI]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000510 ! precursor activation attribute
-relationship: has_units UO:0000187 ! percent
+relationship: has_units: UO:0000187 ! percent
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000139
@@ -1101,8 +1034,6 @@ is_a: MS:1000125 ! Thermo Finnigan instrument model
 id: MS:1000155
 name: ELEMENT2
 def: "OBSOLETE ThermoFinnigan ELEMENT2 MS." [PSI:MS]
-comment: This former purgatory term was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000156
@@ -1402,18 +1333,12 @@ is_a: MS:1000495 ! Applied Biosystems instrument model
 id: MS:1000205
 name: selected ion monitoring
 def: "The operation of a mass spectrometer in which the intensities of several specific m/z values are recorded rather than the entire mass spectrum." [PSI:MS]
-synonym: "MIM" RELATED []
-synonym: "Multiple Ion Monitoring" EXACT []
-synonym: "SIM" EXACT []
 is_a: MS:1000596 ! measurement method
 
 [Term]
 id: MS:1000206
 name: selected reaction monitoring
 def: "Data acquired from specific product ions corresponding to m/z selected precursor ions recorded via multiple stages of mass spectrometry. Selected reaction monitoring can be performed in time or in space." [PSI:MS]
-synonym: "MRM" RELATED []
-synonym: "Multiple Reaction Monitoring" RELATED []
-synonym: "SRM" EXACT []
 is_a: MS:1000596 ! measurement method
 
 [Term]
@@ -1421,34 +1346,29 @@ id: MS:1000207
 name: accurate mass
 def: "OBSOLETE An experimentally determined mass that is can be to determine a unique elemental formula. For ions less than 200 u, a measurement with 5 ppm accuracy is sufficient to determine the elemental composition." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
-comment: This child of the former purgatory term ion attribute was made obsolete.
-relationship: has_units UO:0000002 ! mass unit
-is_obsolete: true
+relationship: has_units: UO:0000002 ! mass unit
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000208
 name: average mass
 def: "OBSOLETE The mass of an ion or molecule calculated using the average mass of each element weighted for its natural isotopic abundance." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
-comment: This child of the former purgatory term ion attribute was made obsolete.
-relationship: has_units UO:0000002 ! mass unit
-is_obsolete: true
+relationship: has_units: UO:0000002 ! mass unit
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000209
 name: appearance energy
 def: "OBSOLETE The minimum energy that must be imparted to an atom or molecule to produce a specified ion. The term appearance potential is not recommended." [PSI:MS]
-synonym: "AE" EXACT []
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
-comment: This child of the former purgatory term ion attribute was made obsolete.
-relationship: has_units UO:0000266 ! electronvolt
-is_obsolete: true
+relationship: has_units: UO:0000266 ! electronvolt
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000210
 name: base peak
 def: "The peak in a mass spectrum that has the greatest intensity. This term may be applied to the spectra of pure substances or mixtures." [PSI:MS]
-synonym: "BP" EXACT []
 is_a: MS:1000231 ! peak
 
 [Term]
@@ -1456,79 +1376,63 @@ id: MS:1000211
 name: OBSOLETE charge number
 def: "OBSOLETE The total charge on an ion divided by the electron charge e. OBSOLETED 2009-10-27 since this was viewed as a duplication of 00041 charge state." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
-is_obsolete: true
+relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000212
 name: dalton
 def: "OBSOLETE A non-SI unit of mass (symbol Da) that is equal to the unified atomic mass unit: 1.660 538 86(28) x 10^-27 kg." [PSI:MS]
-comment: This term was made obsolete because it was redundant with the Unit Ontology term dalton (UO:0000221).
-is_obsolete: true
 
 [Term]
 id: MS:1000213
 name: electron affinity
 def: "OBSOLETE The electron affinity of M is the minimum energy required for the process M- ? M + e where M- and M are in their ground rotational, vibrational and electronic states and the electron has zero kinetic energy." [PSI:MS]
-comment: This child of the former purgatory term ion attribute was made obsolete.
-synonym: "EA" EXACT []
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
-is_obsolete: true
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000214
 name: electron energy obsolete
 def: "OBSOLETE The potential difference through which electrons are accelerated before they are used to bring about electron ionization." [PSI:MS]
-comment: This former purgatory term was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000215
 name: exact mass
 def: "OBSOLETE The calculated mass of an ion or molecule containing a single isotope of each atom." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
-comment: This child of the former purgatory term ion attribute was made obsolete.
-relationship: has_units UO:0000002 ! mass unit
-is_obsolete: true
+relationship: has_units: UO:0000002 ! mass unit
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000216
 name: field-free region
 def: "A section of a mass spectrometer in which there are no electric or magnetic fields." [PSI:MS]
-synonym: "FFR" EXACT []
 is_a: MS:1000487 ! ion optics attribute
 
 [Term]
 id: MS:1000217
 name: ionization cross section
 def: "OBSOLETE A measure of the probability that a given ionization process will occur when an atom or molecule interacts with a photon, electron, atom or molecule." [PSI:MS]
-comment: This child of the former purgatory term ion reaction was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000218
 name: ionization efficiency
 def: "OBSOLETE The ratio of the number of ions formed to the number of electrons, molecules or photons used." [PSI:MS]
-comment: This term was made obsolete because it was replaced by ionization efficiency (MS:1000392).
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
-is_obsolete: true
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000219
 name: ionization energy
 def: "OBSOLETE The minimum energy required to remove an electron from an atom or molecule to produce a positive ion." [PSI:MS]
-synonym: "IE" EXACT []
-comment: This child of the former purgatory term ion attribute was made obsolete.
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
-relationship: has_units UO:0000266 ! electronvolt
-is_obsolete: true
+relationship: has_units: UO:0000266 ! electronvolt
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000220
 name: isotope dilution mass spectrometry
 def: "OBSOLETE A quantitative mass spectrometry technique in which an isotopically enriched compound is used as an internal standard." [PSI:MS]
-comment: This child of the former purgatory term mass spectrometry was made obsolete.
-synonym: "IDMS" EXACT []
-is_obsolete: true
 
 [Term]
 id: MS:1000221
@@ -1541,17 +1445,15 @@ id: MS:1000222
 name: mass defect
 def: "OBSOLETE The difference between the monoisotopic and nominal mass of a molecule or atom." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
-comment: This child of the former purgatory term ion attribute was made obsolete.
-relationship: has_units UO:0000002 ! mass unit
-is_obsolete: true
+relationship: has_units: UO:0000002 ! mass unit
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000223
 name: mass number
 def: "OBSOLETE The sum of the protons and neutrons in an atom, molecule or ion." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
-comment: This child of the former purgatory term ion attribute was made obsolete.
-is_obsolete: true
+relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000224
@@ -1559,90 +1461,75 @@ name: molecular mass
 def: "Mass of a molecule measured in unified atomic mass units (u or Da)." [https://en.wikipedia.org/wiki/Molecular_mass]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000861 ! molecular entity property
-relationship: has_units UO:0000002 ! mass unit
+relationship: has_units: UO:0000002 ! mass unit
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000225
 name: monoisotopic mass
 def: "OBSOLETE The mass of an ion or molecule calculated using the mass of the most abundant isotope of each element." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
-comment: This child of the former purgatory term ion attribute was made obsolete.
-relationship: has_units UO:0000002 ! mass unit
-is_obsolete: true
+relationship: has_units: UO:0000002 ! mass unit
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000226
 name: molecular beam mass spectrometry
 def: "OBSOLETE A mass spectrometry technique in which the sample is introduced into the mass spectrometer as a molecular beam." [PSI:MS]
-comment: This child of the former purgatory term mass spectrometer was made obsolete.
-synonym: "MBMS" EXACT []
-is_obsolete: true
 
 [Term]
 id: MS:1000227
 name: multiphoton ionization
 def: "Photoionization of an atom or molecule in which in two or more photons are absorbed." [PSI:MS]
-synonym: "MPI" EXACT []
 is_a: MS:1000008 ! ionization type
 
 [Term]
 id: MS:1000228
 name: nitrogen rule
 def: "OBSOLETE An organic molecule containing the elements C, H, O, S, P, or halogen has an odd nominal mass if it contains an odd number of nitrogen atoms." [PSI:MS]
-comment: This child of the former purgatory term ion reaction was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000229
 name: nominal mass
 def: "OBSOLETE The mass of an ion or molecule calculated using the mass of the most abundant isotope of each element rounded to the nearest integer value." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
-comment: This child of the former purgatory term ion attribute was made obsolete.
-relationship: has_units UO:0000002 ! mass unit
-is_obsolete: true
+relationship: has_units: UO:0000002 ! mass unit
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000230
 name: odd-electron rule
 def: "OBSOLETE Odd-electron ions may dissociate to form either odd or even-electron ions, whereas even-electron ions generally form even-electron fragment ions." [PSI:MS]
-comment: This child of the former purgatory term ion reaction was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000231
 name: peak
 def: "A localized region of relatively large ion signal in a mass spectrum. Although peaks are often associated with particular ions, the terms peak and ion should not be used interchangeably." [PSI:MS]
-relationship: part_of MS:1000442 ! spectrum
+relationship: part_of: MS:1000442 ! spectrum
 
 [Term]
 id: MS:1000232
 name: peak intensity
 def: "OBSOLETE The height or area of a peak in a mass spectrum." [PSI:MS]
-comment: This term was made obsolete because it was replaced by base peak intensity (MS:1000505).
-is_obsolete: true
 
 [Term]
 id: MS:1000233
 name: proton affinity
 def: "OBSOLETE The proton affinity of a species M is defined as the negative of the enthalpy change for the reaction M + H+ ->[M+H]+, where all species are in their ground rotational, vibrational and electronic states." [PSI:MS]
-synonym: "PA" EXACT [PSI:MS]
-comment: This child of the former purgatory term ion attribute was made obsolete.
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
-is_obsolete: true
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000234
 name: mass resolving power
 def: "OBSOLETE In a mass spectrum, the observed mass divided by the difference between two masses that can be separated. The method by which delta m was obtained and the mass at which the measurement was made should be reported." [PSI:MS]
-comment: This term was made obsolete because it was replaced by mass resolving power (MS:1000800).
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
-is_obsolete: true
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000235
 name: total ion current chromatogram
 def: "Representation of the total ion current detected in each of a series of mass spectra versus time." [PSI:MS]
-synonym: "TIC chromatogram" EXACT []
 is_a: MS:1000810 ! ion current chromatogram
 
 [Term]
@@ -1651,387 +1538,294 @@ name: transmission
 def: "The ratio of the number of ions leaving a region of a mass spectrometer to the number entering that region." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000496 ! instrument attribute
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000237
 name: unified atomic mass unit
 def: "OBSOLETE A non-SI unit of mass (u) defined as one twelfth of ^12 C in its ground state and equal to 1.660 538 86(28) x 10^-27 kg." [PSI:MS]
-comment: This term was made obsolete because it was redundant with Unit Ontology dalton (UO:0000221).
-synonym: "u" EXACT []
-is_obsolete: true
 
 [Term]
 id: MS:1000238
 name: accelerator mass spectrometry
 def: "OBSOLETE A mass spectrometry technique in which atoms extracted from a sample are ionized, accelerated to MeV energies and separated according to their momentum, charge and energy." [PSI:MS]
-comment: This child of the former purgatory term mass spectrometer was made obsolete.
-synonym: "AMS" EXACT []
-is_obsolete: true
 
 [Term]
 id: MS:1000239
 name: atmospheric pressure matrix-assisted laser desorption ionization
 def: "Matrix-assisted laser desorption ionization in which the sample target is at atmospheric pressure and the ions formed by the pulsed laser are sampled through a small aperture into the mass spectrometer." [PSI:MS]
-synonym: "AP MALDI" EXACT []
 is_a: MS:1000240 ! atmospheric pressure ionization
 
 [Term]
 id: MS:1000240
 name: atmospheric pressure ionization
 def: "Any ionization process in which ions are formed in the gas phase at atmospheric pressure." [PSI:MS]
-synonym: "API" EXACT []
 is_a: MS:1000008 ! ionization type
 
 [Term]
 id: MS:1000241
 name: Atmostpheric Pressure Photoionization
 def: "OBSOLETE Atmospheric pressure chemical ionization in which the reactant ions are generated by photo-ionization." [PSI:MS]
-comment: This term was made obsolete because it was replaced by atmospheric pressure photoionization (MS:1000382).
-synonym: "APPI" EXACT []
-is_obsolete: true
 
 [Term]
 id: MS:1000242
 name: blackbody infrared radiative dissociation
 def: "A special case of infrared multiphoton dissociation wherein excitation of the reactant ion is caused by absorption of infrared photons radiating from heated blackbody surroundings, which are usually the walls of a vacuum chamber. See also infrared multiphoton dissociation." [PSI:MS]
-synonym: "BIRD" EXACT []
 is_a: MS:1000044 ! dissociation method
 
 [Term]
 id: MS:1000243
 name: charge-remote fragmentation
 def: "OBSOLETE A fragmentation of an even-electron ion in which the cleaved bond is not adjacent to the apparent charge site." [PSI:MS]
-comment: This child of the former purgatory term ion reaction was made obsolete.
-synonym: "CRF" EXACT []
-is_obsolete: true
 
 [Term]
 id: MS:1000244
 name: consecutive reaction monitoring
 def: "OBSOLETE MSn experiment with three or more stages of m/z separation and in which a particular multi-step reaction path is monitored." [PSI:MS]
-comment: This former purgatory term was made obsolete.
-synonym: "CRM" EXACT []
-is_obsolete: true
 
 [Term]
 id: MS:1000245
 name: charge stripping
 def: "The reaction of a positive ion with an atom or molecule that results in the removal of one or more electrons from the ion." [PSI:MS]
-synonym: "CS" EXACT []
 is_a: MS:1000510 ! precursor activation attribute
 
 [Term]
 id: MS:1000246
 name: delayed extraction
 def: "The application of the accelerating voltage pulse after a time delay in desorption ionization from a surface. The extraction delay can produce energy focusing in a time-of-flight mass spectrometer." [PSI:MS]
-synonym: "DE" EXACT []
 is_a: MS:1000597 ! ion optics type
 
 [Term]
 id: MS:1000247
 name: desorption ionization
 def: "The formation of ions from a solid or liquid material after the rapid vaporization of that sample." [PSI:MS]
-synonym: "DI" EXACT []
 is_a: MS:1000008 ! ionization type
 
 [Term]
 id: MS:1000248
 name: direct insertion probe
 def: "A device for introducing a solid or liquid sample into a mass spectrometer ion source for desorption ionization." [PSI:MS]
-synonym: "DIP" EXACT []
 is_a: MS:1000007 ! inlet type
 
 [Term]
 id: MS:1000249
 name: direct liquid introduction
 def: "The delivery of a liquid sample into a mass spectrometer for spray or desorption ionization." [PSI:MS]
-synonym: "DLI" EXACT []
 is_a: MS:1000007 ! inlet type
 
 [Term]
 id: MS:1000250
 name: electron capture dissociation
 def: "A process in which a multiply protonated molecules interacts with a low energy electrons. Capture of the electron leads the liberation of energy and a reduction in charge state of the ion with the production of the (M + nH) (n-1)+ odd electron ion, which readily fragments." [PSI:MS]
-synonym: "ECD" EXACT []
 is_a: MS:1000044 ! dissociation method
 
 [Term]
 id: MS:1000251
 name: even-electron ion
 def: "OBSOLETE An ion containing no unpaired electrons in its ground electronic state, e.g. CH3+ in its ground state." [PSI:MS]
-comment: This child of the former purgatory term ion chemical type was made obsolete.
-synonym: "EE" EXACT []
-is_obsolete: true
 
 [Term]
 id: MS:1000252
 name: electron-induced excitation in organics
 def: "OBSOLETE The reaction of an ion with an electron in which the translational energy of the collision is converted into internal energy of the ion." [PSI:MS]
-comment: This child of the former purgatory term ion reaction was made obsolete.
-synonym: "EIEIO" EXACT []
-is_obsolete: true
 
 [Term]
 id: MS:1000253
 name: electron multiplier
 def: "A device to amplify the current of a beam or packet of charged particles or photons by incidence upon the surface of an electrode to produce secondary electrons. The secondary electrons are then accelerated to other electrodes or parts of a continuous electrode to produce further secondary electrons." [PSI:MS]
-synonym: "EM" EXACT []
 is_a: MS:1000026 ! detector type
 
 [Term]
 id: MS:1000254
 name: electrostatic energy analyzer
 def: "A device consisting of conducting parallel plates, concentric cylinders or concentric spheres that separates charged particles according to their kinetic energy by means of an electric field that is constant in time." [PSI:MS]
-synonym: "ESA" EXACT []
 is_a: MS:1000443 ! mass analyzer type
 
 [Term]
 id: MS:1000255
 name: flowing afterglow
 def: "An ion source immersed in a flow of helium or other inert buffer gas that carries the ions through a meter-long reactor at pressures around 100 Pa." [PSI:MS]
-synonym: "FA" EXACT []
 is_a: MS:1000008 ! ionization type
 
 [Term]
 id: MS:1000256
 name: high-field asymmetric waveform ion mobility spectrometry
 def: "OBSOLETE The separation of ions between two concentric cylindrical electrodes due to application of a high voltage asymmetric waveform whereby ions migrate towards one of the two electrodes depending on the ratio of the high- to low-field mobility of the ion." [PSI:MS]
-comment: This child of the former purgatory term mass spectrometer was made obsolete.
-synonym: "FAIMS" EXACT []
-is_obsolete: true
 
 [Term]
 id: MS:1000257
 name: field desorption
 def: "The formation of gas-phase ions from a material deposited on a solid surface in the presence of a high electric field. Because this process may encompass ionization by field ionization or other mechanisms, it is not recommended as a synonym for field desorption ionization." [PSI:MS]
-synonym: "FD" EXACT []
 is_a: MS:1000247 ! desorption ionization
 
 [Term]
 id: MS:1000258
 name: field ionization
 def: "The removal of electrons from any species by interaction with a high electric field." [PSI:MS]
-synonym: "FI" EXACT []
 is_a: MS:1000008 ! ionization type
 
 [Term]
 id: MS:1000259
 name: glow discharge ionization
 def: "The formation of ions in the gas phase and from solid samples at the cathode by application of a voltage to a low pressure gas." [PSI:MS]
-synonym: "GD-MS" EXACT []
 is_a: MS:1000008 ! ionization type
 
 [Term]
 id: MS:1000260
 name: ion kinetic energy spectrometry
 def: "OBSOLETE A method of analysis in which a beam of ions is separated according to the ratio of its translational energy to charge." [PSI:MS]
-comment: This child of the former purgatory term mass spectrometer was made obsolete.
-synonym: "IKES" EXACT []
-is_obsolete: true
 
 [Term]
 id: MS:1000261
 name: ion mobility spectrometry
 def: "OBSOLETE The separation of ions according to their velocity through a buffer gas under the influence of an electric field." [PSI:MS]
-comment: This child of the former purgatory term mass spectrometer was made obsolete.
-synonym: "IMS" EXACT []
-is_obsolete: true
 
 [Term]
 id: MS:1000262
 name: infrared multiphoton dissociation
 def: "Multiphoton ionization where the reactant ion dissociates as a result of the absorption of multiple infrared photons." [PSI:MS]
-synonym: "IRMPD" EXACT []
 is_a: MS:1000044 ! dissociation method
 
 [Term]
 id: MS:1000263
 name: isotope ratio mass spectrometry
 def: "OBSOLETE The measurement of the relative quantity of the different isotopes of an element in a material with a mass spectrometer." [PSI:MS]
-comment: This child of the former purgatory term mass spectrometry was made obsolete.
-synonym: "IRMS" EXACT []
-is_obsolete: true
 
 [Term]
 id: MS:1000264
 name: ion trap
 def: "A device for spatially confining ions using electric and magnetic fields alone or in combination." [PSI:MS]
-synonym: "IT" EXACT []
 is_a: MS:1000443 ! mass analyzer type
 
 [Term]
 id: MS:1000265
 name: kinetic energy release distribution
 def: "OBSOLETE Distribution of values of translational kinetic energy release for an ensemble of metastable ions undergoing a specific dissociation reaction." [PSI:MS]
-comment: This child of the former purgatory term ion reaction was made obsolete.
-synonym: "KERD" EXACT []
-is_obsolete: true
 
 [Term]
 id: MS:1000266
 name: Laser Desorption
 def: "OBSOLETE The formation of ions through the interaction of a laser with a material or with gas-phase ions or molecules." [PSI:MS]
-comment: This term was made obsolete because it was replaced by laser desorption ionization (MS:1000393).
-synonym: "Laser Ionization MERGE" EXACT []
-synonym: "LD" EXACT []
-is_obsolete: true
-replaced_by: MS:1000393
 
 [Term]
 id: MS:1000267
 name: mass analyzed ion kinetic energy spectrometry
 def: "OBSOLETE Spectra that are obtained from a sector mass spectrometer that incorporates at least one magnetic sector plus one electric sector in reverse geometry. The accelerating voltage, V, and the magnetic sector field, B, are set at fixed values to select the precursor ions, which are then allowed to dissociate or to react in a field free region between the two sectors. The kinetic energy product ions of m/z selected precursor ions is analyzed by scanning the electric sector field, E. The width of the product ion spectrum peaks is related to the kinetic energy release distribution (KERD) for the dissociation process." [PSI:MS]
-comment: This child of the former purgatory term mass spectrometer was made obsolete.
-synonym: "MIKES" EXACT []
-is_obsolete: true
 
 [Term]
 id: MS:1000268
 name: mass spectrometry
 def: "OBSOLETE The branch of science that deals with all aspects of mass spectrometers and the results obtained with these instruments." [PSI:MS]
-comment: This former purgatory term was made obsolete.
-synonym: "MS" EXACT []
-is_obsolete: true
 
 [Term]
 id: MS:1000269
 name: mass spectrometry/mass spectrometry
 def: "OBSOLETE The acquisition, study and spectra of the electrically charged products or precursors of a m/z selected ion or ions." [PSI:MS]
-comment: This child of the former purgatory term mass spectrometer was made obsolete.
-synonym: "MS/MS" EXACT []
-is_obsolete: true
 
 [Term]
 id: MS:1000270
 name: multiple stage mass spectrometry
 def: "OBSOLETE Multiple stages of precursor ion m/z selection followed by product ion detection for successive progeny ions." [PSI:MS]
-comment: This child of the former purgatory term m/z Separation Method was made obsolete.
-synonym: "MSn" EXACT []
-is_obsolete: true
 
 [Term]
 id: MS:1000271
 name: Negative Ion chemical ionization
 def: "Chemical ionization that results in the formation of negative ions." [PSI:MS]
-synonym: "NICI" EXACT []
 is_a: MS:1000008 ! ionization type
 
 [Term]
 id: MS:1000272
 name: neutralization reionization mass spectrometry
 def: "With this technique, m/z selected ions form neutrals by charge transfer to a collision gas or by dissociation. The neutrals are separated from the remaining ions and ionized in collisions with a second gas. This method is used to investigate reaction intermediates and other unstable species." [PSI:MS]
-synonym: "NRMS" EXACT []
 is_a: MS:1000008 ! ionization type
 
 [Term]
 id: MS:1000273
 name: photoionization
 def: "The ionization of an atom or molecule by a photon, written M + h? ? M^+ + e. The term photon impact is not recommended." [PSI:MS]
-synonym: "PI" EXACT []
 is_a: MS:1000008 ! ionization type
 
 [Term]
 id: MS:1000274
 name: pyrolysis mass spectrometry
 def: "A mass spectrometry technique in which the sample is heated to the point of decomposition and the gaseous decomposition products are introduced into the ion source." [PSI:MS]
-synonym: "PyMS" EXACT []
 is_a: MS:1000008 ! ionization type
 
 [Term]
 id: MS:1000275
 name: collision quadrupole
 def: "A transmission quadrupole to which an oscillating potential is applied so as to focus a beam of ions through a collision gas with no m/z separation." [PSI:MS]
-synonym: "q" EXACT []
 is_a: MS:1000597 ! ion optics type
 
 [Term]
 id: MS:1000276
 name: resonance enhanced multiphoton ionization
 def: "Multiphoton ionization in which the ionization cross section is significantly enhanced because the energy of the incident photons is resonant with an intermediate excited state of the neutral species." [PSI:MS]
-synonym: "REMPI" EXACT []
 is_a: MS:1000008 ! ionization type
 
 [Term]
 id: MS:1000277
 name: residual gas analyzer
 def: "OBSOLETE A mass spectrometer used to measure the composition and pressure of gasses in an evacuated chamber." [PSI:MS]
-comment: This child of the former purgatory term mass spectrometer was made obsolete.
-synonym: "RGA" EXACT []
-is_obsolete: true
 
 [Term]
 id: MS:1000278
 name: surface enhanced laser desorption ionization
 def: "The formation of ionized species in the gas phase from analytes deposited on a particular surface substrate which is irradiated with a laser beam of which wavelength is absorbed by the surface. See also desorption/ionization on silicon and laser desorption/ionization." [PSI:MS]
-synonym: "SELDI" EXACT []
 is_a: MS:1000406 ! surface ionization
 
 [Term]
 id: MS:1000279
 name: surface enhanced neat desorption
 def: "Matrix-assisted laser desorption ionization in which the matrix is covalently linked to the target surface." [PSI:MS]
-synonym: "SEND" EXACT []
 is_a: MS:1000406 ! surface ionization
 
 [Term]
 id: MS:1000280
 name: suface ionization
 def: "OBSOLETE The ionization of a neutral species when it interacts with a solid surface with an appropriate work function and temperature." [PSI:MS]
-comment: This term was made obsolete because it was replaced by surface ionization (MS:1000406).
-synonym: "SI" EXACT []
-is_obsolete: true
 
 [Term]
 id: MS:1000281
 name: selected ion flow tube
 def: "A device in which m/z selected ions are entrained in an inert carrier gas and undergo ion-molecule reactions." [PSI:MS]
-synonym: "SIFT" EXACT []
 is_a: MS:1000597 ! ion optics type
 
 [Term]
 id: MS:1000282
 name: sustained off-resonance irradiation
 def: "A technique associated with Fourier transform ion cyclotron resonance (FT-ICR) mass spectrometry to carry out ion/neutral reactions such as low-energy collision-induced dissociation. A radio-frequency electric field of slightly off-resonance to the cyclotron frequency of the reactant ion cyclically accelerates and decelerates the reactant ion that is confined in the Penning ion trap. The ion's orbit does not exceed the dimensions of ion trap while the ion undergoes an ion/neutral species process that produces a high average translational energy for an extended time." [PSI:MS]
-synonym: "SORI" EXACT []
 is_a: MS:1000044 ! dissociation method
 
 [Term]
 id: MS:1000283
 name: Spark Source Mass Spectrometry
 def: "OBSOLETE Mass spectrometry using spark ionization." [PSI:MS]
-comment: This term was made obsolete because it was replaced by spark ionization (MS:1000404).
-synonym: "SSMS" EXACT []
-is_obsolete: true
 
 [Term]
 id: MS:1000284
 name: stored waveform inverse fourier transform
 def: "A technique to create excitation waveforms for ions in FT-ICR mass spectrometer or Paul ion trap. An excitation waveform in the time-domain is generated by taking the inverse Fourier transform of an appropriate frequency-domain programmed excitation spectrum, in which the resonance frequencies of ions to be excited are included. This technique may be used for selection of precursor ions in MS2 experiments." [PSI:MS]
-synonym: "SWIFT" EXACT []
 is_a: MS:1000443 ! mass analyzer type
 
 [Term]
 id: MS:1000285
 name: total ion current
 def: "The sum of all the separate ion currents carried by the ions of different m/z contributing to a complete mass spectrum or in a specified m/z range of a mass spectrum." [PSI:MS]
-synonym: "TIC" EXACT []
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1003058 ! spectrum property
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000286
 name: time lag focusing
 def: "Energy focusing in a time-of-flight mass spectrometer that is accomplished by introducing a time delay between the formation of the ions and the application of the accelerating voltage pulse." [PSI:MS]
-synonym: "TLF" EXACT []
 is_a: MS:1000597 ! ion optics type
 
 [Term]
 id: MS:1000287
 name: time-of-flight mass spectrometer
 def: "OBSOLETE An instrument that separates ions by m/z in a field-free region after acceleration to a fixed kinetic energy." [PSI:MS]
-comment: This child of the former purgatory term mass spectrometer was made obsolete.
-synonym: "TOF-MS" EXACT []
-is_obsolete: true
 
 [Term]
 id: MS:1000288
@@ -2043,15 +1837,11 @@ is_a: MS:1000443 ! mass analyzer type
 id: MS:1000289
 name: double-focusing mass spectrometer
 def: "OBSOLETE A mass spectrometer that uses a magnetic sector for m/z focusing and an electric sector for energy focusing of an ion beam." [PSI:MS]
-comment: This child of the former purgatory term mass spectrometer was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000290
 name: hybrid mass spectrometer
 def: "OBSOLETE A mass spectrometer that combines m/z analyzers of different types to perform tandem mass spectrometry." [PSI:MS]
-comment: This child of the former purgatory term mass spectrometer was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000291
@@ -2063,15 +1853,11 @@ is_a: MS:1000264 ! ion trap
 id: MS:1000292
 name: mass spectrograph obsolete
 def: "OBSOLETE An instrument that separates a beam of ions according to their mass-to-charge ratio in which the ions are directed onto a focal plane detector such as a photographic plate." [PSI:MS]
-comment: This former purgatory term was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000293
 name: mass spectrometer
 def: "OBSOLETE An instrument that measures the mass-to-charge ratio and relative abundances of ions." [PSI:MS]
-comment: This former purgatory term was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000294
@@ -2084,37 +1870,26 @@ is_a: MS:1000559 ! spectrum type
 id: MS:1000295
 name: mattauch-herzog geometry
 def: "OBSOLETE An arrangement for a double-focusing mass spectrometer in which a deflection of ?/(4 ?(2)) radians in a radial electric field is followed by a magnetic deflection of ?/2 radians." [PSI:MS]
-comment: This former purgatory term was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000296
 name: nier-johnson geometry
 def: "OBSOLETE An arrangement for a double-focusing mass spectrometer in which a deflection of ?/2 radians in a radial electric field analyzer is followed by a magnetic deflection of ?/3 radians." [PSI:MS]
-comment: This former purgatory term was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000297
 name: paul ion trap
 def: "OBSOLETE A device that permits the trapping of ions by means of an alternating current voltage. The ejection of ions with a m/z less than a prescribed value and retention of those with higher mass depends on the application of radio frequency voltages between a ring electrode and two end-cap electrodes to confine the ions in a circular path. The choice of these voltages determines the m/z below which ions are ejected." [PSI:MS]
-comment: This term was made obsolete because it is redundant to quadrupole ion trap.
-synonym: "quadrupole ion trap" RELATED []
-is_obsolete: true
 
 [Term]
 id: MS:1000298
 name: prolate traochoidal mass spectrometer
 def: "OBSOLETE A mass spectrometer in which the ions of different m/z are separated by means of crossed electric and magnetic fields in such a way that the selected ions follow a prolate trochoidal path." [PSI:MS]
-comment: This child of the former purgatory term mass spectrometer was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000299
 name: quistor
 def: "OBSOLETE An abbreviation of quadrupole ion storage trap. This term is synonymous with Paul Ion Trap. If so then add a synonym to paul and obsolete this term." [PSI:MS]
-comment: This former purgatory term was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000300
@@ -2126,22 +1901,16 @@ is_a: MS:1000597 ! ion optics type
 id: MS:1000301
 name: sector mass spectrometer
 def: "OBSOLETE A mass spectrometer consisting of one or more magnetic sectors for m/z selection in a beam of ions. Such instruments may also have one or more electric sectors for energy selection." [PSI:MS]
-comment: This child of the former purgatory term mass spectrometer was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000302
 name: tandem mass spectrometer
 def: "OBSOLETE A mass spectrometer designed for mass spectrometry/mass spectrometry." [PSI:MS]
-comment: This child of the former purgatory term mass spectrometer was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000303
 name: transmission quadrupole mass spectrometer
 def: "OBSOLETE A mass spectrometer that consists of four parallel rods whose centers form the corners of a square and whose opposing poles are connected. The voltage applied to the rods is a superposition of a static potential and a sinusoidal radio frequency potential. The motion of an ion in the x and y dimensions is described by the Matthieu equation whose solutions show that ions in a particular m/z range can be transmitted along the z axis." [PSI:MS]
-comment: This child of the former purgatory term mass spectrometer was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000304
@@ -2149,21 +1918,18 @@ name: accelerating voltage
 def: "The electrical potential used to impart kinetic energy to ions in a mass spectrometer." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000487 ! ion optics attribute
-relationship: has_units UO:0000218 ! volt
+relationship: has_units: UO:0000218 ! volt
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000305
 name: cyclotron motion
 def: "OBSOLETE The circular motion of a charged particle moving at velocity v in a magnetic field B that results from the force qvB." [PSI:MS]
-comment: This child of the former purgatory term m/z Separation Method was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000306
 name: dynamic mass spectrometry
 def: "OBSOLETE A mass spectrometer in which m/z separation using one or more electric fields that vary with time." [PSI:MS]
-comment: This child of the former purgatory term mass spectrometer was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000307
@@ -2177,7 +1943,8 @@ name: electric field strength
 def: "The magnitude of the force per unit charge at a given point in space." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000487 ! ion optics attribute
-relationship: has_units UO:0000268 ! volt per meter
+relationship: has_units: UO:0000268 ! volt per meter
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000309
@@ -2201,50 +1968,36 @@ is_a: MS:1000597 ! ion optics type
 id: MS:1000312
 name: mass limit
 def: "OBSOLETE The m/z value above which ions cannot be detected in a mass spectrometer." [PSI:MS]
-comment: This former purgatory term was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000313
 name: scan m/z range?
 def: "OBSOLETE The limit of m/z over which a mass spectrometer can detect ions." [PSI:MS]
-comment: This former purgatory term was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000314
 name: mass selective axial ejection
 def: "OBSOLETE The use of mass selective instability to eject ions of selected m/z values from an ion trap." [PSI:MS]
-comment: This child of the former purgatory term m/z Separation Method was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000315
 name: mass selective instability
 def: "OBSOLETE A method for selective ejection of ions according to their m/z value in an ion trap." [PSI:MS]
-comment: This child of the former purgatory term m/z Separation Method was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000316
 name: mathieu stability diagram
 def: "OBSOLETE A graphical representation expressed in terms of reduced coordinates that describes charged particle motion in a quadrupole mass filter or quadrupole ion trap mass spectrometer." [PSI:MS]
-comment: This child of the former purgatory term m/z Separation Method was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000317
 name: orthogonal extraction
 def: "OBSOLETE The pulsed acceleration of ions perpendicular to their direction of travel into a time-of-flight mass spectrometer. Ions may be extracted from a directional ion source, drift tube or m/z separation stage." [PSI:MS]
-comment: This child of the former purgatory term m/z Separation Method was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000318
 name: resonance ion ejection
 def: "OBSOLETE A mode of ion ejection in a quadrupole ion trap that relies on a auxiliary radio frequency voltage that is applied to the end-cap electrodes. The voltage is tuned to the secular frequency of a particular ion to eject it." [PSI:MS]
-comment: This child of the former purgatory term m/z Separation Method was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000319
@@ -2262,8 +2015,6 @@ is_a: MS:1000597 ! ion optics type
 id: MS:1000321
 name: 2E Mass Spectrum
 def: "OBSOLETE A mass spectrum obtained by setting the electric sector field E to twice the value required to transmit the main ion-beam thereby allowing ions with a kinetic energy-to-charge ratio twice that of the main ion-beam to be transmitted. Product ions resulting from partial charge transfer reactions such as m^2+ + N ? m^+ + N^+ that occur in a collision cell (containing a gas, N) located in a field-free region preceding a magnetic and electric sector combination are detected. When the magnetic sector field B is scanned, a mass spectrum of singly charged product ions of doubly charged precursor ions is obtained." [PSI:MS]
-comment: This child of the former purgatory term m/z Separation Method was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000322
@@ -2275,39 +2026,28 @@ is_a: MS:1000294 ! mass spectrum
 id: MS:1000323
 name: constant neutral loss scan
 def: "OBSOLETE Spectrum of all precursor ions that undergo a selected m/z decrement." [PSI:MS]
-comment: This former purgatory term was made obsolete.
-synonym: "constant neutral mass loss scan" RELATED []
-synonym: "fixed neutral fragment scan" RELATED []
-is_obsolete: true
 
 [Term]
 id: MS:1000324
 name: constant neutral gain scan
 def: "OBSOLETE Spectrum of all precursor ions that undergo a selected m/z increment." [PSI:MS]
-comment: This former purgatory term was made obsolete.
-synonym: "Constant Neutral Mass Gain Scan" EXACT []
-is_obsolete: true
 
 [Term]
 id: MS:1000325
 name: constant neutral gain spectrum
 def: "A spectrum formed of all product ions that have been produced by gain of a pre-selected neutral mass following the reaction with and addition of the gas in a collision cell." [PSI:MS]
-synonym: "constant neutral mass gain spectrum" EXACT []
 is_a: MS:1000294 ! mass spectrum
 
 [Term]
 id: MS:1000326
 name: constant neutral loss spectrum
 def: "A spectrum formed of all product ions that have been produced with a selected m/z decrement from any precursor ions. The spectrum shown correlates to the precursor ion spectrum. See also neutral loss spectrum." [PSI:MS]
-synonym: "constant neutral mass loss spectrum" EXACT []
 is_a: MS:1000294 ! mass spectrum
 
 [Term]
 id: MS:1000327
 name: consecutive reaction monitoring
 def: "OBSOLETE A type of MS2 experiments with three or more stages of m/z separation and in which a particular multi-step reaction path is monitored." [PSI:MS]
-comment: This term was made obsolete because it was replaced by consecutive reaction monitoring (MS:1000244).
-is_obsolete: true
 
 [Term]
 id: MS:1000328
@@ -2319,50 +2059,36 @@ is_a: MS:1000294 ! mass spectrum
 id: MS:1000329
 name: linked scan
 def: "OBSOLETE A scan in an instrument with two or more m/z analysers or in a sector mass spectrometer that incorporates at least one magnetic sector and one electric sector. Two or more of the analyzers are scanned simultaneously so as to preserve a predetermined relationship between scan parameters to produce a product ion, precursor ion or constant neutral loss spectrum." [PSI:MS]
-comment: This former purgatory term was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000330
 name: linked scan at constant b/e
 def: "OBSOLETE A linked scan at constant B/E may be performed on a sector mass spectrometer that incorporates at least one magnetic sector plus one electric sector. The magnetic field B and the electric field E are scanned simultaneously while the accelerating voltage V is held constant, so as to maintain the ratio of the two fields constant. This linked scan may record a product ion spectrum of dissociation or other reactions occurring in a field free region preceding the two sectors." [PSI:MS]
-comment: This child of the former purgatory term linked scan was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000331
 name: Linked Scan at Constant E2/V
 def: "OBSOLETE A linked scan performed on a sector instrument that incorporates at least one electric sector plus one magnetic sector. The electric sector field, E, and the accelerating voltage, V, are scanned simultaneously, so as to maintain the ratio E2/V at a constant value. This linked scan recordss a product ion spectrum of dissociation or other reactions occurring in a field free region (FFR) preceding the two sectors." [PSI:MS]
-comment: This child of the former purgatory term linked scan was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000332
 name: Linked Scan at Constant B2/E
 def: "OBSOLETE A linked scan performed on a sector mass spectrometer that incorporates at least one electric sector plus one magnetic sector in either order. The accelerating voltage is fixed and the magnetic field, B, and the electric field, E, are scanned simultaneously so as to maintain the ratio B2/E at a constant value. This linked scan records a precursor ion spectrum of dissociation or other reactions occurring in the field free region preceding the two sectors. The term B2/E linked scan is not recommended." [PSI:MS]
-comment: This child of the former purgatory term linked scan was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000333
 name: Linked Scan at Constant B[1-(E/E0)]^1/2 / E
 def: "OBSOLETE A linked scan performed on a sector instrument that incorporates at least one electric sector plus one magnetic sector placed in either order. The accelerating voltage is fixed while scanning the magnetic field, B, and electric field, E, simultaneously, so as to maintain the quantity B[1-(E/E0)]1/2/E at a constant value. This linked scan records a constant neutral mass loss (or gain) spectrum of dissociation or other reactions occurring in a field free region preceding the two sectors. E0 is the electric field required to transmit the singly charged analog of the desired neutral fragment. The term B[1-(E/E0)]1/2/E linked scan." [PSI:MS]
-comment: This child of the former purgatory term linked scan was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000334
 name: MS/MS in Time
 def: "OBSOLETE A tandem mass spectrometry method in which product ion spectra are recorded in a single m/z analyzer (such as a Paul Ion Trap or FTMS) in discreet steps over time. Ions in a specific m/z range are selected, dissociated, and the product ions analyzed sequentially in time." [PSI:MS]
-comment: This child of the former purgatory term m/z Separation Method was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000335
 name: MS/MS in Space
 def: "OBSOLETE A tandem mass spectrometry method in which product ion spectra are recorded in m/z analyzers separated in space. Specific m/z separation functions are designed such that in one section of the instrument ions are selected, dissociated in an intermediate region, and the product ions are then transmitted to another analyser for m/z separation and data acquisition." [PSI:MS]
-comment: This child of the former purgatory term m/z Separation Method was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000336
@@ -2370,36 +2096,27 @@ name: neutral loss
 def: "The loss of an uncharged species during a rearrangement process. The value slot holds the molecular formula in Hill notation of the neutral loss molecule, see PMID: 21182243. This term must be used in conjunction with a child of the term MS:1002307 (fragmentation ion type)." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001055 ! modification parameters
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000337
 name: nth generation product ion
 def: "OBSOLETE Serial product ions from dissociation of selected precursor ions where n refers to the number of stages of dissociation. The term granddaughter ion is deprecated." [PSI:MS]
-comment: This child of the former purgatory term product ion was made obsolete.
-synonym: "granddaughter ion" RELATED []
-is_obsolete: true
 
 [Term]
 id: MS:1000338
 name: nth generation product ion scan
 def: "OBSOLETE The specific scan functions or processes that record the appropriate generation of product ion or ions of any m/z selected precursor ions." [PSI:MS]
-comment: This former purgatory term was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000339
 name: nth generation product ion spectrum
 def: "OBSOLETE The mass spectrum recorded from any mass spectrometer in which the appropriate scan function can be set to record the appropriate generation product ion or ions of m/z selected precursor ions." [PSI:MS]
-comment: This term was made obsolete because it was merged with MSn spectrum (MS:1000580).
-is_obsolete: true
 
 [Term]
 id: MS:1000340
 name: precursor ion
 def: "OBSOLETE An ion that reacts to form particular product ions. The reaction can be unimolecular dissociation, ion/molecule reaction, isomerization, or change in charge state. The term parent ion is deprecated." [PSI:MS]
-comment: This child of the former purgatory term ion role was made obsolete.
-synonym: "parent ion" RELATED []
-is_obsolete: true
 
 [Term]
 id: MS:1000341
@@ -2411,25 +2128,17 @@ is_a: MS:1000294 ! mass spectrum
 id: MS:1000342
 name: product ion
 def: "OBSOLETE An ion formed as the product of a reaction involving a particular precursor ion. The reaction can be unimolecular dissociation to form fragment ions, an ion/molecule reaction, or simply involve a change in the number of charges. The term fragment ion is deprecated. The term daughter ion is deprecated." [PSI:MS]
-comment: This child of the former purgatory term ion role was made obsolete.
-synonym: "daughter ion" RELATED []
-is_obsolete: true
 
 [Term]
 id: MS:1000343
 name: product ion spectrum
 def: "OBSOLETE A mass spectrum recorded from any spectrometer in which the appropriate m/z separation scan function is set to record the product ion or ions of selected precursor ions." [PSI:MS]
-comment: This term was made obsolete because it was merged with MSn spectrum (MS:1000580).
 is_a: MS:1000294 ! mass spectrum
-is_obsolete: true
 
 [Term]
 id: MS:1000344
 name: progeny ion
 def: "OBSOLETE A charged product of a series of consecutive reactions that includes product ions, 1st generation product ions, 2nd generation product ions, etc. Given the sequential fragmentation scheme: M1+ -> M2+ -> M3+ -> M4+ -> M5+. M4+ is the precursor ion of M5+, a 1st generation product ion of M3+, a 2nd generation product ion of M2+ and a 3rd generation product ion of M1+." [PSI:MS]
-comment: This child of the former purgatory term ion chemical type was made obsolete.
-synonym: "Progeny Fragment Ion" EXACT []
-is_obsolete: true
 
 [Term]
 id: MS:1000345
@@ -2477,8 +2186,6 @@ is_a: MS:1000026 ! detector type
 id: MS:1000352
 name: secondary electron
 def: "OBSOLETE Electrons that are ejected from a sample surface as a result of bombardment by a primary beam of atoms, ions or photons. WAS IN DETECTOR TYPE. Where should it go." [PSI:MS]
-comment: This former purgatory term was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000353
@@ -2490,183 +2197,131 @@ is_a: MS:1003055 ! adduct
 id: MS:1000354
 name: aromatic ion
 def: "OBSOLETE A planar cyclic ion that obeys the Hueckel (4n + 2) rule where n is a positive integer representing the number of conjugated Pi electrons. Charge delocalization leads to greater stability compared to a hypothetical localized structure." [PSI:MS]
-comment: This child of the former purgatory term ion chemical type was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000355
 name: analog ion
 def: "OBSOLETE Ions that have similar chemical valence, for example the acetyl cation CH3-CO+ and the thioacetyl cation CH3-CS+." [PSI:MS]
-comment: This child of the former purgatory term ion chemical type was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000356
 name: anti-aromatic ion
 def: "OBSOLETE A planar cyclic ion with 4n ? electrons and is therefore not aromatic." [PSI:MS]
-comment: This child of the former purgatory term ion chemical type was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000357
 name: cationized molecule
 def: "OBSOLETE An ion formed by the association of a cation with a neutral molecule, M, for example [M+ Na]+ and [M + K]+. The terms quasi-molecular ion and pseudo-molecular ion should not be used." [PSI:MS]
-comment: This child of the former purgatory term ion chemical type was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000358
 name: cluster ion
 def: "OBSOLETE An ion formed by a multi-component atomic or molecular assembly of one or more ions with atoms or molecules, such as [(H20)nH]+, [(NaCl)nNa]+ and [(H3PO3)nHPO3]-." [PSI:MS]
-comment: This child of the former purgatory term ion chemical type was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000359
 name: Conventional ion
 def: "OBSOLETE A radical cation or anion in which the charge site and the unpaired electron spin are both formally located in the same atom or group of atoms, as opposed to the spatially separate electronic configuration of distonic ions. The radical cation of methanol, CH3OH+, in which the charge and spin sites are formally located at the O atom is an example of a conventional ion, whereas .CH2-OH2+ is a distonic ion." [PSI:MS]
-comment: This child of the former purgatory term ion chemical type was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000360
 name: diagnostic ion
 def: "OBSOLETE A product ion whose formation reveals structural or compositional information of its precursor. For instance, the phenyl cation in an electron ionization mass spectrum is a diagnostic ion for benzene and derivatives." [PSI:MS]
-comment: This child of the former purgatory term ion chemical type was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000361
 name: dimeric ion
 def: "OBSOLETE An ion formed by ionization of a dimer or by the association of an ion with its neutral counterpart such as [M2]+ or [M-H-M]+." [PSI:MS]
-comment: This child of the former purgatory term ion chemical type was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000362
 name: distonic ion
 def: "OBSOLETE A radical cation or anion in which the charge site and the unpaired electron spin cannot be both formally located in the same atom or group of atoms as it can be with a conventional ion. For example, CH2-OH2+ is a distonic ion whereas the radical cation of methanol, CH3OH+ is a conventional ion." [PSI:MS]
-comment: This child of the former purgatory term ion chemical type was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000363
 name: enium ion
 def: "OBSOLETE A positively charged lower-valency ion of the nonmetallic elements. The methenium ion is CH3+. Other examples are the oxenium, sulfenium, nitrenium, phosphenium, and halenium ions." [PSI:MS]
-comment: This child of the former purgatory term ion chemical type was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000364
 name: fragment ion
 def: "OBSOLETE A product ion that results from the dissociation of a precursor ion." [PSI:MS]
-comment: This term was made obsolete because it was replaced by product ion (MS:1000342).
-is_obsolete: true
 
 [Term]
 id: MS:1000365
 name: ion?
 def: "OBSOLETE An atomic or molecular species having a net positive or negative electric charge." [PSI:MS]
-comment: This former purgatory term was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000366
 name: Isotopologue ion
 def: "OBSOLETE An ion that differs only in the isotopic composition of one or more of its constituent atoms. For example CH4+ and CH3D+ or 10BF3 and 11BF3. The term isotopologue is a contraction of isotopic homologue." [PSI:MS]
-comment: This child of the former purgatory term ion chemical type was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000367
 name: Isotopomeric ion
 def: "OBSOLETE Isomeric ion having the same numbers of each isotopic atom but differing in their positions. Isotopomeric ions can be either configurational isomers in which two atomic isotopes exchange positions or isotopic stereoisomers. The term isotopomer is a shortening of isotopic isomer." [PSI:MS]
-comment: This child of the former purgatory term ion chemical type was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000368
 name: metastable ion
 def: "OBSOLETE An ion that is formed with internal energy higher than the threshold for dissociation but with a lifetime great enough to allow it to exit the ion source and enter the mass spectrometer where it dissociates before detection." [PSI:MS]
-comment: This child of the former purgatory term ion stability type was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000369
 name: molecular ion
 def: "OBSOLETE An ion formed by the removal of one or more electrons to form a positive ion or the addition off one or more electrons to form a negative ion." [PSI:MS]
-comment: This child of the former purgatory term ion chemical type was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000370
 name: negative ion
 def: "OBSOLETE An atomic or molecular species having a net negative electric charge." [PSI:MS]
-comment: This child of the former purgatory term ion chemical type was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000371
 name: non-classical ion
 def: "OBSOLETE Hyper-coordinated carbonium ion such as the penta-coordinated norbornyl cation. Note: Tri-coordinated carbenium ions are termed classical ions." [PSI:MS]
-comment: This child of the former purgatory term ion chemical type was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000372
 name: onium ion
 def: "OBSOLETE A positively charged hypervalent ion of the nonmetallic elements. Examples are the methonium ion CH5+, the hydrogenonium ion H3+ and the hydronium ion H3O+. Other examples are the carbonium, oxonium, sulfonium, nitronium, diazonium, phosphonium, and halonium ions. Onium ions are not limited to monopositive ions; multiply-charged onium ions exist such as the gitonic (proximal) oxonium dication H4O2+ and the distonic oxonium dication H2O+-CH2-CH2-OH2+." [PSI:MS]
-comment: This child of the former purgatory term ion chemical type was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000373
 name: principal ion
 def: "OBSOLETE Most abundant ion of an isotope cluster, such as the 11B79Br2 81Br+ ion of m/z 250 of the cluster of isotopologue molecular ions of BBr3. The term principal ion has also been used to describe ions that have been artificially isotopically enriched in one or more positions such as CH3 13CH3+ or CH2D2 +, but those are best defined as isotopologue ions." [PSI:MS]
-comment: This child of the former purgatory term ion chemical type was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000374
 name: positive ion
 def: "OBSOLETE An atomic or molecular species having a net positive electric charge." [PSI:MS]
-comment: This child of the former purgatory term ion chemical type was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000375
 name: protonated molecule
 def: "OBSOLETE An ion formed by interaction of a neutral molecule with a proton and represented by the symbol [M + H]+, where M is the neutral molecule. The term 'protonated molecular ion,' 'quasi-molecular ion' and 'pseudo-molecular ion' are not recommended." [PSI:MS]
-comment: This child of the former purgatory term ion chemical type was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000376
 name: radical ion
 def: "OBSOLETE An ion, either a cation or anion, containing unpaired electrons in its ground state. The unpaired electron is denoted by a superscript dot alongside the superscript symbol for charge, such as for the molecular ion of a molecule M, that is, M+. Radical ions with more than one charge and/or more than one unpaired electron are denoted such as M(2+)(2). Unless the positions of the unpaired electron and charge can be associated with specific atoms, superscript charge designation should be placed before the superscript dot designation." [PSI:MS]
-comment: This child of the former purgatory term ion chemical type was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000377
 name: reference ion
 def: "OBSOLETE A stable ion whose structure is known with certainty. These ions are usually formed by direct ionization of a neutral molecule of known structure and are used to verify by comparison the structure of an unknown ion." [PSI:MS]
-comment: This child of the former purgatory term ion chemical type was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000378
 name: stable ion
 def: "OBSOLETE An ion with internal energy sufficiently low that it does not rearrange or dissociate prior to detection in a mass spectrometer." [PSI:MS]
-comment: This child of the former purgatory term ion stability type was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000379
 name: unstable ion
 def: "OBSOLETE An ion with sufficient energy to dissociate within the ion source." [PSI:MS]
-comment: This child of the former purgatory term ion stability type was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000380
@@ -2732,15 +2387,11 @@ is_a: MS:1000008 ! ionization type
 id: MS:1000390
 name: ion desolvation
 def: "OBSOLETE The removal of solvent molecules clustered around a gas-phase ion by means of heating and/or collisions with gas molecules." [PSI:MS]
-comment: This child of the former purgatory term ion reaction was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000391
 name: ion-pair formation
 def: "OBSOLETE The reaction of a molecule to form both a positive ion and negative ion fragment among the products." [PSI:MS]
-comment: This child of the former purgatory term ion reaction was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000392
@@ -2748,6 +2399,7 @@ name: ionization efficiency
 def: "The ratio of the number of ions formed to the number of electrons, molecules or photons used." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000482 ! source attribute
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000393
@@ -2777,7 +2429,6 @@ is_a: MS:1000073 ! electrospray ionization
 id: MS:1000398
 name: nanoelectrospray
 def: "Electrospray ionization at a flow rate less than ~25 nL/min. Nanoelectrospray is synonymous with nanospray. The flow is dependent on the potenial on the tip of the electrospray needle and/or a gas presure to push the sample through the needle. See also electrospray ionization and microelectrospray." [PSI:MS]
-synonym: "nanospray" EXACT []
 is_a: MS:1000073 ! electrospray ionization
 
 [Term]
@@ -2796,8 +2447,6 @@ is_a: MS:1000008 ! ionization type
 id: MS:1000401
 name: pre-ionization state
 def: "OBSOLETE An electronic state capable of undergoing auto-Ionization." [PSI:MS]
-comment: This child of the former purgatory term ion reaction was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000402
@@ -2845,22 +2494,16 @@ is_a: MS:1000008 ! ionization type
 id: MS:1000409
 name: association reaction
 def: "OBSOLETE The reaction of an ion with a neutral species in which the reactants combine to form a single ion." [PSI:MS]
-comment: This child of the former purgatory term ion reaction was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000410
 name: alpha-cleavage
 def: "OBSOLETE A homolytic cleavage where the bond fission occurs between at the atom adjacent to the atom at the apparent charge site and an atom removed from the aparent charge site by two bonds." [PSI:MS]
-comment: This child of the former purgatory term ion reaction was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000411
 name: beta-cleavage
 def: "OBSOLETE A homolytic cleavage where the bond fission occurs between at an atom removed from the apparent charge site atom by two bonds and an atom adjacent to that atom and removed from the aparent charge site by three bonds." [PSI:MS]
-comment: This child of the former purgatory term ion reaction was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000412
@@ -2868,48 +2511,37 @@ name: buffer gas
 def: "An inert gas used for collisional deactivation of internally excited ions." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000510 ! precursor activation attribute
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000413
 name: charge-induced fragmentation
 def: "OBSOLETE Fragmentation of an odd electron ion in which the cleaved bond is adjacent to the apparent charge site. Synonymous with charge mediated fragmentation." [PSI:MS]
-comment: This child of the former purgatory term ion reaction was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000414
 name: charge inversion reaction
 def: "OBSOLETE Reaction of an ion with a neutral species in which the charge on the product ion is reversed in sign with respect to the reactant ion." [PSI:MS]
-comment: This child of the former purgatory term ion reaction was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000415
 name: charge permutation reaction
 def: "OBSOLETE The reaction of an ion with a neutral species with a resulting change in the magnitude or sign of the charge on the reactant ion." [PSI:MS]
-comment: This child of the former purgatory term ion reaction was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000416
 name: charge stripping reaction
 def: "OBSOLETE Reaction of a positive ion with a neutral species in which the positive charge on the product ion is greater than that on the reactant ion." [PSI:MS]
-comment: This child of the former purgatory term ion reaction was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000417
 name: charge transfer reaction
 def: "OBSOLETE The reaction of an ion with a neutral species in which some or all of the charge of the reactant ion is transferred to the neutral species." [PSI:MS]
-comment: This child of the former purgatory term ion reaction was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000418
 name: collisional excitation
 def: "OBSOLETE The reaction of an ion with a neutral species in which the translational energy of the collision is converted into internal energy of the ion." [PSI:MS]
-comment: This child of the former purgatory term ion reaction was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000419
@@ -2917,99 +2549,73 @@ name: collision gas
 def: "An inert gas used for collisional excitation. The term target gas is not recommended." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000510 ! precursor activation attribute
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000420
 name: heterolytic cleavage
 def: "OBSOLETE Fragmentation of a molecule or ion in which both electrons forming the single bond that is broken remain on one of the atoms that were originally bonded. This term is synonymous with heterolysis." [PSI:MS]
-comment: This child of the former purgatory term ion reaction was made obsolete.
-synonym: "heterolysis" RELATED []
-is_obsolete: true
 
 [Term]
 id: MS:1000421
 name: high energy collision
 def: "OBSOLETE Collision-induced dissociation process wherein the projectile ion has laboratory-frame translational energy higher than 1 keV." [PSI:MS]
-comment: This child of the former purgatory term ion reaction was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000422
 name: beam-type collision-induced dissociation
 def: "A collision-induced dissociation process that occurs in a beam-type collision cell." [PSI:MS]
-synonym: "HCD" EXACT []
 is_a: MS:1000133 ! collision-induced dissociation
 
 [Term]
 id: MS:1000423
 name: homolytic cleavage
 def: "OBSOLETE Fragmentation of an odd electron ion that results from one of a pair of electrons that form a bond between two atoms moving to form a pair with the odd electron on the atom at the apparent charge site. Fragmentation results in the formation of an even electron ion and a radical. This reaction involves the movement of a single electron and is symbolized by a single-barbed arrow. Synonymous with Homolysis." [PSI:MS]
-comment: This child of the former purgatory term ion reaction was made obsolete.
-synonym: "homolysis" RELATED []
-is_obsolete: true
 
 [Term]
 id: MS:1000424
 name: hydrogen/deuterium exchange
 def: "OBSOLETE Exchange of hydrogen atoms with deuterium atoms in a molecule or pre-formed ion in solution prior to introduction into a mass spectrometer, or by reaction of an ion with a deuterated collision gas inside a mass spectrometer." [PSI:MS]
-comment: This child of the former purgatory term ion reaction was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000425
 name: ion energy loss spectrum
 def: "OBSOLETE A plot of the relative abundance of a beam or other collection of ions as a function their loss of translational energy in reactions with neutral species." [PSI:MS]
-comment: This former purgatory term was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000426
 name: ionizing collision
 def: "OBSOLETE The reaction of an ion with a neutral species in which one or more electrons are removed from either the ion or neutral." [PSI:MS]
-comment: This child of the former purgatory term ion reaction was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000427
 name: ion/molecule reaction
 def: "OBSOLETE The reaction of an ion with a neutral molecule. The term ion-molecule reaction is not recommended because the hyphen suggests a single species that is that is both an ion and a molecule." [PSI:MS]
-comment: This child of the former purgatory term ion reaction was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000428
 name: ion/neutral complex
 def: "OBSOLETE A particular type of transition state that lies between precursor and product ions on the reaction coordinate of some ion reactions." [PSI:MS]
-comment: This child of the former purgatory term ion reaction was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000429
 name: ion/neutral species reaction
 def: "OBSOLETE A process wherein a charged species interacts with a neutral reactant to produce either chemically different species or changes in the internal energy of one or both of the reactants." [PSI:MS]
-comment: This child of the former purgatory term ion reaction was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000430
 name: ion/neutral species exchange reaction
 def: "OBSOLETE In this reaction an association reaction is accompanied by the subsequent or simultaneous liberation of a different neutral species as a product." [PSI:MS]
-comment: This child of the former purgatory term ion reaction was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000431
 name: kinetic method
 def: "OBSOLETE An approach to determination of ion thermodynamic quantities by a bracketing procedure in which the relative probabilities of competing ion fragmentations are measured via the relative abundances of the reaction products. The extended kinetic method takes the associated entropy changes into account." [PSI:MS]
-comment: This child of the former purgatory term ion reaction was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000432
 name: low energy collisions
 def: "OBSOLETE A collision between an ion and neutral species with translational energy approximately 1000 eV or lower." [PSI:MS]
-comment: This child of the former purgatory term ion reaction was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000433
@@ -3021,89 +2627,70 @@ is_a: MS:1000044 ! dissociation method
 id: MS:1000434
 name: McLafferty Rearrangement
 def: "OBSOLETE A dissociation reaction triggered by transfer of a hydrogen atom via a 6-member transition state to the formal radical/charge site from a carbon atom four atoms removed from the charge/radical site (the gamma-carbon); subsequent rearrangement of electron density leads to expulsion of an olefin molecule. This term was originally applied to ketone ions where the charge/radical site is the carbonyl oxygen, but it is now more widely applied." [PSI:MS]
-comment: This child of the former purgatory term ion reaction was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000435
 name: photodissociation
 def: "A process wherein the reactant ion is dissociated as a result of absorption of one or more photons." [PSI:MS]
-synonym: "multiphoton dissociation" EXACT []
-synonym: "MPD" EXACT []
 is_a: MS:1000044 ! dissociation method
 
 [Term]
 id: MS:1000436
 name: partial charge transfer reaction
 def: "OBSOLETE Reaction of an ion with a neutral species in which some but not all of the ion charge is transferred to the neutral." [PSI:MS]
-comment: This child of the former purgatory term ion reaction was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000437
 name: ion reaction
 def: "OBSOLETE Chemical transformation involving an ion." [PSI:MS]
-comment: This child of the former purgatory term ion was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000438
 name: superelastic collision
 def: "OBSOLETE Collision in which the translational energy of the fast-moving collision partner is increased at the expense of internal energy of one or both collision partners." [PSI:MS]
-comment: This child of the former purgatory term ion reaction was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000439
 name: surface-induced reaction
 def: "OBSOLETE A process wherein a reactant ion interacts with a surface to produce either chemically different species or a change in the internal energy of the reactant ion." [PSI:MS]
-comment: This child of the former purgatory term ion reaction was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000440
 name: unimolecular dissociation
 def: "OBSOLETE Fragmentation reaction in which the molecularity is treated as one, irrespective of whether the dissociative state is that of a metastable ion produced in the ion source or results from collisional excitation of a stable ion." [PSI:MS]
-comment: This child of the former purgatory term ion reaction was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000441
 name: scan
 def: "Function or process of the mass spectrometer where it records a spectrum." [PSI:MS]
-relationship: part_of MS:1001458 ! spectrum generation information
+relationship: part_of: MS:1001458 ! spectrum generation information
 
 [Term]
 id: MS:1000442
 name: spectrum
 def: "Representation of intensity values corresponding to a range of measurement space." [PSI:MS]
-relationship: part_of MS:1001458 ! spectrum generation information
+relationship: part_of: MS:1001458 ! spectrum generation information
 
 [Term]
 id: MS:1000443
 name: mass analyzer type
 def: "Mass analyzer separates the ions according to their mass-to-charge ratio." [PSI:MS]
-relationship: part_of MS:1000451 ! mass analyzer
+relationship: part_of: MS:1000451 ! mass analyzer
 
 [Term]
 id: MS:1000444
 name: m/z Separation Method
 def: "OBSOLETE Mass/charge separation Method." [PSI:MS]
-comment: This former purgatory term was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000445
 name: sequential m/z separation method
 def: "OBSOLETE Sequential m/z separation method." [PSI:MS]
-comment: This former purgatory term was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000446
 name: fast ion bombardment
 def: "The ionization of any species by the interaction of a focused beam of ions having a translational energy of several thousand eV with a solid sample." [PSI:MS]
-synonym: "FIB" EXACT []
 is_a: MS:1000008 ! ionization type
 
 [Term]
@@ -3134,109 +2721,93 @@ is_a: MS:1000494 ! Thermo Scientific instrument model
 id: MS:1000451
 name: mass analyzer
 def: "Terms used to describe the Analyzer." [PSI:MS]
-synonym: "analyzer" EXACT []
-relationship: part_of MS:1000463 ! instrument
+relationship: part_of: MS:1000463 ! instrument
 
 [Term]
 id: MS:1000452
 name: data transformation
 def: "Terms used to describe types of data processing." [PSI:MS]
-synonym: "data processing" EXACT []
-relationship: part_of MS:1001458 ! spectrum generation information
+relationship: part_of: MS:1001458 ! spectrum generation information
 
 [Term]
 id: MS:1000453
 name: detector
 def: "The device that detects ions." [PSI:MS]
-relationship: part_of MS:1000463 ! instrument
+relationship: part_of: MS:1000463 ! instrument
 
 [Term]
 id: MS:1000454
 name: instrument additional description
 def: "OBSOLETE Additional terms to describe the instrument as outlined in the mass spec doc, Appendix 1, section 1.5." [PSI:MS]
-comment: This former purgatory term was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000455
 name: ion selection attribute
 def: "Ion selection properties that are associated with a value." [PSI:MS]
 is_a: MS:1000547 ! object attribute
-relationship: part_of MS:1000442 ! spectrum
+relationship: part_of: MS:1000442 ! spectrum
 
 [Term]
 id: MS:1000456
 name: precursor activation
 def: "Terms to describe the precursor activation." [PSI:MS]
-synonym: "activation" EXACT []
-relationship: part_of MS:1000442 ! spectrum
+relationship: part_of: MS:1000442 ! spectrum
 
 [Term]
 id: MS:1000457
 name: sample
 def: "Terms to describe the sample." [PSI:MS]
-relationship: part_of MS:1001458 ! spectrum generation information
+relationship: part_of: MS:1001458 ! spectrum generation information
 
 [Term]
 id: MS:1000458
 name: source
 def: "Terms to describe the source." [PSI:MS]
-relationship: part_of MS:1000463 ! instrument
+relationship: part_of: MS:1000463 ! instrument
 
 [Term]
 id: MS:1000459
 name: spectrum instrument description
 def: "OBSOLETE Terms used to describe the spectrum." [PSI:MS]
-comment: This former purgatory term was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000460
 name: unit
 def: "OBSOLETE Terms to describe units." [PSI:MS]
-comment: This term was made obsolete because it was redundant with the Unit Ontology term unit (UO:0000000).
-relationship: part_of MS:1001458 ! spectrum generation information
-is_obsolete: true
+relationship: part_of: MS:1001458 ! spectrum generation information
 
 [Term]
 id: MS:1000461
 name: additional description
 def: "OBSOLETE Terms to describe Additional." [PSI:MS]
-comment: This former purgatory term was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000462
 name: ion optics
 def: "Device used in the construction of a mass spectrometer to focus, contain or otherwise manipulate ions." [PSI:MS]
-relationship: part_of MS:1000463 ! instrument
+relationship: part_of: MS:1000463 ! instrument
 
 [Term]
 id: MS:1000463
 name: instrument
 def: "Description of the instrument or the mass spectrometer." [PSI:MS]
-synonym: "instrument configuration" EXACT []
-relationship: part_of MS:1001458 ! spectrum generation information
+relationship: part_of: MS:1001458 ! spectrum generation information
 
 [Term]
 id: MS:1000464
 name: mass unit
 def: "OBSOLETE A unit of measurement for mass." [PSI:MS]
-comment: This term was made obsolete because it was redundant with Unit Ontology mass unit (UO:0000002).
-is_obsolete: true
 
 [Term]
 id: MS:1000465
 name: scan polarity
 def: "Relative orientation of the electromagnetic field during the selection and detection of ions in the mass spectrometer." [PSI:MS]
-relationship: part_of MS:1000441 ! scan
+relationship: part_of: MS:1000441 ! scan
 
 [Term]
 id: MS:1000466
 name: alternating
 def: "OBSOLETE Alternating." [PSI:MS]
-comment: This term was made obsolete because .
-is_obsolete: true
 
 [Term]
 id: MS:1000467
@@ -3302,7 +2873,6 @@ is_a: MS:1000490 ! Agilent instrument model
 id: MS:1000477
 name: 6410 Triple Quadrupole LC/MS
 def: "The 6410 Quadrupole LC/MS system is a Agilent liquid chromatography instrument combined with a Agilent triple quadrupole mass spectrometer. Mass range of the mass spectrometer is 15-1650 m/z, resolution is at three settings of 0.7 u (unit), 1.2 u (wide) and 2.5 u (widest). The mass accuracy for 6410 mass spectrometer is 0.1 across the mass range. The collision cell is a hexapole with linear acceleration." [PSI:MS]
-synonym: "6410 Triple Quad LC/MS" EXACT []
 is_a: MS:1000490 ! Agilent instrument model
 
 [Term]
@@ -3315,32 +2885,29 @@ is_a: MS:1000490 ! Agilent instrument model
 id: MS:1000479
 name: purgatory
 def: "OBSOLETE Terms that will likely become obsolete unless there are wails of dissent." [PSI:MS]
-comment: The whole branch purgatory term was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000480
 name: mass analyzer attribute
 def: "Analyzer properties that are associated with a value." [PSI:MS]
-relationship: part_of MS:1000451 ! mass analyzer
+relationship: part_of: MS:1000451 ! mass analyzer
 
 [Term]
 id: MS:1000481
 name: detector attribute
 def: "Detector attribute recognized as a value." [PSI:MS]
-relationship: part_of MS:1000453 ! detector
+relationship: part_of: MS:1000453 ! detector
 
 [Term]
 id: MS:1000482
 name: source attribute
 def: "Property of a source device that need a value." [PSI:MS]
-relationship: part_of MS:1000458 ! source
+relationship: part_of: MS:1000458 ! source
 
 [Term]
 id: MS:1000483
 name: Thermo Fisher Scientific instrument model
 def: "Thermo Fisher Scientific instrument model. The company has gone through several names including Thermo Finnigan, Thermo Scientific." [PSI:MS]
-synonym: "Thermo Scientific" RELATED []
 is_a: MS:1000031 ! instrument model
 
 [Term]
@@ -3361,7 +2928,8 @@ name: source potential
 def: "Potential difference at the MS source in volts." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000482 ! source attribute
-relationship: has_units UO:0000218 ! volt
+relationship: has_units: UO:0000218 ! volt
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000487
@@ -3415,7 +2983,6 @@ is_a: MS:1000483 ! Thermo Fisher Scientific instrument model
 id: MS:1000495
 name: Applied Biosystems instrument model
 def: "Applied Biosystems instrument model." [PSI:MS]
-synonym: "ABI" EXACT []
 is_a: MS:1000031 ! instrument model
 
 [Term]
@@ -3423,62 +2990,59 @@ id: MS:1000496
 name: instrument attribute
 def: "Instrument properties that are associated with a value." [PSI:MS]
 is_a: MS:1000547 ! object attribute
-relationship: part_of MS:1000463 ! instrument
+relationship: part_of: MS:1000463 ! instrument
 
 [Term]
 id: MS:1000497
 name: zoom scan
 def: "Special scan mode where data with improved resolution is acquired. This is typically achieved by scanning a more narrow m/z window or scanning with a lower scan rate." [PSI:MS]
-synonym: "enhanced resolution scan" EXACT []
 is_a: MS:1000503 ! scan attribute
 
 [Term]
 id: MS:1000498
 name: full scan
 def: "OBSOLETE Feature of the ion trap mass spectrometer where MS data is acquired over a mass range." [PSI:MS]
-comment: This former purgatory term was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000499
 name: spectrum attribute
 def: "Nonphysical characteristic attributed to a spectrum." [PSI:MS]
-relationship: part_of MS:1000442 ! spectrum
+relationship: part_of: MS:1000442 ! spectrum
 
 [Term]
 id: MS:1000500
 name: scan window upper limit
 def: "The lower m/z bound of a mass spectrometer scan window." [PSI:MS]
-synonym: "mzRangeStop" RELATED []
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000549 ! selection window attribute
-relationship: has_units MS:1000040 ! m/z
+relationship: has_units: MS:1000040 ! m/z
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000501
 name: scan window lower limit
 def: "The upper m/z bound of a mass spectrometer scan window." [PSI:MS]
-synonym: "mzRangeStart" RELATED []
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000549 ! selection window attribute
-relationship: has_units MS:1000040 ! m/z
+relationship: has_units: MS:1000040 ! m/z
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000502
 name: dwell time
 def: "The time spent gathering data across a peak." [PSI:MS]
-synonym: "Scan Duration" RELATED []
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000503 ! scan attribute
-relationship: has_units UO:0000010 ! second
-relationship: has_units UO:0000031 ! minute
+relationship: has_units: UO:0000010 ! second
+relationship: has_units: UO:0000031 ! minute
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000503
 name: scan attribute
 def: "Nonphysical characteristic attributed to a spectrum acquisition scan." [PSI:MS]
 is_a: MS:1000547 ! object attribute
-relationship: part_of MS:1000441 ! scan
+relationship: part_of: MS:1000441 ! scan
 
 [Term]
 id: MS:1000504
@@ -3486,7 +3050,8 @@ name: base peak m/z
 def: "M/z value of the signal of highest intensity in the mass spectrum." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1003058 ! spectrum property
-relationship: has_units MS:1000040 ! m/z
+relationship: has_units: MS:1000040 ! m/z
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000505
@@ -3494,31 +3059,28 @@ name: base peak intensity
 def: "The intensity of the greatest peak in the mass spectrum." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1003058 ! spectrum property
-relationship: has_units MS:1000131 ! number of detector counts
-relationship: has_units MS:1000132 ! percent of base peak
-relationship: has_units MS:1000814 ! counts per second
-relationship: has_units MS:1000905 ! percent of base peak times 100
-relationship: has_units UO:0000269 ! absorbance unit
+relationship: has_units: MS:1000131 ! number of detector counts
+relationship: has_units: MS:1000132 ! percent of base peak
+relationship: has_units: MS:1000814 ! counts per second
+relationship: has_units: MS:1000905 ! percent of base peak times 100
+relationship: has_units: UO:0000269 ! absorbance unit
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000506
 name: ion role
 def: "OBSOLETE Ion Role." [PSI:MS]
-comment: This child of the former purgatory term ion was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000507
 name: ion property
 def: "Nonphysical characteristic attributed to an ion." [PSI:MS]
-relationship: part_of MS:1002806 ! ion
+relationship: part_of: MS:1002806 ! ion
 
 [Term]
 id: MS:1000508
 name: ion chemical type
 def: "OBSOLETE Ion Type." [PSI:MS]
-comment: This child of the former purgatory term ion was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000509
@@ -3526,13 +3088,14 @@ name: activation energy
 def: "Activation Energy." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000510 ! precursor activation attribute
-relationship: has_units UO:0000266 ! electronvolt
+relationship: has_units: UO:0000266 ! electronvolt
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000510
 name: precursor activation attribute
 def: "Precursor Activation Attribute." [PSI:MS]
-relationship: part_of MS:1000456 ! precursor activation
+relationship: part_of: MS:1000456 ! precursor activation
 
 [Term]
 id: MS:1000511
@@ -3540,6 +3103,7 @@ name: ms level
 def: "Stage number achieved in a multi stage mass spectrometry acquisition." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1000499 ! spectrum attribute
+relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000512
@@ -3547,13 +3111,14 @@ name: filter string
 def: "A string unique to Thermo instrument describing instrument settings for the scan." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000503 ! scan attribute
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000513
 name: binary data array
 def: "A data array of values." [PSI:MS]
-relationship: part_of MS:1000442 ! spectrum
-relationship: part_of MS:1000625 ! chromatogram
+relationship: part_of: MS:1000442 ! spectrum
+relationship: part_of: MS:1000625 ! chromatogram
 
 [Term]
 id: MS:1000514
@@ -3562,7 +3127,7 @@ def: "A data array of m/z values." [PSI:MS]
 xref: binary-data-type:MS\:1000521 "32-bit float"
 xref: binary-data-type:MS\:1000523 "64-bit float"
 is_a: MS:1000513 ! binary data array
-relationship: has_units MS:1000040 ! m/z
+relationship: has_units: MS:1000040 ! m/z
 
 [Term]
 id: MS:1000515
@@ -3571,11 +3136,11 @@ def: "A data array of intensity values." [PSI:MS]
 xref: binary-data-type:MS\:1000521 "32-bit float"
 xref: binary-data-type:MS\:1000523 "64-bit float"
 is_a: MS:1000513 ! binary data array
-relationship: has_units MS:1000131 ! number of detector counts
-relationship: has_units MS:1000132 ! percent of base peak
-relationship: has_units MS:1000814 ! counts per second
-relationship: has_units MS:1000905 ! percent of base peak times 100
-relationship: has_units UO:0000269 ! absorbance unit
+relationship: has_units: MS:1000131 ! number of detector counts
+relationship: has_units: MS:1000132 ! percent of base peak
+relationship: has_units: MS:1000814 ! counts per second
+relationship: has_units: MS:1000905 ! percent of base peak times 100
+relationship: has_units: UO:0000269 ! absorbance unit
 
 [Term]
 id: MS:1000516
@@ -3596,8 +3161,8 @@ is_a: MS:1000513 ! binary data array
 id: MS:1000518
 name: binary data type
 def: "Encoding type of binary data specifying the binary representation and precision, e.g. 64-bit float." [PSI:MS]
-relationship: part_of MS:1000442 ! spectrum
-relationship: part_of MS:1000625 ! chromatogram
+relationship: part_of: MS:1000442 ! spectrum
+relationship: part_of: MS:1000625 ! chromatogram
 
 [Term]
 id: MS:1000519
@@ -3610,7 +3175,6 @@ id: MS:1000520
 name: 16-bit float
 def: "OBSOLETE Signed 16-bit float." [PSI:MS]
 is_a: MS:1000518 ! binary data type
-is_obsolete: true
 
 [Term]
 id: MS:1000521
@@ -3634,13 +3198,13 @@ is_a: MS:1000518 ! binary data type
 id: MS:1000524
 name: data file content
 def: "Describes the data content on the file." [PSI:MS]
-relationship: part_of MS:1000577 ! source data file
+relationship: part_of: MS:1000577 ! source data file
 
 [Term]
 id: MS:1000525
 name: spectrum representation
 def: "Way in which the spectrum is represented, either with regularly spaced data points or with a list of centroided peaks." [PSI:MS]
-relationship: part_of MS:1000442 ! spectrum
+relationship: part_of: MS:1000442 ! spectrum
 
 [Term]
 id: MS:1000526
@@ -3655,7 +3219,8 @@ def: "Highest m/z value observed in the m/z array." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000808 ! chromatogram attribute
 is_a: MS:1003058 ! spectrum property
-relationship: has_units MS:1000040 ! m/z
+relationship: has_units: MS:1000040 ! m/z
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000528
@@ -3664,7 +3229,8 @@ def: "Lowest m/z value observed in the m/z array." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000808 ! chromatogram attribute
 is_a: MS:1003058 ! spectrum property
-relationship: has_units MS:1000040 ! m/z
+relationship: has_units: MS:1000040 ! m/z
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000529
@@ -3672,6 +3238,7 @@ name: instrument serial number
 def: "Serial Number of the instrument." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000496 ! instrument attribute
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000530
@@ -3683,7 +3250,7 @@ is_a: MS:1000452 ! data transformation
 id: MS:1000531
 name: software
 def: "Software related to the recording or transformation of spectra." [PSI:MS]
-relationship: part_of MS:0000000 ! Proteomics Standards Initiative Mass Spectrometry Vocabularies
+relationship: part_of: MS:0000000 ! Proteomics Standards Initiative Mass Spectrometry Vocabularies
 
 [Term]
 id: MS:1000532
@@ -3698,7 +3265,6 @@ is_a: MS:1001457 ! data processing software
 id: MS:1000533
 name: Bioworks
 def: "Thermo Finnigan software for data analysis of peptides and proteins." [PSI:MS]
-synonym: "Bioworks Browser" RELATED []
 is_a: MS:1000693 ! Thermo Finnigan software
 is_a: MS:1001456 ! analysis software
 is_a: MS:1001457 ! data processing software
@@ -3742,7 +3308,6 @@ is_a: MS:1001457 ! data processing software
 id: MS:1000538
 name: massWolf
 def: "A software for converting Waters raw directory format to mzXML or mzML. MassWolf was originally developed at the Institute for Systems Biology." [PSI:MS]
-synonym: "wolf" EXACT []
 is_a: MS:1001457 ! data processing software
 
 [Term]
@@ -3801,28 +3366,26 @@ is_a: MS:1000530 ! file format conversion
 id: MS:1000547
 name: object attribute
 def: "Object Attribute." [PSI:MS]
-relationship: part_of MS:1001458 ! spectrum generation information
+relationship: part_of: MS:1001458 ! spectrum generation information
 
 [Term]
 id: MS:1000548
 name: sample attribute
 def: "Sample properties that are associated with a value." [PSI:MS]
 is_a: MS:1000547 ! object attribute
-relationship: part_of MS:1000457 ! sample
+relationship: part_of: MS:1000457 ! sample
 
 [Term]
 id: MS:1000549
 name: selection window attribute
 def: "Selection window properties that are associated with a value." [PSI:MS]
 is_a: MS:1000547 ! object attribute
-relationship: part_of MS:1000441 ! scan
+relationship: part_of: MS:1000441 ! scan
 
 [Term]
 id: MS:1000550
 name: time unit
 def: "OBSOLETE Time Unit." [PSI:MS]
-comment: This term was made obsolete because it was redundant with the Unit Ontology term time unit (UO:0000003).
-is_obsolete: true
 
 [Term]
 id: MS:1000551
@@ -3837,8 +3400,6 @@ is_a: MS:1001457 ! data processing software
 id: MS:1000552
 name: maldi spot identifier
 def: "OBSOLETE Maldi Spot Identifier." [PSI:MS]
-comment: This former purgatory term was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1000553
@@ -3880,7 +3441,7 @@ is_a: MS:1000125 ! Thermo Finnigan instrument model
 id: MS:1000559
 name: spectrum type
 def: "Spectrum type." [PSI:MS]
-relationship: part_of MS:1000442 ! spectrum
+relationship: part_of: MS:1000442 ! spectrum
 
 [Term]
 id: MS:1000560
@@ -3892,7 +3453,7 @@ is_a: MS:1001459 ! file format
 id: MS:1000561
 name: data file checksum type
 def: "Checksum is a form of redundancy check, a simple way to protect the integrity of data by detecting errors in data." [PSI:MS]
-relationship: part_of MS:1000577 ! source data file
+relationship: part_of: MS:1000577 ! source data file
 
 [Term]
 id: MS:1000562
@@ -3936,6 +3497,7 @@ name: MD5
 def: "MD5 (Message-Digest algorithm 5) is a (now deprecated) cryptographic hash function with a 128-bit hash value used to check the integrity of files." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000561 ! data file checksum type
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000569
@@ -3943,12 +3505,13 @@ name: SHA-1
 def: "SHA-1 (Secure Hash Algorithm-1) is a cryptographic hash function designed by the National Security Agency (NSA). It is also used to verify file integrity. Since 2011 it has been deprecated by the NIST as a U. S. government standard." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000561 ! data file checksum type
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000570
 name: spectra combination
 def: "Method used to combine the mass spectra." [PSI:MS]
-relationship: part_of MS:1000442 ! spectrum
+relationship: part_of: MS:1000442 ! spectrum
 
 [Term]
 id: MS:1000571
@@ -3960,8 +3523,8 @@ is_a: MS:1000570 ! spectra combination
 id: MS:1000572
 name: binary data compression type
 def: "Compression Type." [PSI:MS]
-relationship: part_of MS:1000442 ! spectrum
-relationship: part_of MS:1000625 ! chromatogram
+relationship: part_of: MS:1000442 ! spectrum
+relationship: part_of: MS:1000625 ! chromatogram
 
 [Term]
 id: MS:1000573
@@ -3991,9 +3554,8 @@ is_a: MS:1000572 ! binary data compression type
 id: MS:1000577
 name: source data file
 def: "Data file from which an entity is sourced." [PSI:MS]
-synonym: "source file" EXACT []
-relationship: part_of MS:1001458 ! spectrum generation information
 is_a: MS:1000499 ! spectrum attribute
+relationship: part_of: MS:1001458 ! spectrum generation information
 
 [Term]
 id: MS:1000578
@@ -4005,19 +3567,12 @@ is_a: MS:1000125 ! Thermo Finnigan instrument model
 id: MS:1000579
 name: MS1 spectrum
 def: "Mass spectrum created by a single-stage MS experiment or the first stage of a multi-stage experiment." [PSI:MS]
-synonym: "full spectrum" EXACT []
-synonym: "Q1 spectrum" EXACT []
-synonym: "Q3 spectrum" EXACT []
-synonym: "Single-Stage Mass Spectrometry" EXACT []
 is_a: MS:1000294 ! mass spectrum
 
 [Term]
 id: MS:1000580
 name: MSn spectrum
 def: "MSn refers to multi-stage MS2 experiments designed to record product ion spectra where n is the number of product ion stages (progeny ions). For ion traps, sequential MS/MS experiments can be undertaken where n > 2 whereas for a simple triple quadrupole system n=2. Use the term ms level (MS:1000511) for specifying n." [PSI:MS]
-synonym: "multiple-stage mass spectrometry spectrum" EXACT []
-synonym: "nth generation product ion spectrum" EXACT []
-synonym: "product ion spectrum" EXACT []
 is_a: MS:1000294 ! mass spectrum
 
 [Term]
@@ -4030,18 +3585,12 @@ is_a: MS:1000294 ! mass spectrum
 id: MS:1000582
 name: SIM spectrum
 def: "Spectrum obtained with the operation of a mass spectrometer in which the abundances of one ion or several ions of specific m/z values are recorded rather than the entire mass spectrum (Selected Ion Monitoring)." [PSI:MS]
-synonym: "MIM spectrum" EXACT []
-synonym: "multiple ion monitoring spectrum" EXACT []
-synonym: "selected ion monitoring spectrum" EXACT []
 is_a: MS:1000294 ! mass spectrum
 
 [Term]
 id: MS:1000583
 name: SRM spectrum
 def: "Spectrum obtained when data are acquired from specific product ions corresponding to m/z values of selected precursor ions a recorded via two or more stages of mass spectrometry. The precursor/product ion pair is called a transition pair. Data can be obtained for a single transition pair or multiple transition pairs. Multiple time segments of different transition pairs can exist in a single file. Single precursor ions can have multiple product ions consitituting multiple transition pairs. Selected reaction monitoring can be performed as tandem mass spectrometry in time or tandem mass spectrometry in space." [PSI:MS]
-synonym: "MRM spectrum" EXACT []
-synonym: "multiple reaction monitoring spectrum" EXACT []
-synonym: "selected reaction monitoring spectrum" EXACT []
 is_a: MS:1000294 ! mass spectrum
 
 [Term]
@@ -4055,7 +3604,7 @@ id: MS:1000585
 name: contact attribute
 def: "Details about a person or organization to contact in case of concern or discussion about the file." [PSI:MS]
 is_a: MS:1000547 ! object attribute
-relationship: part_of MS:0000000 ! Proteomics Standards Initiative Mass Spectrometry Vocabularies
+relationship: part_of: MS:0000000 ! Proteomics Standards Initiative Mass Spectrometry Vocabularies
 
 [Term]
 id: MS:1000586
@@ -4063,6 +3612,7 @@ name: contact name
 def: "Name of the contact person or organization." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000585 ! contact attribute
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000587
@@ -4070,6 +3620,7 @@ name: contact address
 def: "Postal address of the contact person or organization." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000585 ! contact attribute
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000588
@@ -4077,6 +3628,7 @@ name: contact URL
 def: "Uniform Resource Locator related to the contact person or organization." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000585 ! contact attribute
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000589
@@ -4084,6 +3636,7 @@ name: contact email
 def: "Email address of the contact person or organization." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000585 ! contact attribute
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000590
@@ -4091,6 +3644,7 @@ name: contact affiliation
 def: "Home institution of the contact person." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000585 ! contact attribute
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000591
@@ -4114,7 +3668,6 @@ is_a: MS:1000543 ! data processing action
 id: MS:1000594
 name: low intensity data point removal
 def: "The removal of very low intensity data points that are likely to be spurious noise rather than real signal." [PSI:MS]
-synonym: "thresholding" EXACT []
 is_a: MS:1001486 ! data filtering
 
 [Term]
@@ -4124,14 +3677,14 @@ def: "A data array of relative time offset values from a reference time." [PSI:M
 xref: binary-data-type:MS\:1000521 "32-bit float"
 xref: binary-data-type:MS\:1000523 "64-bit float"
 is_a: MS:1000513 ! binary data array
-relationship: has_units UO:0000010 ! second
-relationship: has_units UO:0000031 ! minute
+relationship: has_units: UO:0000010 ! second
+relationship: has_units: UO:0000031 ! minute
 
 [Term]
 id: MS:1000596
 name: measurement method
 def: "An attribute of resolution when recording the detector response in absence of the analyte." [PSI:MS]
-relationship: part_of MS:1001458 ! spectrum generation information
+relationship: part_of: MS:1001458 ! spectrum generation information
 
 [Term]
 id: MS:1000597
@@ -4143,14 +3696,12 @@ is_a: MS:1000462 ! ion optics
 id: MS:1000598
 name: electron transfer dissociation
 def: "A process to fragment ions in a mass spectrometer by inducing fragmentation of cations (e.g. peptides or proteins) by transferring electrons to them." [PSI:MS]
-synonym: "ETD" EXACT []
 is_a: MS:1000044 ! dissociation method
 
 [Term]
 id: MS:1000599
 name: pulsed q dissociation
 def: "A process that involves precursor ion activation at high Q, a time delay to allow the precursor to fragment, then a rapid pulse to low Q where all fragment ions are trapped. The product ions can then be scanned out of the ion trap and detected." [PSI:MS]
-synonym: "PQD" EXACT []
 is_a: MS:1000044 ! dissociation method
 
 [Term]
@@ -4250,7 +3801,6 @@ is_a: MS:1000560 ! mass spectrometer file format
 id: MS:1000615
 name: ProteoWizard software
 def: "ProteoWizard software for data processing and analysis. Primarily developed by the labs of P. Malick and D. Tabb." [PSI:MS]
-synonym: "pwiz" EXACT []
 is_a: MS:1001456 ! analysis software
 is_a: MS:1001457 ! data processing software
 
@@ -4260,6 +3810,7 @@ name: preset scan configuration
 def: "A user-defined scan configuration that specifies the instrumental settings in which a spectrum is acquired. An instrument may cycle through a list of preset scan configurations to acquire data. This is a more generic term for the Thermo \"scan event\", which is defined in the Thermo Xcalibur glossary as: a mass spectrometer scan that is defined by choosing the necessary scan parameter settings. Multiple scan events can be defined for each segment of time." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000503 ! scan attribute
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000617
@@ -4268,7 +3819,7 @@ def: "A data array of electromagnetic radiation wavelength values." [PSI:MS]
 xref: binary-data-type:MS\:1000521 "32-bit float"
 xref: binary-data-type:MS\:1000523 "64-bit float"
 is_a: MS:1000513 ! binary data array
-relationship: has_units UO:0000018 ! nanometer
+relationship: has_units: UO:0000018 ! nanometer
 
 [Term]
 id: MS:1000618
@@ -4277,7 +3828,8 @@ def: "Highest wavelength observed in an EMR spectrum." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1003058 ! spectrum property
 is_a: MS:1000808 ! chromatogram attribute
-relationship: has_units UO:0000018 ! nanometer
+relationship: has_units: UO:0000018 ! nanometer
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000619
@@ -4286,22 +3838,20 @@ def: "Lowest wavelength observed in an EMR spectrum." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1003058 ! spectrum property
 is_a: MS:1000808 ! chromatogram attribute
-relationship: has_units UO:0000018 ! nanometer
+relationship: has_units: UO:0000018 ! nanometer
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000620
 name: PDA spectrum
 def: "OBSOLETE Spectrum generated from a photodiode array detector (ultraviolet/visible spectrum)." [PSI:MS]
-comment: This term was made obsolete because it was replaced by absorption spectrum (MS:1000806).
 is_a: MS:1000524 ! data file content
 is_a: MS:1000559 ! spectrum type
-is_obsolete: true
 
 [Term]
 id: MS:1000621
 name: photodiode array detector
 def: "An array detector used to record spectra in the ultraviolet and visible region of light." [PSI:MS]
-synonym: "PDA" EXACT []
 is_a: MS:1000345 ! array detector
 
 [Term]
@@ -4320,26 +3870,24 @@ is_a: MS:1000494 ! Thermo Scientific instrument model
 id: MS:1000624
 name: inductive detector
 def: "Inductive detector." [PSI:MS]
-synonym: "image current detector" EXACT []
 is_a: MS:1000026 ! detector type
 
 [Term]
 id: MS:1000625
 name: chromatogram
 def: "Representation of a chromatographic separation attribute measurement versus time." [PSI:MS]
-relationship: part_of MS:1001458 ! spectrum generation information
+relationship: part_of: MS:1001458 ! spectrum generation information
 
 [Term]
 id: MS:1000626
 name: chromatogram type
 def: "Type of chromatogram measurement being represented." [PSI:MS]
-relationship: part_of MS:1000625 ! chromatogram
+relationship: part_of: MS:1000625 ! chromatogram
 
 [Term]
 id: MS:1000627
 name: selected ion current chromatogram
 def: "Representation of an array of the measurements of a specific single ion current versus time." [PSI:MS]
-synonym: "SIC chromatogram" EXACT []
 is_a: MS:1000810 ! ion current chromatogram
 
 [Term]
@@ -4354,17 +3902,18 @@ name: low intensity threshold
 def: "Threshold below which some action is taken." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000630 ! data processing parameter
-relationship: has_units MS:1000131 ! number of detector counts
-relationship: has_units MS:1000132 ! percent of base peak
-relationship: has_units MS:1000814 ! counts per second
-relationship: has_units MS:1000905 ! percent of base peak times 100
-relationship: has_units UO:0000269 ! absorbance unit
+relationship: has_units: MS:1000131 ! number of detector counts
+relationship: has_units: MS:1000132 ! percent of base peak
+relationship: has_units: MS:1000814 ! counts per second
+relationship: has_units: MS:1000905 ! percent of base peak times 100
+relationship: has_units: UO:0000269 ! absorbance unit
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000630
 name: data processing parameter
 def: "Data processing parameter used in the data processing performed on the data file." [PSI:MS]
-relationship: part_of MS:1001458 ! spectrum generation information
+relationship: part_of: MS:1001458 ! spectrum generation information
 
 [Term]
 id: MS:1000631
@@ -4372,11 +3921,12 @@ name: high intensity threshold
 def: "Threshold above which some action is taken." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000630 ! data processing parameter
-relationship: has_units MS:1000131 ! number of detector counts
-relationship: has_units MS:1000132 ! percent of base peak
-relationship: has_units MS:1000814 ! counts per second
-relationship: has_units MS:1000905 ! percent of base peak times 100
-relationship: has_units UO:0000269 ! absorbance unit
+relationship: has_units: MS:1000131 ! number of detector counts
+relationship: has_units: MS:1000132 ! percent of base peak
+relationship: has_units: MS:1000814 ! counts per second
+relationship: has_units: MS:1000905 ! percent of base peak times 100
+relationship: has_units: UO:0000269 ! absorbance unit
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000632
@@ -4390,6 +3940,7 @@ name: possible charge state
 def: "A possible charge state of the ion in a situation where the charge of an ion is known to be one of several possible values rather than a completely unknown value or determined to be a specific charge with reasonable certainty." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1000455 ! ion selection attribute
+relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000634
@@ -4794,7 +4345,6 @@ is_a: MS:1000531 ! software
 id: MS:1000693
 name: Thermo Finnigan software
 def: "Thermo Finnigan software for data acquisition and analysis." [PSI:MS]
-synonym: "Bioworks Browser" RELATED []
 is_a: MS:1000531 ! software
 
 [Term]
@@ -5136,7 +4686,8 @@ name: selected ion m/z
 def: "Mass-to-charge ratio of an selected ion." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000455 ! ion selection attribute
-relationship: has_units MS:1000040 ! m/z
+relationship: has_units: MS:1000040 ! m/z
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000745
@@ -5156,6 +4707,7 @@ name: completion time
 def: "The time that a data processing action was finished." [PSI:MS]
 xref: value-type:xsd\:dateTime "The allowed value-type for this CV term."
 is_a: MS:1000630 ! data processing parameter
+relationship: has_value_type: xsd\:dateTime ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000748
@@ -5234,9 +4786,7 @@ is_a: MS:1000752 ! TOPP software
 id: MS:1000760
 name: MapAligner
 def: "OBSOLETE Corrects retention time distortions between maps." [PSI:MS]
-comment: This term was made obsolete, because it is replaced by the terms under the 'TOPP map aligner' (MS:1002147) branch.
 is_a: MS:1000752 ! TOPP software
-is_obsolete: true
 
 [Term]
 id: MS:1000761
@@ -5248,17 +4798,13 @@ is_a: MS:1000752 ! TOPP software
 id: MS:1000762
 name: NoiseFilter
 def: "OBSOLETE Removes noise from profile spectra by using different smoothing techniques." [PSI:MS]
-comment: This term was made obsolete, because it is replaced by the terms under the 'TOPP noise filter' (MS:1002131) branch.
 is_a: MS:1000752 ! TOPP software
-is_obsolete: true
 
 [Term]
 id: MS:1000763
 name: PeakPicker
 def: "OBSOLETE Finds mass spectrometric peaks in profile mass spectra." [PSI:MS]
-comment: This term was made obsolete, because it is replaced by the terms under the 'TOPP peak picker' (MS:1002134) branch.
 is_a: MS:1000752 ! TOPP software
-is_obsolete: true
 
 [Term]
 id: MS:1000764
@@ -5270,9 +4816,7 @@ is_a: MS:1000752 ! TOPP software
 id: MS:1000765
 name: SpectraFilter
 def: "OBSOLETE Applies a filter to peak spectra." [PSI:MS]
-comment: This term was made obsolete, because it is replaced by the terms under the 'TOPP spectra filter' (MS:1002137) branch.
 is_a: MS:1000752 ! TOPP software
-is_obsolete: true
 
 [Term]
 id: MS:1000766
@@ -5284,8 +4828,7 @@ is_a: MS:1000752 ! TOPP software
 id: MS:1000767
 name: native spectrum identifier format
 def: "Describes how the native spectrum identifiers are formated." [PSI:MS]
-synonym: "nativeID format" EXACT []
-relationship: part_of MS:1000577 ! source data file
+relationship: part_of: MS:1000577 ! source data file
 
 [Term]
 id: MS:1000768
@@ -5321,35 +4864,30 @@ is_a: MS:1000767 ! native spectrum identifier format
 id: MS:1000773
 name: Bruker FID nativeID format
 def: "Native format defined by file=xsd:IDREF." [PSI:MS]
-comment: The nativeID must be the same as the source file ID.
 is_a: MS:1000767 ! native spectrum identifier format
 
 [Term]
 id: MS:1000774
 name: multiple peak list nativeID format
 def: "Native format defined by index=xsd:nonNegativeInteger." [PSI:MS]
-comment: Used for conversion of peak list files with multiple spectra, i.e. MGF, PKL, merged DTA files. Index is the spectrum number in the file, starting from 0.
 is_a: MS:1000767 ! native spectrum identifier format
 
 [Term]
 id: MS:1000775
 name: single peak list nativeID format
 def: "Native format defined by file=xsd:IDREF." [PSI:MS]
-comment: The nativeID must be the same as the source file ID. Used for conversion of peak list files with one spectrum per file, typically folder of PKL or DTAs, each sourceFileRef is different.
 is_a: MS:1000767 ! native spectrum identifier format
 
 [Term]
 id: MS:1000776
 name: scan number only nativeID format
 def: "Native format defined by scan=xsd:nonNegativeInteger." [PSI:MS]
-comment: Used for conversion from mzXML, or DTA folder where native scan numbers can be derived.
 is_a: MS:1000767 ! native spectrum identifier format
 
 [Term]
 id: MS:1000777
 name: spectrum identifier nativeID format
 def: "Native format defined by spectrum=xsd:nonNegativeInteger." [PSI:MS]
-comment: Used for conversion from mzData. The spectrum id attribute is referenced.
 is_a: MS:1000767 ! native spectrum identifier format
 
 [Term]
@@ -5392,17 +4930,12 @@ is_a: MS:1000592 ! smoothing
 id: MS:1000784
 name: Gaussian smoothing
 def: "Reduces intensity spikes by convolving the data with a one-dimensional Gaussian function." [PSI:MS]
-synonym: "binomial smoothing" EXACT []
-synonym: "Weierstrass transform" EXACT []
 is_a: MS:1000592 ! smoothing
 
 [Term]
 id: MS:1000785
 name: moving average smoothing
 def: "Reduces intensity spikes by averaging each point with two or more adjacent points. The more adjacent points that used, the stronger the smoothing effect." [PSI:MS]
-synonym: "box smoothing" EXACT []
-synonym: "boxcar smoothing" EXACT []
-synonym: "sliding average smoothing" EXACT []
 is_a: MS:1000592 ! smoothing
 
 [Term]
@@ -5416,6 +4949,7 @@ xref: binary-data-type:MS\:1000523 "64-bit float"
 xref: binary-data-type:MS\:1001479 "null-terminated ASCII string"
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000513 ! binary data array
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000787
@@ -5423,11 +4957,12 @@ name: inclusive low intensity threshold
 def: "Threshold at or below which some action is taken." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000630 ! data processing parameter
-relationship: has_units MS:1000131 ! number of detector counts
-relationship: has_units MS:1000132 ! percent of base peak
-relationship: has_units MS:1000814 ! counts per second
-relationship: has_units MS:1000905 ! percent of base peak times 100
-relationship: has_units UO:0000269 ! absorbance unit
+relationship: has_units: MS:1000131 ! number of detector counts
+relationship: has_units: MS:1000132 ! percent of base peak
+relationship: has_units: MS:1000814 ! counts per second
+relationship: has_units: MS:1000905 ! percent of base peak times 100
+relationship: has_units: UO:0000269 ! absorbance unit
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000788
@@ -5435,11 +4970,12 @@ name: inclusive high intensity threshold
 def: "Threshold at or above which some action is taken." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000630 ! data processing parameter
-relationship: has_units MS:1000131 ! number of detector counts
-relationship: has_units MS:1000132 ! percent of base peak
-relationship: has_units MS:1000814 ! counts per second
-relationship: has_units MS:1000905 ! percent of base peak times 100
-relationship: has_units UO:0000269 ! absorbance unit
+relationship: has_units: MS:1000131 ! number of detector counts
+relationship: has_units: MS:1000132 ! percent of base peak
+relationship: has_units: MS:1000814 ! counts per second
+relationship: has_units: MS:1000905 ! percent of base peak times 100
+relationship: has_units: UO:0000269 ! absorbance unit
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000789
@@ -5457,35 +4993,31 @@ is_a: MS:1000580 ! MSn spectrum
 id: MS:1000791
 name: enhanced resolution scan
 def: "OBSOLETE Scan with enhanced resolution." [PSI:MS]
-comment: This term was made obsolete because it was merged with zoom scan (MS:1000497).
-is_obsolete: true
 
 [Term]
 id: MS:1000792
 name: isolation window attribute
 def: "Isolation window parameter." [PSI:MS]
 is_a: MS:1000547 ! object attribute
-relationship: part_of MS:1000441 ! scan
+relationship: part_of: MS:1000441 ! scan
 
 [Term]
 id: MS:1000793
 name: isolation window upper limit
 def: "OBSOLETE The highest m/z being isolated in an isolation window." [PSI:MS]
-comment: This term was obsoleted in favour of using a target, lower, upper offset scheme. See terms 1000827-1000829.
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000792 ! isolation window attribute
-relationship: has_units MS:1000040 ! m/z
-is_obsolete: true
+relationship: has_units: MS:1000040 ! m/z
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000794
 name: isolation window lower limit
 def: "OBSOLETE The lowest m/z being isolated in an isolation window." [PSI:MS]
-comment: This term was obsoleted in favour of using a target, lower, upper offset scheme. See terms 1000827-1000829.
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000792 ! isolation window attribute
-relationship: has_units MS:1000040 ! m/z
-is_obsolete: true
+relationship: has_units: MS:1000040 ! m/z
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000795
@@ -5497,28 +5029,28 @@ is_a: MS:1000570 ! spectra combination
 id: MS:1000796
 name: spectrum title
 def: "Free-form text title describing a spectrum, usually a series of key value pairs as used in an MGF file." [PSI:MS]
-comment: This is the preferred storage place for the spectrum TITLE from an MGF peak list.
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001405 ! spectrum identification result details
 is_a: MS:1000499 ! spectrum attribute
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000797
 name: peak list scans
 def: "A list of scan numbers and or scan ranges associated with a peak list. If possible the list of scans should be converted to native spectrum identifiers instead of using this term." [PSI:MS]
-comment: This is the preferred storage place for the spectrum SCANS attribute from an MGF peak list.
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001405 ! spectrum identification result details
 is_a: MS:1003058 ! spectrum property
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000798
 name: peak list raw scans
 def: "A list of raw scans and or scan ranges used to generate a peak list. If possible the list of scans should be converted to native spectrum identifiers instead of using this term." [PSI:MS]
-comment: This is the preferred storage place for the spectrum RAWSCANS attribute from an MGF peak list.
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001405 ! spectrum identification result details
 is_a: MS:1003058 ! spectrum property
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000799
@@ -5526,6 +5058,7 @@ name: custom unreleased software tool
 def: "A software tool that has not yet been released. The value should describe the software. Please do not use this term for publicly available software - contact the PSI-MS working group in order to have another CV term added." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000531 ! software
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000800
@@ -5533,19 +5066,18 @@ name: mass resolving power
 def: "The observed mass divided by the difference between two masses that can be separated: m/dm. The procedure by which dm was obtained and the mass at which the measurement was made should be reported." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000503 ! scan attribute
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000801
 name: area peak picking
 def: "Spectral peak processing conducted on the acquired data to convert profile data to centroided data. The area defined by all raw data points that belong to the peak is reported." [PSI:MS]
-synonym: "sum peak picking" EXACT []
 is_a: MS:1000035 ! peak picking
 
 [Term]
 id: MS:1000802
 name: height peak picking
 def: "Spectral peak processing conducted on the acquired data to convert profile data to centroided data. The maximum intensity of all raw data points that belong to the peak is reported." [PSI:MS]
-synonym: "max peak picking" EXACT []
 is_a: MS:1000035 ! peak picking
 
 [Term]
@@ -5554,13 +5086,13 @@ name: analyzer scan offset
 def: "Offset between two analyzers in a constant neutral loss or neutral gain scan. The value corresponds to the neutral loss or neutral gain value." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000503 ! scan attribute
-relationship: has_units MS:1000040 ! m/z
+relationship: has_units: MS:1000040 ! m/z
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000804
 name: electromagnetic radiation spectrum
 def: "A plot of the relative intensity of electromagnetic radiation as a function of the wavelength." [PSI:MS]
-synonym: "EMR spectrum" EXACT []
 is_a: MS:1000524 ! data file content
 is_a: MS:1000559 ! spectrum type
 
@@ -5589,15 +5121,15 @@ id: MS:1000808
 name: chromatogram attribute
 def: "Chromatogram properties that are associated with a value." [PSI:MS]
 is_a: MS:1000547 ! object attribute
-relationship: part_of MS:1000625 ! chromatogram
+relationship: part_of: MS:1000625 ! chromatogram
 
 [Term]
 id: MS:1000809
 name: chromatogram title
 def: "A free-form text title describing a chromatogram." [PSI:MS]
-comment: This is the preferred storage place for the spectrum title.
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000808 ! chromatogram attribute
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000810
@@ -5610,7 +5142,6 @@ is_a: MS:1000626 ! chromatogram type
 id: MS:1000811
 name: electromagnetic radiation chromatogram
 def: "Representation of electromagnetic properties versus time." [PSI:MS]
-synonym: "EMR radiation chromatogram" EXACT []
 is_a: MS:1000524 ! data file content
 is_a: MS:1000626 ! chromatogram type
 
@@ -5671,7 +5202,7 @@ def: "A data array of flow rate measurements." [PSI:MS]
 xref: binary-data-type:MS\:1000521 "32-bit float"
 xref: binary-data-type:MS\:1000523 "64-bit float"
 is_a: MS:1000513 ! binary data array
-relationship: has_units UO:0000271 ! microliters per minute
+relationship: has_units: UO:0000271 ! microliters per minute
 
 [Term]
 id: MS:1000821
@@ -5680,7 +5211,7 @@ def: "A data array of pressure measurements." [PSI:MS]
 xref: binary-data-type:MS\:1000521 "32-bit float"
 xref: binary-data-type:MS\:1000523 "64-bit float"
 is_a: MS:1000513 ! binary data array
-relationship: has_units UO:0000110 ! pascal
+relationship: has_units: UO:0000110 ! pascal
 
 [Term]
 id: MS:1000822
@@ -5689,7 +5220,7 @@ def: "A data array of temperature measurements." [PSI:MS]
 xref: binary-data-type:MS\:1000521 "32-bit float"
 xref: binary-data-type:MS\:1000523 "64-bit float"
 is_a: MS:1000513 ! binary data array
-relationship: has_units UO:0000012 ! kelvin
+relationship: has_units: UO:0000012 ! kelvin
 
 [Term]
 id: MS:1000823
@@ -5715,8 +5246,9 @@ name: elution time
 def: "The time of elution from all used chromatographic columns (one or more) in the chromatographic separation step, relative to the start of the chromatography." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000503 ! scan attribute
-relationship: has_units UO:0000010 ! second
-relationship: has_units UO:0000031 ! minute
+relationship: has_units: UO:0000010 ! second
+relationship: has_units: UO:0000031 ! minute
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000827
@@ -5724,7 +5256,8 @@ name: isolation window target m/z
 def: "The primary or reference m/z about which the isolation window is defined." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000792 ! isolation window attribute
-relationship: has_units MS:1000040 ! m/z
+relationship: has_units: MS:1000040 ! m/z
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000828
@@ -5732,7 +5265,8 @@ name: isolation window lower offset
 def: "The extent of the isolation window in m/z below the isolation window target m/z. The lower and upper offsets may be asymmetric about the target m/z." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000792 ! isolation window attribute
-relationship: has_units MS:1000040 ! m/z
+relationship: has_units: MS:1000040 ! m/z
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000829
@@ -5740,26 +5274,27 @@ name: isolation window upper offset
 def: "The extent of the isolation window in m/z above the isolation window target m/z. The lower and upper offsets may be asymmetric about the target m/z." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000792 ! isolation window attribute
-relationship: has_units MS:1000040 ! m/z
+relationship: has_units: MS:1000040 ! m/z
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000831
 name: sample preparation
 def: "Properties of the preparation steps which took place before the measurement was performed." [PSI:MS]
 is_a: MS:1000547 ! object attribute
-relationship: part_of MS:1000548 ! sample attribute
+relationship: part_of: MS:1000548 ! sample attribute
 
 [Term]
 id: MS:1000832
 name: MALDI matrix application
 def: "Attributes to describe the technique how the sample is prepared with the matrix solution." [PSI:MS]
-relationship: part_of MS:1000831 ! sample preparation
+relationship: part_of: MS:1000831 ! sample preparation
 
 [Term]
 id: MS:1000833
 name: matrix application type
 def: "Describes the technique how the matrix is put on the sample target." [PSI:MS]
-relationship: part_of MS:1000832 ! MALDI matrix application
+relationship: part_of: MS:1000832 ! MALDI matrix application
 
 [Term]
 id: MS:1000834
@@ -5767,6 +5302,7 @@ name: matrix solution
 def: "Describes the chemical solution used as matrix." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000832 ! MALDI matrix application
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000835
@@ -5774,7 +5310,8 @@ name: matrix solution concentration
 def: "Concentration of the chemical solution used as matrix." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000832 ! MALDI matrix application
-relationship: has_units UO:0000175 ! gram per liter
+relationship: has_units: UO:0000175 ! gram per liter
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000836
@@ -5805,29 +5342,28 @@ is_a: MS:1001938 ! sample plate type
 id: MS:1000840
 name: laser
 def: "Device that emits light (electromagnetic radiation) through a process called stimulated emission. The term is an acronym for Light Amplification by Stimulated Emission of Radiation." [PSI:MS]
-relationship: part_of MS:1000482 ! source attribute
+relationship: part_of: MS:1000482 ! source attribute
 
 [Term]
 id: MS:1000841
 name: laser attribute
 def: "Laser properties that are associated with a value." [PSI:MS]
-relationship: part_of MS:1000840 ! laser
+relationship: part_of: MS:1000840 ! laser
 
 [Term]
 id: MS:1000842
 name: laser type
 def: "Type of laser used for desorption purpose." [PSI:MS]
-relationship: part_of MS:1000840 ! laser
+relationship: part_of: MS:1000840 ! laser
 
 [Term]
 id: MS:1000843
 name: wavelength
 def: "OBSOLETE The distance between two peaks of the emitted laser beam." [PSI:MS]
-comment: This term was made obsolete because it was redundant with the Pato Ontology term wavelength (UO:0001242).
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000841 ! laser attribute
-relationship: has_units UO:0000018 ! nanometer
-is_obsolete: true
+relationship: has_units: UO:0000018 ! nanometer
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000844
@@ -5835,7 +5371,8 @@ name: focus diameter x
 def: "Describes the diameter of the laser beam in x direction." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000841 ! laser attribute
-relationship: has_units UO:0000017 ! micrometer
+relationship: has_units: UO:0000017 ! micrometer
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000845
@@ -5843,7 +5380,8 @@ name: focus diameter y
 def: "Describes the diameter of the laser beam in y direction." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000841 ! laser attribute
-relationship: has_units UO:0000017 ! micrometer
+relationship: has_units: UO:0000017 ! micrometer
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000846
@@ -5851,7 +5389,8 @@ name: pulse energy
 def: "Describes output energy of the laser system. May be attenuated by filters or other means." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000841 ! laser attribute
-relationship: has_units UO:0000112 ! joule
+relationship: has_units: UO:0000112 ! joule
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000847
@@ -5859,7 +5398,8 @@ name: pulse duration
 def: "Describes how long the laser beam was emitted from the laser device." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000841 ! laser attribute
-relationship: has_units UO:0000150 ! nanosecond
+relationship: has_units: UO:0000150 ! nanosecond
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000848
@@ -5867,7 +5407,8 @@ name: attenuation
 def: "Describes the reduction of the intensity of the laser beam energy." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000841 ! laser attribute
-relationship: has_units UO:0000187 ! percent
+relationship: has_units: UO:0000187 ! percent
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000849
@@ -5875,7 +5416,8 @@ name: impact angle
 def: "Describes the angle between the laser beam and the sample target." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000841 ! laser attribute
-relationship: has_units UO:0000185 ! degree
+relationship: has_units: UO:0000185 ! degree
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000850
@@ -5931,6 +5473,7 @@ name: fraction identifier
 def: "Identier string that describes the sample fraction. This identifier should contain the fraction number(s) or similar information." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000857 ! run attribute
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000859
@@ -5948,23 +5491,23 @@ is_a: MS:1000859 ! molecule
 id: MS:1000861
 name: molecular entity property
 def: "A physical characteristic of a molecular entity." [PSI:MS]
-relationship: part_of MS:1000881 ! molecular entity
+relationship: part_of: MS:1000881 ! molecular entity
 
 [Term]
 id: MS:1000862
 name: isoelectric point
 def: "The pH of a solution at which a charged molecule does not migrate in an electric field." [PSI:MS]
-synonym: "pI" EXACT []
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000861 ! molecular entity property
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000863
 name: predicted isoelectric point
 def: "The pH of a solution at which a charged molecule would not migrate in an electric field, as predicted by a software algorithm." [PSI:MS]
-synonym: "predicted pI" EXACT []
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000862 ! isoelectric point
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000864
@@ -5978,6 +5521,7 @@ name: empirical formula
 def: "A chemical formula which expresses the proportions of the elements present in a substance." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000864 ! chemical formula
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000866
@@ -5985,6 +5529,7 @@ name: molecular formula
 def: "A chemical compound formula expressing the number of atoms of each element present in a compound, without indicating how they are linked." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000864 ! chemical formula
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000867
@@ -5992,6 +5537,7 @@ name: structural formula
 def: "A chemical formula showing the number of atoms of each element in a molecule, their spatial arrangement, and their linkage to each other." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000864 ! chemical formula
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000868
@@ -5999,6 +5545,7 @@ name: SMILES formula
 def: "The simplified molecular input line entry specification or SMILES is a specification for unambiguously describing the structure of a chemical compound using a short ASCII string." [EDAM:2301]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000864 ! chemical formula
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000869
@@ -6006,15 +5553,14 @@ name: collision gas pressure
 def: "The gas pressure of the collision gas used for collisional excitation." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000510 ! precursor activation attribute
-relationship: has_units UO:0000110 ! pascal
+relationship: has_units: UO:0000110 ! pascal
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000870
 name: 4000 QTRAP
 def: "OBSOLETE SCIEX or Applied Biosystems|MDS SCIEX QTRAP 4000." [PSI:MS]
-comment: This term was obsoleted because was redundant to MS:1000139.
 is_a: MS:1000121 ! SCIEX instrument model
-is_obsolete: true
 
 [Term]
 id: MS:1000871
@@ -6046,7 +5592,8 @@ name: declustering potential
 def: "Potential difference between the orifice and the skimmer in volts." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000482 ! source attribute
-relationship: has_units UO:0000218 ! volt
+relationship: has_units: UO:0000218 ! volt
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000876
@@ -6054,7 +5601,8 @@ name: cone voltage
 def: "Potential difference between the sampling cone/orifice in volts." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000482 ! source attribute
-relationship: has_units UO:0000218 ! volt
+relationship: has_units: UO:0000218 ! volt
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000877
@@ -6062,7 +5610,8 @@ name: tube lens voltage
 def: "Potential difference setting of the tube lens in volts." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000482 ! source attribute
-relationship: has_units UO:0000218 ! volt
+relationship: has_units: UO:0000218 ! volt
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000878
@@ -6076,6 +5625,7 @@ name: PubMed identifier
 def: "A unique identifier for a publication in the PubMed database (MIR:00000015)." [PSI:MS]
 xref: value-type:xsd\:integer "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
+relationship: has_value_type: xsd\:integer ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000880
@@ -6083,13 +5633,14 @@ name: interchannel delay
 def: "The duration of intervals between scanning, during which the instrument configuration is switched." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000503 ! scan attribute
-relationship: has_units UO:0000010 ! second
+relationship: has_units: UO:0000010 ! second
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000881
 name: molecular entity
 def: "Constitutionally or isotopically distinct atom, molecule, ion, ion pair, radical, radical ion, complex, conformer, etc., identifiable as a separately distinguishable entity." [https://en.wikipedia.org/wiki/Molecular_entity]
-relationship: part_of MS:0000000 ! Proteomics Standards Initiative Mass Spectrometry Vocabularies
+relationship: part_of: MS:0000000 ! Proteomics Standards Initiative Mass Spectrometry Vocabularies
 
 [Term]
 id: MS:1000882
@@ -6103,13 +5654,14 @@ name: protein short name
 def: "A short name or symbol of a protein (e.g., HSF 1 or HSF1_HUMAN)." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000884 ! protein attribute
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000884
 name: protein attribute
 def: "An nonphysical characterstic attributed to a specific protein." [PSI:MS]
-relationship: part_of MS:1000882 ! protein
 is_a: MS:1001806 ! quantification object attribute
+relationship: part_of: MS:1000882 ! protein
 
 [Term]
 id: MS:1000885
@@ -6118,6 +5670,7 @@ def: "Identifier for a specific protein in a database." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000884 ! protein attribute
 is_a: MS:1003046 ! peptide-to-protein mapping attribute
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000886
@@ -6125,12 +5678,13 @@ name: protein name
 def: "A long name describing the function of the protein." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000884 ! protein attribute
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000887
 name: peptide attribute
 def: "Nonphysical characteristic attributed to a peptide." [PSI:MS]
-relationship: part_of MS:1000860 ! peptide
+relationship: part_of: MS:1000860 ! peptide
 
 [Term]
 id: MS:1000888
@@ -6138,14 +5692,15 @@ name: stripped peptide sequence
 def: "Sequence of letter symbols denoting the order of amino acids that compose the peptide, with any amino acid mass modifications that might be present having been stripped away." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1003050 ! peptidoform attribute
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000889
 name: peptidoform sequence
 def: "Sequence of letter symbols denoting the order of amino acid residues that compose the peptidoform including the encoding of any residue modifications that are present." [PSI:MS]
-comment: Make it more general as there are actually many other ways to display a modified peptide sequence.
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1003050 ! peptidoform attribute
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000890
@@ -6163,7 +5718,6 @@ is_a: MS:1000890 ! peptidoform labeling state
 id: MS:1000892
 name: unlabeled peptidoform
 def: "A peptide that has not been labelled with heavier-than-usual isotopes. This is often referred to as \"light\" to distinguish from \"heavy\"." [PSI:MS]
-synonym: "light labeled peptide" EXACT []
 is_a: MS:1000890 ! peptidoform labeling state
 
 [Term]
@@ -6172,6 +5726,7 @@ name: peptidoform group label
 def: "An arbitrary string label used to mark a set of peptides that belong together in a set, whereby the members are differentiated by different isotopic labels. For example, the heavy and light forms of the same peptide will both be assigned the same peptide group label." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1003050 ! peptidoform attribute
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000894
@@ -6179,8 +5734,9 @@ name: retention time
 def: "A time interval from the start of chromatography when an analyte exits a chromatographic column." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1003050 ! peptidoform attribute
-relationship: has_units UO:0000010 ! second
-relationship: has_units UO:0000031 ! minute
+relationship: has_units: UO:0000010 ! second
+relationship: has_units: UO:0000031 ! minute
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000895
@@ -6188,8 +5744,9 @@ name: local retention time
 def: "A time interval from the start of chromatography when an analyte exits an unspecified local chromatographic column and instrumental setup." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000894 ! retention time
-relationship: has_units UO:0000010 ! second
-relationship: has_units UO:0000031 ! minute
+relationship: has_units: UO:0000010 ! second
+relationship: has_units: UO:0000031 ! minute
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000896
@@ -6197,8 +5754,9 @@ name: normalized retention time
 def: "A time interval from the start of chromatography when an analyte exits a standardized reference chromatographic column and instrumental setup." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000894 ! retention time
-relationship: has_units UO:0000010 ! second
-relationship: has_units UO:0000031 ! minute
+relationship: has_units: UO:0000010 ! second
+relationship: has_units: UO:0000031 ! minute
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000897
@@ -6206,14 +5764,15 @@ name: predicted retention time
 def: "A time interval from the start of chromatography when an analyte exits a chromatographic column as predicted by a referenced software application." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000894 ! retention time
-relationship: has_units UO:0000010 ! second
-relationship: has_units UO:0000031 ! minute
+relationship: has_units: UO:0000010 ! second
+relationship: has_units: UO:0000031 ! minute
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000898
 name: standard
 def: "Something, such as a practice or a product, that is widely recognized or employed, especially because of its excellence." [PSI:MS]
-relationship: part_of MS:0000000 ! Proteomics Standards Initiative Mass Spectrometry Vocabularies
+relationship: part_of: MS:0000000 ! Proteomics Standards Initiative Mass Spectrometry Vocabularies
 
 [Term]
 id: MS:1000899
@@ -6245,13 +5804,14 @@ name: product ion series ordinal
 def: "The ordinal of the fragment within a specified ion series. (e.g. 8 for a y8 ion)." [PSI:PI]
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1001221 ! product ion attribute
+relationship: has_value_type: xsd\:positiveInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000904
 name: product ion m/z delta
 def: "The difference in m/z of the predicted m/z based on the assigned product ion minus the actual observed peak m/z." [PSI:PI]
 is_a: MS:1001221 ! product ion attribute
-relationship: has_units MS:1000040 ! m/z
+relationship: has_units: MS:1000040 ! m/z
 
 [Term]
 id: MS:1000905
@@ -6259,6 +5819,7 @@ name: percent of base peak times 100
 def: "The magnitude of a peak expressed in terms of the percentage of the magnitude of the base peak intensity multiplied by 100. The base peak is therefore 10000. This unit is common in normalized spectrum libraries." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000043 ! intensity unit
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000906
@@ -6266,7 +5827,8 @@ name: peak intensity rank
 def: "Ordinal specifying the rank in intensity of a peak in a spectrum. Base peak is 1. The next most intense peak is 2, etc." [PSI:MS]
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1000455 ! ion selection attribute
-relationship: part_of MS:1000231 ! peak
+relationship: part_of: MS:1000231 ! peak
+relationship: has_value_type: xsd\:positiveInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000907
@@ -6274,20 +5836,20 @@ name: peak targeting suitability rank
 def: "Ordinal specifying the rank of a peak in a spectrum in terms of suitability for targeting. The most suitable peak is 1. The next most suitability peak is 2, etc. Suitability is algorithm and context dependant." [PSI:MS]
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1000455 ! ion selection attribute
-relationship: part_of MS:1000231 ! peak
+relationship: part_of: MS:1000231 ! peak
+relationship: has_value_type: xsd\:positiveInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000908
 name: transition
 def: "A set of two m/z values corresponding to the precursor m/z and a fragment m/z that in combination can be used to identify or quantify a specific ion, although not necessarily uniquely." [PSI:MS]
-synonym: "reaction" EXACT []
-relationship: part_of MS:1001458 ! spectrum generation information
+relationship: part_of: MS:1001458 ! spectrum generation information
 
 [Term]
 id: MS:1000909
 name: transition validation method
 def: "The strategy used to validate that a transition is effective." [PSI:MS]
-relationship: part_of MS:1000908 ! transition
+relationship: part_of: MS:1000908 ! transition
 
 [Term]
 id: MS:1000910
@@ -6324,7 +5886,7 @@ is_a: MS:1001040 ! intermediate analysis format
 id: MS:1000915
 name: retention time window attribute
 def: "An attribute of a window in time about which a peptide might elute from the column." [PSI:MS]
-relationship: part_of MS:1000894 ! retention time
+relationship: part_of: MS:1000894 ! retention time
 
 [Term]
 id: MS:1000916
@@ -6332,8 +5894,9 @@ name: retention time window lower offset
 def: "The extent of the retention time window in time units below the target retention time. The lower and upper offsets may be asymmetric about the target time." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000915 ! retention time window attribute
-relationship: has_units UO:0000010 ! second
-relationship: has_units UO:0000031 ! minute
+relationship: has_units: UO:0000010 ! second
+relationship: has_units: UO:0000031 ! minute
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000917
@@ -6341,20 +5904,21 @@ name: retention time window upper offset
 def: "The extent of the retention time window in time units above the target retention time. The lower and upper offsets may be asymmetric about the target time." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000915 ! retention time window attribute
-relationship: has_units UO:0000010 ! second
-relationship: has_units UO:0000031 ! minute
+relationship: has_units: UO:0000010 ! second
+relationship: has_units: UO:0000031 ! minute
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000918
 name: target list
 def: "A list of peptides or compounds and their expected m/z coordinates that can be used to cause a mass spectrometry to obtain spectra of those molecules specifically." [PSI:MS]
-relationship: part_of MS:1001458 ! spectrum generation information
+relationship: part_of: MS:1001458 ! spectrum generation information
 
 [Term]
 id: MS:1000919
 name: target inclusion exclusion priority
 def: "A priority setting specifying whether included or excluded targets have priority over the other." [PSI:MS]
-relationship: part_of MS:1000918 ! target list
+relationship: part_of: MS:1000918 ! target list
 
 [Term]
 id: MS:1000920
@@ -6385,9 +5949,6 @@ is_a: MS:1000871 ! SRM software
 id: MS:1000924
 name: MaRiMba
 def: "OBSOLETE Software used to predict transitions for selected reaction monitoring experiments based on observed spectrum libraries developed and distributed by the Institute for Systems Biology." [http://tools.proteomecenter.org/wiki/index.php?title=Software:TPP-MaRiMba]
-comment: This term was made obsolete because it was redundant with an existing term (MS:1000872).
-is_obsolete: true
-replaced_by: MS:1000872
 
 [Term]
 id: MS:1000925
@@ -6401,6 +5962,7 @@ name: product interpretation rank
 def: "The integer rank given an interpretation of an observed product ion. For example, if y8 is selected as the most likely interpretation of a peak, then it is assigned a rank of 1." [PSI:MS]
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1001221 ! product ion attribute
+relationship: has_value_type: xsd\:positiveInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000927
@@ -6408,7 +5970,8 @@ name: ion injection time
 def: "The length of time spent filling an ion trapping device." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000503 ! scan attribute
-relationship: has_units UO:0000028 ! millisecond
+relationship: has_units: UO:0000028 ! millisecond
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000928
@@ -6446,6 +6009,7 @@ name: protein modifications
 def: "Encoding of modifications of the protein sequence from the specified accession, written in PEFF notation." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000884 ! protein attribute
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1000934
@@ -6453,18 +6017,21 @@ name: gene name
 def: "Name of the gene from which the protein is translated." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000884 ! protein attribute
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001000
 name: spectrum interpretation
 def: "Collection of terms from the PSI Proteome Informatics standards describing the interpretation of spectra." [PSI:PI]
-relationship: part_of MS:0000000 ! Proteomics Standards Initiative Mass Spectrometry Vocabularies
+relationship: part_of: MS:0000000 ! Proteomics Standards Initiative Mass Spectrometry Vocabularies
 
 [Term]
 id: MS:1001005
 name: SEQUEST:CleavesAt
+def:
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002096 ! SEQUEST input parameter
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001006
@@ -6478,6 +6045,7 @@ name: SEQUEST:OutputLines
 def: "Number of peptide results to show." [PSI:MS]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1002096 ! SEQUEST input parameter
+relationship: has_value_type: xsd\:nonNegativeInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001009
@@ -6485,6 +6053,7 @@ name: SEQUEST:DescriptionLines
 def: "Number of full protein descriptions to show for top N peptides." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002096 ! SEQUEST input parameter
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001010
@@ -6504,6 +6073,7 @@ name: database source
 def: "The organisation, project or laboratory from where the database is obtained (UniProt, NCBI, EBI, other)." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001011 ! search database details
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001013
@@ -6516,7 +6086,6 @@ id: MS:1001014
 name: database local file path
 def: "OBSOLETE: Use attribute in mzIdentML instead. Local file path of the search database from the search engine's point of view." [PSI:PI]
 is_a: MS:1001011 ! search database details
-is_obsolete: true
 
 [Term]
 id: MS:1001015
@@ -6524,6 +6093,7 @@ name: database original uri
 def: "URI, from where the search database was originally downloaded." [PSI:PI]
 xref: value-type:xsd\:anyURI "The allowed value-type for this CV term."
 is_a: MS:1001011 ! search database details
+relationship: has_value_type: xsd\:anyURI ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001016
@@ -6531,13 +6101,13 @@ name: database version
 def: "Version of the search database. In mzIdentML use the attribute instead." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001011 ! search database details
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001017
 name: database release date
 def: "OBSOLETE: Use attribute in mzIdentML instead. Release date of the search database." [PSI:PI]
 is_a: MS:1001011 ! search database details
-is_obsolete: true
 
 [Term]
 id: MS:1001018
@@ -6587,12 +6157,15 @@ name: translation table
 def: "The translation table used to translate the nucleotides to amino acids." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001011 ! search database details
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001026
 name: SEQUEST:NormalizeXCorrValues
+def:
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002096 ! SEQUEST input parameter
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001027
@@ -6606,6 +6179,7 @@ name: SEQUEST:SequenceHeaderFilter
 def: "String in the header of a sequence entry for that entry to be searched." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002096 ! SEQUEST input parameter
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001029
@@ -6613,6 +6187,7 @@ name: number of sequences searched
 def: "The number of sequences (proteins / nucleotides) from the database search after filtering." [PSI:PI]
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1001011 ! search database details
+relationship: has_value_type: xsd\:positiveInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001030
@@ -6621,6 +6196,7 @@ def: "Number of peptide seqs compared to each spectrum." [PSI:PI]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1001011 ! search database details
 is_a: MS:1001405 ! spectrum identification result details
+relationship: has_value_type: xsd\:nonNegativeInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001031
@@ -6631,15 +6207,16 @@ is_a: MS:1001080 ! search type
 [Term]
 id: MS:1001032
 name: SEQUEST:SequencePartialFilter
+def:
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002096 ! SEQUEST input parameter
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001035
 name: date / time search performed
 def: "OBSOLETE: use attribute in mzIdentML instead. Date and time of the actual search run." [PSI:PI]
 is_a: MS:1001184 ! search statistics
-is_obsolete: true
 
 [Term]
 id: MS:1001036
@@ -6647,6 +6224,7 @@ name: search time taken
 def: "The time taken to complete the search in seconds." [PSI:PI]
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1001184 ! search statistics
+relationship: has_value_type: xsd\:positiveInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001037
@@ -6654,6 +6232,7 @@ name: SEQUEST:ShowFragmentIons
 def: "Flag indicating that fragment ions should be shown." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002096 ! SEQUEST input parameter
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001038
@@ -6661,6 +6240,7 @@ name: SEQUEST:Consensus
 def: "Specify depth as value of the CVParam." [PSI:PI]
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1001006 ! SEQUEST:ViewCV
+relationship: has_value_type: xsd\:positiveInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001040
@@ -6680,6 +6260,7 @@ name: SEQUEST:LimitTo
 def: "Specify \"number of dtas shown\" as value of the CVParam." [PSI:PI]
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1002096 ! SEQUEST input parameter
+relationship: has_value_type: xsd\:positiveInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001044
@@ -6699,6 +6280,7 @@ name: SEQUEST:sort by dCn
 def: "Sort order of SEQUEST search results by the delta of the normalized correlation score." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001041 ! SEQUEST:sortCV
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001047
@@ -6706,6 +6288,7 @@ name: SEQUEST:sort by dM
 def: "Sort order of SEQUEST search results by the difference between a theoretically calculated and the corresponding experimentally measured molecular mass M." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001041 ! SEQUEST:sortCV
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001048
@@ -6713,6 +6296,7 @@ name: SEQUEST:sort by Ions
 def: "Sort order of SEQUEST search results given by the ions." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001041 ! SEQUEST:sortCV
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001049
@@ -6720,6 +6304,7 @@ name: SEQUEST:sort by MH+
 def: "Sort order of SEQUEST search results given by the mass of the protonated ion." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001041 ! SEQUEST:sortCV
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001050
@@ -6727,13 +6312,14 @@ name: SEQUEST:sort by P
 def: "Sort order of SEQUEST search results given by the probability." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001041 ! SEQUEST:sortCV
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001051
 name: multiple enzyme combination rules
 def: "OBSOLETE: use attribute independent in mzIdentML instead. Description of multiple enzyme digestion protocol, if any." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
-is_obsolete: true
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001052
@@ -6741,6 +6327,7 @@ name: SEQUEST:sort by PreviousAminoAcid
 def: "Sort order of SEQUEST search results given by the previous amino acid." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001041 ! SEQUEST:sortCV
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001053
@@ -6748,12 +6335,13 @@ name: SEQUEST:sort by Ref
 def: "Sort order of SEQUEST search results given by the reference." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001041 ! SEQUEST:sortCV
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001055
 name: modification parameters
 def: "Modification parameters for the search engine run." [PSI:PI]
-relationship: part_of MS:1001000 ! spectrum interpretation
+relationship: part_of: MS:1001000 ! spectrum interpretation
 
 [Term]
 id: MS:1001056
@@ -6766,7 +6354,6 @@ id: MS:1001057
 name: tolerance on types
 def: "OBSOLETE: Tolerance on types." [PSI:PI]
 is_a: MS:1001055 ! modification parameters
-is_obsolete: true
 
 [Term]
 id: MS:1001058
@@ -6780,6 +6367,7 @@ name: SEQUEST:sort by RSp
 def: "Sort order of SEQUEST search results given by the result 'Sp' of 'Rank/Sp' in the out file (peptide)." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001041 ! SEQUEST:sortCV
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001060
@@ -6792,8 +6380,6 @@ id: MS:1001061
 name: neutral loss
 def: "OBSOLETE: replaced by MS:1000336 (neutral loss): Leave this to PSI-MOD." [PSI:PI]
 is_a: MS:1001055 ! modification parameters
-is_obsolete: true
-replaced_by: MS:1000336
 
 [Term]
 id: MS:1001062
@@ -6805,10 +6391,7 @@ is_a: MS:1000560 ! mass spectrometer file format
 id: MS:1001065
 name: TODOscoring model
 def: "OBSOLETE: There is Phenyx:ScoringModel for Phenyx! Scoring model (more detailed granularity). TODO: add some child terms." [PSI:PI]
-comment: This term was made obsolete and is replaced by the term (MS:1001961).
 is_a: MS:1001249 ! search input details
-is_obsolete: true
-replaced_by: MS:1001961
 
 [Term]
 id: MS:1001066
@@ -6822,6 +6405,7 @@ name: SEQUEST:sort by Sp
 def: "Sort order of SEQUEST search results by the Sp score." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001041 ! SEQUEST:sortCV
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001069
@@ -6829,6 +6413,7 @@ name: SEQUEST:sort by TIC
 def: "Sort order of SEQUEST search results given by the total ion current." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001041 ! SEQUEST:sortCV
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001070
@@ -6836,6 +6421,7 @@ name: SEQUEST:sort by Scan
 def: "Sort order of SEQUEST search results given by the scan number." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001041 ! SEQUEST:sortCV
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001071
@@ -6843,6 +6429,7 @@ name: SEQUEST:sort by Sequence
 def: "Sort order of SEQUEST search results given by the sequence." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001041 ! SEQUEST:sortCV
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001072
@@ -6850,6 +6437,7 @@ name: SEQUEST:sort by Sf
 def: "Sort order of SEQUEST search results given by the SEQUEST result 'Sf'." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001041 ! SEQUEST:sortCV
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001073
@@ -6905,6 +6493,7 @@ name: SEQUEST:sort by XCorr
 def: "Sort order of SEQUEST search results by the correlation score." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001041 ! SEQUEST:sortCV
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001087
@@ -6919,6 +6508,7 @@ def: "The protein description line from the sequence entry in the source databas
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001085 ! protein-level identification attribute
 is_a: MS:1001342 ! database sequence details
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001089
@@ -6928,24 +6518,19 @@ xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001085 ! protein-level identification attribute
 is_a: MS:1001342 ! database sequence details
 is_a: MS:1001512 ! Sequence database filters
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001090
 name: taxonomy nomenclature
 def: "OBSOLETE: The system used to indicate taxonomy. There should be an enumerated list of options: latin name, NCBI TaxID, common name, Swiss-Prot species ID (ex. RABIT from the full protein ID ALBU_RABIT)." [PSI:PI]
 is_a: MS:1001089 ! molecule taxonomy
-is_obsolete: true
-replaced_by: MS:1001467
-replaced_by: MS:1001468
-replaced_by: MS:1001469
-replaced_by: MS:1001470
 
 [Term]
 id: MS:1001091
 name: NoEnzyme
+def:
 is_a: MS:1001045 ! cleavage agent name
-comment: This term was made obsolete because it is ambiguous and is replaced by NoCleavage (MS:1001955) and unspecific cleavage (MS:1001956).
-is_obsolete: true
 
 [Term]
 id: MS:1001092
@@ -6959,6 +6544,7 @@ name: sequence coverage
 def: "The percent coverage for the protein based upon the matched peptide sequences (can be calculated)." [PSI:PI]
 xref: value-type:xsd\:decimal "The allowed value-type for this CV term."
 is_a: MS:1001085 ! protein-level identification attribute
+relationship: has_value_type: xsd\:decimal ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001094
@@ -6966,12 +6552,15 @@ name: SEQUEST:sort by z
 def: "Sort order of SEQUEST search results given by the charge." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001041 ! SEQUEST:sortCV
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001095
 name: SEQUEST:ProcessAll
+def:
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001087 ! SEQUEST:ProcessCV
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001096
@@ -6979,6 +6568,7 @@ name: SEQUEST:TopPercentMostIntense
 def: "Specify \"percentage\" as value of the CVParam." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001087 ! SEQUEST:ProcessCV
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001097
@@ -6986,6 +6576,7 @@ name: distinct peptide sequences
 def: "This counts distinct sequences hitting the protein without regard to a minimal confidence threshold." [PSI:PI]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1001085 ! protein-level identification attribute
+relationship: has_value_type: xsd\:nonNegativeInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001098
@@ -6993,6 +6584,7 @@ name: confident distinct peptide sequences
 def: "This counts the number of distinct peptide sequences. Multiple charge states and multiple modification states do NOT count as multiple sequences. The definition of 'confident' must be qualified elsewhere." [PSI:PI]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1001085 ! protein-level identification attribute
+relationship: has_value_type: xsd\:nonNegativeInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001099
@@ -7000,6 +6592,7 @@ name: confident peptide qualification
 def: "The point of this entry is to define what is meant by confident for the term Confident distinct peptide sequence and/or Confident peptides. Example 1 - metric=Paragon:Confidence value=95 sense=greater than Example 2 - metric=Mascot:Eval value=0.05 sense=less than." [PSI:PI]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1001085 ! protein-level identification attribute
+relationship: has_value_type: xsd\:nonNegativeInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001100
@@ -7007,6 +6600,7 @@ name: confident peptide sequence number
 def: "This counts the number of peptide sequences without regard to whether they are distinct. Multiple charges states and multiple modification states DO count as multiple peptides. The definition of 'confident' must be qualified elsewhere." [PSI:PI]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1001085 ! protein-level identification attribute
+relationship: has_value_type: xsd\:nonNegativeInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001101
@@ -7017,14 +6611,18 @@ is_a: MS:1001085 ! protein-level identification attribute
 [Term]
 id: MS:1001102
 name: SEQUEST:Chromatogram
+def:
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001006 ! SEQUEST:ViewCV
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001103
 name: SEQUEST:InfoAndLog
+def:
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001006 ! SEQUEST:ViewCV
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001104
@@ -7044,6 +6642,7 @@ name: SEQUEST:TopNumber
 def: "Specify \"number\" as value of the CVParam." [PSI:PI]
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1001087 ! SEQUEST:ProcessCV
+relationship: has_value_type: xsd\:positiveInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001107
@@ -7063,6 +6662,7 @@ name: SEQUEST:CullTo
 def: "Specify cull string as value of the CVParam." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001087 ! SEQUEST:ProcessCV
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001110
@@ -7073,8 +6673,10 @@ is_a: MS:1002096 ! SEQUEST input parameter
 [Term]
 id: MS:1001111
 name: SEQUEST:Full
+def:
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001110 ! SEQUEST:modeCV
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001112
@@ -7083,6 +6685,7 @@ def: "Residue preceding the first amino acid in the peptide sequence as it occur
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1003046 ! peptide-to-protein mapping attribute
 is_a: MS:1001105 ! peptide sequence-level identification attribute
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001113
@@ -7091,24 +6694,22 @@ def: "Residue following the last amino acid in the peptide sequence as it occurs
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1003046 ! peptide-to-protein mapping attribute
 is_a: MS:1001105 ! peptide sequence-level identification attribute
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001114
 name: retention time(s)
 def: "OBSOLETE Retention time of the spectrum from the source file." [PSI:PI]
-comment: This term was made obsolete because scan start time (MS:1000016) should be used instead.
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001105 ! peptide sequence-level identification attribute
-relationship: has_units UO:0000010 ! second
-relationship: has_units UO:0000031 ! minute
-is_obsolete: true
+relationship: has_units: UO:0000010 ! second
+relationship: has_units: UO:0000031 ! minute
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001115
 name: scan number(s)
 def: "OBSOLETE: use spectrumID attribute of SpectrumIdentificationResult. Take from mzData." [PSI:PI]
-comment: This former purgatory term was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1001116
@@ -7122,7 +6723,8 @@ name: theoretical mass
 def: "The theoretical mass of the molecule (e.g. the peptide sequence and its modifications)." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001105 ! peptide sequence-level identification attribute
-relationship: has_units UO:0000221 ! dalton
+relationship: has_units: UO:0000221 ! dalton
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001118
@@ -7139,8 +6741,10 @@ is_a: MS:1002473 ! ion series considered in search
 [Term]
 id: MS:1001120
 name: SEQUEST:FormatAndLinks
+def:
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001110 ! SEQUEST:modeCV
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001121
@@ -7148,6 +6752,7 @@ name: number of matched peaks
 def: "The number of peaks that were matched as qualified by the ion series considered field. If a peak matches multiple ions then only 1 would be added the count." [PSI:PI]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1001105 ! peptide sequence-level identification attribute
+relationship: has_value_type: xsd\:nonNegativeInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001122
@@ -7161,6 +6766,7 @@ name: number of peaks used
 def: "The number of peaks from the original peak list that are used to calculate the scores for a particular search engine. All ions that have the opportunity to match or be counted even if they don't." [PSI:PI]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1001105 ! peptide sequence-level identification attribute
+relationship: has_value_type: xsd\:nonNegativeInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001124
@@ -7168,6 +6774,7 @@ name: number of peaks submitted
 def: "The number of peaks from the original peaks listed that were submitted to the search engine." [PSI:PI]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1001105 ! peptide sequence-level identification attribute
+relationship: has_value_type: xsd\:nonNegativeInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001125
@@ -7176,12 +6783,15 @@ def: "Result of quality estimation: decision of a manual validation." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001092 ! peptide sequence-level identification statistic
 is_a: MS:1001116 ! single protein identification statistic
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001126
 name: SEQUEST:Fast
+def:
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001110 ! SEQUEST:modeCV
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001127
@@ -7199,16 +6809,15 @@ is_a: MS:1002096 ! SEQUEST input parameter
 id: MS:1001129
 name: quantification information
 def: "Quantification information." [PSI:PI]
-relationship: part_of MS:1001000 ! spectrum interpretation
+relationship: part_of: MS:1001000 ! spectrum interpretation
 
 [Term]
 id: MS:1001130
 name: peptide raw area
 def: "OBSOLETE Peptide raw area." [PSI:PI]
-comment: This term was made obsolete because it is replaced by 'MS1 feature area' (MS:1001844).
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002737 ! peptide-level quantification datatype
-is_obsolete: true
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001131
@@ -7216,6 +6825,7 @@ name: error on peptide area
 def: "Error on peptide area." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002737 ! peptide-level quantification datatype
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001132
@@ -7223,6 +6833,7 @@ name: peptide ratio
 def: "Peptide ratio." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002737 ! peptide-level quantification datatype
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001133
@@ -7230,6 +6841,7 @@ name: error on peptide ratio
 def: "Error on peptide ratio." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002737 ! peptide-level quantification datatype
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001134
@@ -7237,6 +6849,7 @@ name: protein ratio
 def: "Protein ratio." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002738 ! protein-level quantification datatype
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001135
@@ -7244,15 +6857,15 @@ name: error on protein ratio
 def: "Error on protein ratio." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002738 ! protein-level quantification datatype
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001136
 name: p-value (protein diff from 1 randomly)
 def: "OBSOLETE P-value (protein diff from 1 randomly)." [PSI:PI]
-comment: This term was made obsolete because it is replaced by 't-test p-value' (MS:1001855).
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002738 ! protein-level quantification datatype
-is_obsolete: true
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001137
@@ -7260,6 +6873,7 @@ name: absolute quantity
 def: "Absolute quantity in terms of real concentration or molecule copy number in sample." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001138
@@ -7267,6 +6881,7 @@ name: error on absolute quantity
 def: "Error on absolute quantity." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001139
@@ -7279,9 +6894,7 @@ is_a: MS:1001129 ! quantification information
 id: MS:1001140
 name: quantitation software version
 def: "OBSOLETE Quantitation software version." [PSI:PI]
-comment: This term was made obsolete because part of mzQuantML schema.
 is_a: MS:1001129 ! quantification information
-is_obsolete: true
 
 [Term]
 id: MS:1001141
@@ -7289,6 +6902,7 @@ name: intensity of precursor ion
 def: "The intensity of the precursor ion." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001142
@@ -7305,6 +6919,7 @@ is_a: MS:1002347 ! PSM-level identification statistic
 [Term]
 id: MS:1001144
 name: SEQUEST:SelectDefault
+def:
 is_a: MS:1001128 ! SEQUEST:selectCV
 
 [Term]
@@ -7322,6 +6937,7 @@ is_a: MS:1001066 ! ions series considered in search
 [Term]
 id: MS:1001147
 name: protein ambiguity group result details
+def:
 is_a: MS:1001085 ! protein-level identification attribute
 is_a: MS:1001153 ! search engine specific score
 
@@ -7352,7 +6968,7 @@ is_a: MS:1001066 ! ions series considered in search
 [Term]
 id: MS:1001152
 name: param: y ion-H2O DEPRECATED
-comment: This term was made obsolete - use MS:1001262 and MS:1002455 instead.
+def:
 is_a: MS:1001066 ! ions series considered in search
 
 [Term]
@@ -7367,6 +6983,7 @@ name: SEQUEST:probability
 def: "The SEQUEST result 'Probability'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001155
@@ -7374,7 +6991,8 @@ name: SEQUEST:xcorr
 def: "The SEQUEST result 'XCorr'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_order MS:1002108 ! higher score better
+relationship: has_order: MS:1002108 ! higher score better
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001156
@@ -7382,6 +7000,7 @@ name: SEQUEST:deltacn
 def: "The SEQUEST result 'DeltaCn'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001157
@@ -7389,12 +7008,15 @@ name: SEQUEST:sp
 def: "The SEQUEST result 'Sp' (protein)." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001158
 name: SEQUEST:Uniq
+def:
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001159
@@ -7402,6 +7024,7 @@ name: SEQUEST:expectation value
 def: "The SEQUEST result 'Expectation value'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001153 ! search engine specific score
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001160
@@ -7409,6 +7032,7 @@ name: SEQUEST:sf
 def: "The SEQUEST result 'Sf'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001161
@@ -7416,6 +7040,7 @@ name: SEQUEST:matched ions
 def: "The SEQUEST result 'Matched Ions'." [PSI:PI]
 xref: value-type:xsd\:integer "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type: xsd\:integer ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001162
@@ -7423,6 +7048,7 @@ name: SEQUEST:total ions
 def: "The SEQUEST result 'Total Ions'." [PSI:PI]
 xref: value-type:xsd\:integer "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type: xsd\:integer ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001163
@@ -7430,6 +7056,7 @@ name: SEQUEST:consensus score
 def: "The SEQUEST result 'Consensus Score'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001153 ! search engine specific score
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001164
@@ -7438,6 +7065,7 @@ def: "The Paragon result 'Unused ProtScore'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
 is_a: MS:1002368 ! search engine specific score for protein groups
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001165
@@ -7446,6 +7074,7 @@ def: "The Paragon result 'Total ProtScore'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
 is_a: MS:1002368 ! search engine specific score for protein groups
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001166
@@ -7453,6 +7082,7 @@ name: Paragon:score
 def: "The Paragon result 'Score'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001167
@@ -7460,6 +7090,7 @@ name: Paragon:confidence
 def: "The Paragon result 'Confidence'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001168
@@ -7467,6 +7098,7 @@ name: Paragon:expression error factor
 def: "The Paragon result 'Expression Error Factor'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001169
@@ -7474,6 +7106,7 @@ name: Paragon:expression change p-value
 def: "The Paragon result 'Expression change P-value'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001170
@@ -7481,6 +7114,7 @@ name: Paragon:contrib
 def: "The Paragon result 'Contrib'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001171
@@ -7488,6 +7122,7 @@ name: Mascot:score
 def: "The Mascot result 'Score'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001172
@@ -7495,6 +7130,7 @@ name: Mascot:expectation value
 def: "The Mascot result 'expectation value'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001173
@@ -7502,6 +7138,7 @@ name: Mascot:matched ions
 def: "The Mascot result 'Matched ions'." [PSI:PI]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type: xsd\:nonNegativeInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001174
@@ -7509,6 +7146,7 @@ name: Mascot:total ions
 def: "The Mascot result 'Total ions'." [PSI:PI]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type: xsd\:nonNegativeInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001175
@@ -7528,6 +7166,7 @@ name: number of molecular hypothesis considered
 def: "Number of Molecular Hypothesis Considered - This is the number of molecules (e.g. peptides for proteomics) considered for a particular search." [PSI:PI]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1001184 ! search statistics
+relationship: has_value_type: xsd\:nonNegativeInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001178
@@ -7539,8 +7178,8 @@ is_a: MS:1001079 ! database type nucleotide
 id: MS:1001180
 name: Cleavage agent regular expression
 def: "Regular expressions for cleavage enzymes." [PSI:PI]
-relationship: part_of MS:1001044 ! cleavage agent details
 is_a: MS:1002479 ! regular expression
+relationship: part_of: MS:1001044 ! cleavage agent details
 
 [Term]
 id: MS:1001184
@@ -7564,11 +7203,10 @@ is_a: MS:1001056 ! modification specificity rule
 id: MS:1001191
 name: p-value
 def: "OBSOLETE Quality estimation by p-value." [PSI:PI]
-comment: This term was made obsolete because now is split into peptide and protein terms.
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001092 ! peptide sequence-level identification statistic
 is_a: MS:1001198 ! protein identification confidence metric
-is_obsolete: true
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001192
@@ -7577,6 +7215,7 @@ def: "Result of quality estimation: Expect value." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001092 ! peptide sequence-level identification statistic
 is_a: MS:1001116 ! single protein identification statistic
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001193
@@ -7585,6 +7224,7 @@ def: "Result of quality estimation: confidence score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001092 ! peptide sequence-level identification statistic
 is_a: MS:1001116 ! single protein identification statistic
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001194
@@ -7592,6 +7232,7 @@ name: quality estimation with decoy database
 def: "Quality estimation by decoy database." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001060 ! quality estimation method details
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001195
@@ -7635,8 +7276,9 @@ name: DB MW filter maximum
 def: "Maximum value of molecular weight filter." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001512 ! Sequence database filters
-relationship: has_units UO:0000221 ! dalton
-relationship: has_units UO:0000222 ! kilodalton
+relationship: has_units: UO:0000221 ! dalton
+relationship: has_units: UO:0000222 ! kilodalton
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001202
@@ -7644,8 +7286,9 @@ name: DB MW filter minimum
 def: "Minimum value of molecular weight filter." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001512 ! Sequence database filters
-relationship: has_units UO:0000221 ! dalton
-relationship: has_units UO:0000222 ! kilodalton
+relationship: has_units: UO:0000221 ! dalton
+relationship: has_units: UO:0000222 ! kilodalton
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001203
@@ -7653,6 +7296,7 @@ name: DB PI filter maximum
 def: "Maximum value of isoelectric point filter." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001512 ! Sequence database filters
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001204
@@ -7660,6 +7304,7 @@ name: DB PI filter minimum
 def: "Minimum value of isoelectric point filter." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001512 ! Sequence database filters
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001207
@@ -7701,8 +7346,6 @@ is_a: MS:1001210 ! mass type settings
 id: MS:1001213
 name: search result details
 def: "OBSOLETE: Scores and global result characteristics." [PSI:PI]
-comment: This former purgatory term was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1001214
@@ -7710,7 +7353,8 @@ name: protein-level global FDR
 def: "Estimation of the global false discovery rate of proteins." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002705 ! protein-level result list statistic
-relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_domain: MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001215
@@ -7718,6 +7362,7 @@ name: SEQUEST:PeptideSp
 def: "The SEQUEST result 'Sp' in out file (peptide)." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001217
@@ -7725,6 +7370,7 @@ name: SEQUEST:PeptideRankSp
 def: "The SEQUEST result 'Sp' of 'Rank/Sp' in out file (peptide). Also called 'rsp'." [PSI:PI]
 xref: value-type:xsd\:integer "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type: xsd\:integer ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001218
@@ -7732,6 +7378,7 @@ name: SEQUEST:PeptideNumber
 def: "The SEQUEST result '#' in out file (peptide)." [PSI:PI]
 xref: value-type:xsd\:integer "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type: xsd\:integer ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001219
@@ -7739,6 +7386,7 @@ name: SEQUEST:PeptideIdnumber
 def: "The SEQUEST result 'Id#' in out file (peptide)." [PSI:PI]
 xref: value-type:xsd\:integer "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type: xsd\:integer ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001220
@@ -7774,28 +7422,26 @@ is_a: MS:1002307 ! fragmentation ion type
 id: MS:1001225
 name: product ion m/z
 def: "The m/z of the product ion." [PSI:PI]
-synonym: "fragment ion m/z" EXACT []
 is_a: MS:1001221 ! product ion attribute
-relationship: has_units MS:1000040 ! m/z
+relationship: has_units: MS:1000040 ! m/z
 
 [Term]
 id: MS:1001226
 name: product ion intensity
 def: "The intensity of a single product ion." [PSI:PI]
-synonym: "fragment ion intensity" EXACT []
 is_a: MS:1001221 ! product ion attribute
-relationship: has_units MS:1000131 ! number of detector counts
-relationship: has_units MS:1000132 ! percent of base peak
-relationship: has_units MS:1000814 ! counts per second
-relationship: has_units MS:1000905 ! percent of base peak times 100
+relationship: has_units: MS:1000131 ! number of detector counts
+relationship: has_units: MS:1000132 ! percent of base peak
+relationship: has_units: MS:1000814 ! counts per second
+relationship: has_units: MS:1000905 ! percent of base peak times 100
 
 [Term]
 id: MS:1001227
 name: product ion m/z error
 def: "The product ion m/z error." [PSI:PI]
 is_a: MS:1001221 ! product ion attribute
-relationship: has_units MS:1000040 ! m/z
-relationship: has_units UO:0000166 ! parts per notation unit
+relationship: has_units: MS:1000040 ! m/z
+relationship: has_units: UO:0000166 ! parts per notation unit
 
 [Term]
 id: MS:1001228
@@ -7915,7 +7561,7 @@ is_a: MS:1000560 ! mass spectrometer file format
 id: MS:1001249
 name: search input details
 def: "Details describing the search input." [PSI:PI]
-relationship: part_of MS:1001000 ! spectrum interpretation
+relationship: part_of: MS:1001000 ! spectrum interpretation
 
 [Term]
 id: MS:1001250
@@ -7924,13 +7570,14 @@ def: "Result of quality estimation: the local FDR at the current position of a s
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001092 ! peptide sequence-level identification statistic
 is_a: MS:1001116 ! single protein identification statistic
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001251
 name: Trypsin
 def: "Enzyme trypsin." [PSI:PI]
 is_a: MS:1001045 ! cleavage agent name
-relationship: has_regexp MS:1001176 ! (?<=[KR])(?!P)
+relationship: has_regexp: MS:1001176 ! (?<=[KR])(?!P)
 
 [Term]
 id: MS:1001252
@@ -8022,6 +7669,7 @@ name: programmer
 def: "Programmer role." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001266 ! role type
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001269
@@ -8029,6 +7677,7 @@ name: instrument vendor
 def: "Instrument vendor role." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001266 ! role type
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001270
@@ -8036,6 +7685,7 @@ name: lab personnel
 def: "Lab personnel role." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001266 ! role type
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001271
@@ -8079,14 +7729,13 @@ name: decoy DB accession regexp
 def: "Specify the regular expression for decoy accession numbers." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001450 ! decoy DB details
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001284
 name: decoy DB derived from
 def: "OBSOLETE The name of the database, the search database was derived from." [PSI:PI]
-comment: This term was made obsolete, because a combination of database name, DB composition , decoy DB type , decoy DB generation algorithm, decoy DB accession regexp and decoy DB details suffices.
 is_a: MS:1001450 ! decoy DB details
-is_obsolete: true
 
 [Term]
 id: MS:1001285
@@ -8128,71 +7777,51 @@ is_a: MS:1001013 ! database name
 id: MS:1001291
 name: decoy DB from nr
 def: "OBSOLETE Decoy database from a non-redundant GenBank sequence database." [PSI:PI]
-comment: This term was made obsolete, because a combination of database name, DB composition , decoy DB type , decoy DB generation algorithm, decoy DB accession regexp and decoy DB details suffices.
-is_obsolete: true
 
 [Term]
 id: MS:1001292
 name: decoy DB from IPI_rat
 def: "OBSOLETE Decoy database from a International Protein Index database for Rattus norvegicus." [PSI:PI]
-comment: This term was made obsolete, because a combination of database name, DB composition , decoy DB type , decoy DB generation algorithm, decoy DB accession regexp and decoy DB details suffices.
-is_obsolete: true
 
 [Term]
 id: MS:1001293
 name: decoy DB from IPI_mouse
 def: "OBSOLETE Decoy database from a International Protein Index database for Mus musculus." [PSI:PI]
-comment: This term was made obsolete, because a combination of database name, DB composition , decoy DB type , decoy DB generation algorithm, decoy DB accession regexp and decoy DB details suffices.
-is_obsolete: true
 
 [Term]
 id: MS:1001294
 name: decoy DB from IPI_arabidopsis
 def: "OBSOLETE Decoy database from a International Protein Index database for Arabidopsis thaliana." [PSI:PI]
-comment: This term was made obsolete, because a combination of database name, DB composition , decoy DB type , decoy DB generation algorithm, decoy DB accession regexp and decoy DB details suffices.
-is_obsolete: true
 
 [Term]
 id: MS:1001295
 name: decoy DB from EST
 def: "OBSOLETE Decoy database from an expressed sequence tag nucleotide sequence database." [PSI:PI]
-comment: This term was made obsolete, because a combination of database name, DB composition , decoy DB type , decoy DB generation algorithm, decoy DB accession regexp and decoy DB details suffices.
-is_obsolete: true
 
 [Term]
 id: MS:1001296
 name: decoy DB from IPI_zebrafish
 def: "OBSOLETE Decoy database from a International Protein Index database for Danio rerio." [PSI:PI]
-comment: This term was made obsolete, because a combination of database name, DB composition , decoy DB type , decoy DB generation algorithm, decoy DB accession regexp and decoy DB details suffices.
-is_obsolete: true
 
 [Term]
 id: MS:1001297
 name: decoy DB from UniProtKB/Swiss-Prot
 def: "OBSOLETE Decoy database from a Swiss-Prot protein sequence database." [PSI:PI]
-comment: This term was made obsolete, because a combination of database name, DB composition , decoy DB type , decoy DB generation algorithm, decoy DB accession regexp and decoy DB details suffices.
-is_obsolete: true
 
 [Term]
 id: MS:1001298
 name: decoy DB from IPI_chicken
 def: "OBSOLETE Decoy database from a International Protein Index database for Gallus gallus." [PSI:PI]
-comment: This term was made obsolete, because a combination of database name, DB composition , decoy DB type , decoy DB generation algorithm, decoy DB accession regexp and decoy DB details suffices.
-is_obsolete: true
 
 [Term]
 id: MS:1001299
 name: decoy DB from IPI_cow
 def: "OBSOLETE Decoy database from a International Protein Index database for Bos taurus." [PSI:PI]
-comment: This term was made obsolete, because a combination of database name, DB composition , decoy DB type , decoy DB generation algorithm, decoy DB accession regexp and decoy DB details suffices.
-is_obsolete: true
 
 [Term]
 id: MS:1001300
 name: decoy DB from IPI_human
 def: "OBSOLETE Decoy database from a International Protein Index database for Homo sapiens." [PSI:PI]
-comment: This term was made obsolete, because a combination of database name, DB composition , decoy DB type , decoy DB generation algorithm, decoy DB accession regexp and decoy DB details suffices.
-is_obsolete: true
 
 [Term]
 id: MS:1001301
@@ -8200,6 +7829,7 @@ name: protein rank
 def: "The rank of the protein in a list sorted by the search engine." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1001085 ! protein-level identification attribute
+relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001302
@@ -8211,95 +7841,92 @@ is_a: MS:1002093 ! search engine input parameter
 id: MS:1001303
 name: Arg-C
 def: "Endoproteinase Arg-C." [PSI:PI]
-synonym: "Trypsin/R" EXACT []
-synonym: "Clostripain" EXACT []
 is_a: MS:1001045 ! cleavage agent name
-relationship: has_regexp MS:1001272 ! (?<=R)(?!P)
+relationship: has_regexp: MS:1001272 ! (?<=R)(?!P)
 
 [Term]
 id: MS:1001304
 name: Asp-N
 def: "Endoproteinase Asp-N." [PSI:PI]
 is_a: MS:1001045 ! cleavage agent name
-relationship: has_regexp MS:1001273 ! (?=[BD])
+relationship: has_regexp: MS:1001273 ! (?=[BD])
 
 [Term]
 id: MS:1001305
 name: Asp-N_ambic
 def: "Enzyme Asp-N, Ammonium Bicarbonate (AmBic)." [PSI:PI]
 is_a: MS:1001045 ! cleavage agent name
-relationship: has_regexp MS:1001274 ! (?=[DE])
+relationship: has_regexp: MS:1001274 ! (?=[DE])
 
 [Term]
 id: MS:1001306
 name: Chymotrypsin
 def: "Enzyme chymotrypsin." [PSI:PI]
 is_a: MS:1001045 ! cleavage agent name
-relationship: has_regexp MS:1001332 ! (?<=[FYWL])(?!P)
+relationship: has_regexp: MS:1001332 ! (?<=[FYWL])(?!P)
 
 [Term]
 id: MS:1001307
 name: CNBr
 def: "Cyanogen bromide." [PSI:PI]
 is_a: MS:1001045 ! cleavage agent name
-relationship: has_regexp MS:1001333 ! (?<=M)
+relationship: has_regexp: MS:1001333 ! (?<=M)
 
 [Term]
 id: MS:1001308
 name: Formic_acid
 def: "Formic acid." [PubChem_Compound:284]
 is_a: MS:1001045 ! cleavage agent name
-relationship: has_regexp MS:1001334 ! ((?<=D))|((?=D))
+relationship: has_regexp: MS:1001334 ! ((?<=D))|((?=D))
 
 [Term]
 id: MS:1001309
 name: Lys-C
 def: "Endoproteinase Lys-C." [PSI:PI]
-synonym: "Trypsin/K" EXACT []
 is_a: MS:1001045 ! cleavage agent name
-relationship: has_regexp MS:1001335 ! (?<=K)(?!P)
+relationship: has_regexp: MS:1001335 ! (?<=K)(?!P)
 
 [Term]
 id: MS:1001310
 name: Lys-C/P
 def: "Proteinase Lys-C/P." [PSI:PI]
 is_a: MS:1001045 ! cleavage agent name
-relationship: has_regexp MS:1001336 ! (?<=K)
+relationship: has_regexp: MS:1001336 ! (?<=K)
 
 [Term]
 id: MS:1001311
 name: PepsinA
 def: "PepsinA proteinase." [PSI:PI]
 is_a: MS:1001045 ! cleavage agent name
-relationship: has_regexp MS:1001337 ! (?<=[FL])
+relationship: has_regexp: MS:1001337 ! (?<=[FL])
 
 [Term]
 id: MS:1001312
 name: TrypChymo
 def: "Cleavage agent TrypChymo." [PSI:PI]
 is_a: MS:1001045 ! cleavage agent name
-relationship: has_regexp MS:1001338 ! (?<=[FYWLKR])(?!P)
+relationship: has_regexp: MS:1001338 ! (?<=[FYWLKR])(?!P)
 
 [Term]
 id: MS:1001313
 name: Trypsin/P
 def: "Cleavage agent Trypsin/P." [PSI:PI]
 is_a: MS:1001045 ! cleavage agent name
-relationship: has_regexp MS:1001339 ! (?<=[KR])
+relationship: has_regexp: MS:1001339 ! (?<=[KR])
 
 [Term]
 id: MS:1001314
 name: V8-DE
 def: "Cleavage agent V8-DE." [PSI:PI]
 is_a: MS:1001045 ! cleavage agent name
-relationship: has_regexp MS:1001340 ! (?<=[BDEZ])(?!P)
+relationship: has_regexp: MS:1001340 ! (?<=[BDEZ])(?!P)
 
 [Term]
 id: MS:1001315
 name: V8-E
 def: "Cleavage agent V8-E." [PSI:PI]
 is_a: MS:1001045 ! cleavage agent name
-relationship: has_regexp MS:1001341 ! (?<=[EZ])(?!P)
+relationship: has_regexp: MS:1001341 ! (?<=[EZ])(?!P)
 
 [Term]
 id: MS:1001316
@@ -8307,6 +7934,7 @@ name: Mascot:SigThreshold
 def: "Significance threshold below which the p-value of a peptide match must lie to be considered statistically significant (default 0.05)." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002095 ! Mascot input parameter
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001317
@@ -8314,6 +7942,7 @@ name: Mascot:MaxProteinHits
 def: "The number of protein hits to display in the report. If 'Auto', all protein hits that have a protein score exceeding the average peptide identity threshold are reported. Otherwise an integer at least 1." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002095 ! Mascot input parameter
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001318
@@ -8321,6 +7950,7 @@ name: Mascot:ProteinScoringMethod
 def: "Mascot protein scoring method; either 'Standard' or 'MudPIT'." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002095 ! Mascot input parameter
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001319
@@ -8328,6 +7958,7 @@ name: Mascot:MinMSMSThreshold
 def: "Mascot peptide match ion score threshold. If between 0 and 1, then peptide matches whose expect value exceeds the thresholds are suppressed; if at least 1, then peptide matches whose ion score is below the threshold are suppressed." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002095 ! Mascot input parameter
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001320
@@ -8335,6 +7966,7 @@ name: Mascot:ShowHomologousProteinsWithSamePeptides
 def: "If true, show (sequence or spectrum) same-set proteins. Otherwise they are suppressed." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002095 ! Mascot input parameter
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001321
@@ -8342,6 +7974,7 @@ name: Mascot:ShowHomologousProteinsWithSubsetOfPeptides
 def: "If true, show (sequence or spectrum) sub-set and subsumable proteins. Otherwise they are suppressed." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002095 ! Mascot input parameter
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001322
@@ -8349,6 +7982,7 @@ name: Mascot:RequireBoldRed
 def: "Only used in Peptide Summary and Select Summary reports. If true, a peptide match must be 'bold red' to be included in the report; bold red means the peptide is a top ranking match in a query and appears for the first time (in linear order) in the list of protein hits." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002095 ! Mascot input parameter
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001323
@@ -8356,6 +7990,7 @@ name: Mascot:UseUnigeneClustering
 def: "If true, then the search results are against a nucleic acid database and Unigene clustering is enabled. Otherwise UniGene clustering is not in use." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002095 ! Mascot input parameter
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001324
@@ -8363,6 +7998,7 @@ name: Mascot:IncludeErrorTolerantMatches
 def: "If true, then the search results are error tolerant and peptide matches from the second pass are included in search results. Otherwise no error tolerant peptide matches are included." [http://www.matrixscience.com/help/error_tolerant_help.html]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002095 ! Mascot input parameter
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001325
@@ -8370,13 +8006,12 @@ name: Mascot:ShowDecoyMatches
 def: "If true, then the search results are against an automatically generated decoy database and the reported peptide matches and protein hits come from the decoy database. Otherwise peptide matches and protein hits come from the original database." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002095 ! Mascot input parameter
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001326
 name: add_others
 def: "OBSOLETE." [PSI:PI]
-comment: This former purgatory term was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1001328
@@ -8384,6 +8019,7 @@ name: OMSSA:evalue
 def: "OMSSA E-value." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001329
@@ -8391,6 +8027,7 @@ name: OMSSA:pvalue
 def: "OMSSA p-value." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001330
@@ -8398,6 +8035,7 @@ name: X\!Tandem:expect
 def: "The X!Tandem expectation value." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001331
@@ -8405,6 +8043,7 @@ name: X\!Tandem:hyperscore
 def: "The X!Tandem hyperscore." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001332
@@ -8542,7 +8181,7 @@ is_a: MS:1001347 ! database file formats
 id: MS:1001354
 name: mass table options
 def: "Root node for options for the mass table used." [PSI:PI]
-relationship: part_of MS:1001000 ! spectrum interpretation
+relationship: part_of: MS:1001000 ! spectrum interpretation
 
 [Term]
 id: MS:1001355
@@ -8568,12 +8207,13 @@ name: msmsEval quality
 def: "This term reports the quality of the spectrum assigned by msmsEval." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001357 ! spectrum quality descriptions
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001359
 name: ambiguous residues
 def: "Children of this term describe ambiguous residues." [PSI:PI]
-relationship: part_of MS:1001000 ! spectrum interpretation
+relationship: part_of: MS:1001000 ! spectrum interpretation
 
 [Term]
 id: MS:1001360
@@ -8581,6 +8221,7 @@ name: alternate single letter codes
 def: "List of standard residue one letter codes which are used to replace a non-standard." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001359 ! ambiguous residues
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001361
@@ -8588,7 +8229,8 @@ name: alternate mass
 def: "List of masses a non-standard letter code is replaced with." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001359 ! ambiguous residues
-relationship: has_units UO:0000221 ! dalton
+relationship: has_units: UO:0000221 ! dalton
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001362
@@ -8596,6 +8238,7 @@ name: number of unmatched peaks
 def: "The number of unmatched peaks." [PSI:PI]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1002345 ! PSM-level attribute
+relationship: has_value_type: xsd\:nonNegativeInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001363
@@ -8609,7 +8252,8 @@ name: peptide sequence-level global FDR
 def: "Estimation of the global false discovery rate for distinct peptides once redundant identifications of the same peptide have been removed (id est multiple PSMs have been collapsed to one entry)." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002703 ! peptide sequence-level result list statistic
-relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_domain: MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001365
@@ -8647,6 +8291,7 @@ name: Mascot:homology threshold
 def: "The Mascot result 'homology threshold'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001371
@@ -8654,12 +8299,15 @@ name: Mascot:identity threshold
 def: "The Mascot result 'identity threshold'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001372
 name: SEQUEST:Sequences
+def:
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
+relationship: has_value_type: xsd\:positiveInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001373
@@ -8667,12 +8315,15 @@ name: SEQUEST:TIC
 def: "SEQUEST total ion current." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001374
 name: SEQUEST:Sum
+def:
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001375
@@ -8680,6 +8331,7 @@ name: Phenyx:Instrument Type
 def: "The instrument type parameter value in Phenyx." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002097 ! Phenyx input parameter
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001376
@@ -8687,6 +8339,7 @@ name: Phenyx:Scoring Model
 def: "The selected scoring model in Phenyx." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002097 ! Phenyx input parameter
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001377
@@ -8694,6 +8347,7 @@ name: Phenyx:Default Parent Charge
 def: "The default parent charge value in Phenyx." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002097 ! Phenyx input parameter
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001378
@@ -8701,6 +8355,7 @@ name: Phenyx:Trust Parent Charge
 def: "The parameter in Phenyx that specifies if the experimental charge state is to be considered as correct." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002097 ! Phenyx input parameter
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001379
@@ -8708,6 +8363,7 @@ name: Phenyx:Turbo
 def: "The turbo mode parameter in Phenyx." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002097 ! Phenyx input parameter
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001380
@@ -8715,6 +8371,7 @@ name: Phenyx:Turbo:ErrorTol
 def: "The maximal allowed fragment m/z error filter considered in the turbo mode of Phenyx." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002097 ! Phenyx input parameter
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001381
@@ -8722,6 +8379,7 @@ name: Phenyx:Turbo:Coverage
 def: "The minimal peptide sequence coverage value, expressed in percent, considered in the turbo mode of Phenyx." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002097 ! Phenyx input parameter
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001382
@@ -8729,6 +8387,7 @@ name: Phenyx:Turbo:Series
 def: "The list of ion series considered in the turbo mode of Phenyx." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002097 ! Phenyx input parameter
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001383
@@ -8736,6 +8395,7 @@ name: Phenyx:MinPepLength
 def: "The minimal number of residues for a peptide to be considered for a valid identification in Phenyx." [PSI:PI]
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1002097 ! Phenyx input parameter
+relationship: has_value_type: xsd\:positiveInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001384
@@ -8743,6 +8403,7 @@ name: Phenyx:MinPepzscore
 def: "The minimal peptide z-score for a peptide to be considered for a valid identification in Phenyx." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002097 ! Phenyx input parameter
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001385
@@ -8750,6 +8411,7 @@ name: Phenyx:MaxPepPvalue
 def: "The maximal peptide p-value for a peptide to be considered for a valid identification in Phenyx." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002097 ! Phenyx input parameter
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001386
@@ -8757,6 +8419,7 @@ name: Phenyx:AC Score
 def: "The minimal protein score required for a protein database entry to be displayed in the list of identified proteins in Phenyx." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002097 ! Phenyx input parameter
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001387
@@ -8764,6 +8427,7 @@ name: Phenyx:Conflict Resolution
 def: "The parameter in Phenyx that specifies if the conflict resolution algorithm is to be used." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002097 ! Phenyx input parameter
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001388
@@ -8771,13 +8435,15 @@ name: Phenyx:AC
 def: "The primary sequence database identifier of a protein in Phenyx." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001389
 name: Phenyx:ID
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 def: "A secondary sequence database identifier of a protein in Phenyx." [PSI:PI]
+xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001390
@@ -8785,6 +8451,7 @@ name: Phenyx:Score
 def: "The protein score of a protein match in Phenyx." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001391
@@ -8792,6 +8459,7 @@ name: Phenyx:Peptides1
 def: "First number of phenyx result \"#Peptides\"." [PSI:PI]
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
+relationship: has_value_type: xsd\:positiveInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001392
@@ -8799,6 +8467,7 @@ name: Phenyx:Peptides2
 def: "Second number of phenyx result \"#Peptides\"." [PSI:PI]
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
+relationship: has_value_type: xsd\:positiveInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001393
@@ -8806,6 +8475,7 @@ name: Phenyx:Auto
 def: "The value of the automatic peptide acceptance filter in Phenyx." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001394
@@ -8814,6 +8484,7 @@ def: "The value of the user-defined peptide acceptance filter in Phenyx." [PSI:P
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1002363 ! search engine specific score for proteins
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001395
@@ -8821,6 +8492,7 @@ name: Phenyx:Pepzscore
 def: "The z-score value of a peptide sequence match in Phenyx." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001396
@@ -8829,6 +8501,7 @@ def: "The p-value of a peptide sequence match in Phenyx." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1002358 ! search engine specific peptide sequence-level identification statistic
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001397
@@ -8836,6 +8509,7 @@ name: Phenyx:NumberOfMC
 def: "The number of missed cleavages of a peptide sequence in Phenyx." [PSI:PI]
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type: xsd\:positiveInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001398
@@ -8844,6 +8518,7 @@ def: "The expression of the nature and position(s) of modified residue(s) on a m
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1002363 ! search engine specific score for proteins
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001399
@@ -8867,7 +8542,7 @@ is_a: MS:1001040 ! intermediate analysis format
 id: MS:1001405
 name: spectrum identification result details
 def: "This subsection describes terms which can describe details of spectrum identification results." [PSI:PI]
-relationship: part_of MS:1001000 ! spectrum interpretation
+relationship: part_of: MS:1001000 ! spectrum interpretation
 
 [Term]
 id: MS:1001406
@@ -8899,6 +8574,7 @@ name: translation start codons
 def: "The translation start codons used to translate the nucleotides to amino acids." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001011 ! search database details
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001411
@@ -8909,22 +8585,26 @@ is_a: MS:1001249 ! search input details
 [Term]
 id: MS:1001412
 name: search tolerance plus value
+def:
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001411 ! search tolerance specification
-relationship: has_units UO:0000166 ! parts per notation unit
-relationship: has_units UO:0000169 ! parts per million
-relationship: has_units UO:0000187 ! percent
-relationship: has_units UO:0000221 ! dalton
+relationship: has_units: UO:0000166 ! parts per notation unit
+relationship: has_units: UO:0000169 ! parts per million
+relationship: has_units: UO:0000187 ! percent
+relationship: has_units: UO:0000221 ! dalton
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001413
 name: search tolerance minus value
+def:
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001411 ! search tolerance specification
-relationship: has_units UO:0000166 ! parts per notation unit
-relationship: has_units UO:0000169 ! parts per million
-relationship: has_units UO:0000187 ! percent
-relationship: has_units UO:0000221 ! dalton
+relationship: has_units: UO:0000166 ! parts per notation unit
+relationship: has_units: UO:0000169 ! parts per million
+relationship: has_units: UO:0000187 ! percent
+relationship: has_units: UO:0000221 ! dalton
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001414
@@ -8932,8 +8612,7 @@ name: MGF scans
 def: "OBSOLETE: replaced by MS:1000797 (peak list scans): This term can hold the scans attribute from an MGF input file." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001405 ! spectrum identification result details
-is_obsolete: true
-replaced_by: MS:1000797
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001415
@@ -8941,8 +8620,7 @@ name: MGF raw scans
 def: "OBSOLETE: replaced by MS:1000798 (peak list raw scans): This term can hold the raw scans attribute from an MGF input file." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001405 ! spectrum identification result details
-is_obsolete: true
-replaced_by: MS:1000798
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001416
@@ -8950,8 +8628,7 @@ name: spectrum title
 def: "OBSOLETE: replaced by MS:1000796 (spectrum title): Holds the spectrum title from different input file formats, e.g. MGF TITLE." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001405 ! spectrum identification result details
-is_obsolete: true
-replaced_by: MS:1000796
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001417
@@ -8959,6 +8636,7 @@ name: SpectraST:dot
 def: "SpectraST dot product of two spectra, measuring spectral similarity." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001418
@@ -8966,6 +8644,7 @@ name: SpectraST:dot_bias
 def: "SpectraST measure of how much of the dot product is dominated by a few peaks." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001419
@@ -8973,6 +8652,7 @@ name: SpectraST:discriminant score F
 def: "SpectraST spectrum score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001420
@@ -8980,6 +8660,7 @@ name: SpectraST:delta
 def: "SpectraST normalised difference between dot product of top hit and runner-up." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001421
@@ -8999,6 +8680,7 @@ name: translation table description
 def: "A URL that describes the translation table used to translate the nucleotides to amino acids." [PSI:PI]
 xref: value-type:xsd\:anyURI "The allowed value-type for this CV term."
 is_a: MS:1001011 ! search database details
+relationship: has_value_type: xsd\:anyURI ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001424
@@ -9006,6 +8688,7 @@ name: ProteinExtractor:Methodname
 def: "Name of the used method in the ProteinExtractor algorithm." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001425
@@ -9013,6 +8696,7 @@ name: ProteinExtractor:GenerateNonRedundant
 def: "Flag indicating if a non redundant scoring should be generated." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001426
@@ -9020,6 +8704,7 @@ name: ProteinExtractor:IncludeIdentified
 def: "Flag indicating if identified proteins should be included." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001427
@@ -9027,6 +8712,7 @@ name: ProteinExtractor:MaxNumberOfProteins
 def: "The maximum number of proteins to consider." [PSI:PI]
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
+relationship: has_value_type: xsd\:positiveInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001428
@@ -9034,6 +8720,7 @@ name: ProteinExtractor:MaxProteinMass
 def: "The maximum considered mass for a protein." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001429
@@ -9041,6 +8728,7 @@ name: ProteinExtractor:MinNumberOfPeptides
 def: "The minimum number of proteins to consider." [PSI:PI]
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
+relationship: has_value_type: xsd\:positiveInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001430
@@ -9048,6 +8736,7 @@ name: ProteinExtractor:UseMascot
 def: "Flag indicating to include Mascot scoring for calculation of the ProteinExtractor meta score." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001431
@@ -9055,6 +8744,7 @@ name: ProteinExtractor:MascotPeptideScoreThreshold
 def: "Only peptides with scores higher than that threshold are taken into account in Mascot scoring for calculation of the ProteinExtractor meta score." [DOI:10.4172/jpb.1000056]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001432
@@ -9062,12 +8752,15 @@ name: ProteinExtractor:MascotUniqueScore
 def: "In the final result each protein must have at least one peptide above this Mascot score threshold in ProteinExtractor meta score calculation." [DOI:10.4172/jpb.1000056]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001433
 name: ProteinExtractor:MascotUseIdentityScore
+def:
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001434
@@ -9075,6 +8768,7 @@ name: ProteinExtractor:MascotWeighting
 def: "Influence of Mascot search engine in the process of merging the search engine specific protein lists into the global protein list of ProteinExtractor." [DOI:10.4172/jpb.1000056]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001435
@@ -9082,6 +8776,7 @@ name: ProteinExtractor:UseSequest
 def: "Flag indicating to include SEQUEST scoring for calculation of the ProteinExtractor meta score." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001436
@@ -9089,6 +8784,7 @@ name: ProteinExtractor:SequestPeptideScoreThreshold
 def: "Only peptides with scores higher than that threshold are taken into account in SEQUEST scoring for calculation of the ProteinExtractor meta score." [DOI:10.4172/jpb.1000056]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001437
@@ -9096,6 +8792,7 @@ name: ProteinExtractor:SequestUniqueScore
 def: "In the final result each protein must have at least one peptide above this SEQUEST score threshold in ProteinExtractor meta score calculation." [DOI:10.4172/jpb.1000056]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001438
@@ -9103,6 +8800,7 @@ name: ProteinExtractor:SequestWeighting
 def: "Influence of SEQUEST search engine in the process of merging the search engine specific protein lists into the global protein list of ProteinExtractor." [DOI:10.4172/jpb.1000056]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001439
@@ -9110,6 +8808,7 @@ name: ProteinExtractor:UseProteinSolver
 def: "Flag indicating to include ProteinSolver scoring for calculation of the ProteinExtractor meta score." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001440
@@ -9117,6 +8816,7 @@ name: ProteinExtractor:ProteinSolverPeptideScoreThreshold
 def: "Only peptides with scores higher than that threshold are taken into account in ProteinSolver scoring for calculation of the ProteinExtractor meta score." [DOI:10.4172/jpb.1000056]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001441
@@ -9124,6 +8824,7 @@ name: ProteinExtractor:ProteinSolverUniqueScore
 def: "In the final result each protein must have at least one peptide above this ProteinSolver score threshold in ProteinExtractor meta score calculation." [DOI:10.4172/jpb.1000056]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001442
@@ -9131,6 +8832,7 @@ name: ProteinExtractor:ProteinSolverWeighting
 def: "Influence of ProteinSolver search engine in the process of merging the search engine specific protein lists into the global protein list of ProteinExtractor." [DOI:10.4172/jpb.1000056]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001443
@@ -9138,6 +8840,7 @@ name: ProteinExtractor:UsePhenyx
 def: "Flag indicating to include Phenyx scoring for calculation of the ProteinExtractor meta score." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001444
@@ -9145,6 +8848,7 @@ name: ProteinExtractor:PhenyxPeptideScoreThreshold
 def: "Only peptides with scores higher than that threshold are taken into account in Phenyx scoring for calculation of the ProteinExtractor meta score." [DOI:10.4172/jpb.1000056]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001445
@@ -9152,6 +8856,7 @@ name: ProteinExtractor:PhenyxUniqueScore
 def: "In the final result each protein must have at least one peptide above this Phenyx score threshold in ProteinExtractor meta score calculation." [DOI:10.4172/jpb.1000056]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001446
@@ -9159,6 +8864,7 @@ name: ProteinExtractor:PhenyxWeighting
 def: "Influence of Phenyx search engine in the process of merging the search engine specific protein lists into the global protein list of ProteinExtractor." [DOI:10.4172/jpb.1000056]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001447
@@ -9166,6 +8872,7 @@ name: prot:FDR threshold
 def: "False-discovery rate threshold for proteins." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002485 ! protein-level statistical threshold
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001448
@@ -9173,6 +8880,7 @@ name: pep:FDR threshold
 def: "False-discovery rate threshold for peptides." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002484 ! peptide-level statistical threshold
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001449
@@ -9180,6 +8888,7 @@ name: OMSSA e-value threshold
 def: "Threshold for OMSSA e-value for quality estimation." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002099 ! OMSSA input parameter
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001450
@@ -9193,6 +8902,7 @@ name: decoy DB generation algorithm
 def: "Name of algorithm used for decoy generation." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001450 ! decoy DB details
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001452
@@ -9234,13 +8944,13 @@ is_a: MS:1000531 ! software
 id: MS:1001458
 name: spectrum generation information
 def: "Vocabularies describing the spectrum generation information." [PSI:PI]
-relationship: part_of MS:0000000 ! Proteomics Standards Initiative Mass Spectrometry Vocabularies
+relationship: part_of: MS:0000000 ! Proteomics Standards Initiative Mass Spectrometry Vocabularies
 
 [Term]
 id: MS:1001459
 name: file format
 def: "Format of data files." [PSI:MS]
-relationship: part_of MS:0000000 ! Proteomics Standards Initiative Mass Spectrometry Vocabularies
+relationship: part_of: MS:0000000 ! Proteomics Standards Initiative Mass Spectrometry Vocabularies
 
 [Term]
 id: MS:1001460
@@ -9285,6 +8995,7 @@ name: taxonomy: NCBI TaxID
 def: "This term is used if a NCBI TaxID is specified, e.g. 9606 for Homo sapiens." [PSI:PI]
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1001089 ! molecule taxonomy
+relationship: has_value_type: xsd\:positiveInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001468
@@ -9292,6 +9003,7 @@ name: taxonomy: common name
 def: "This term is used if a common name is specified, e.g. human. Recommend using MS:1001467 (taxonomy: NCBI TaxID) where possible." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001089 ! molecule taxonomy
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001469
@@ -9299,6 +9011,7 @@ name: taxonomy: scientific name
 def: "This term is used if a scientific name is specified, e.g. Homo sapiens. Recommend using MS:1001467 (taxonomy: NCBI TaxID) where possible." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001089 ! molecule taxonomy
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001470
@@ -9306,35 +9019,31 @@ name: taxonomy: Swiss-Prot ID
 def: "This term is used if a swiss prot taxonomy id is specified, e.g. Human. Recommend using MS:1001467 (taxonomy: NCBI TaxID) where possible." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001089 ! molecule taxonomy
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001471
 name: peptide modification details
 def: "The children of this term can be used to describe modifications." [PSI:PI]
-relationship: part_of MS:1001000 ! spectrum interpretation
+relationship: part_of: MS:1001000 ! spectrum interpretation
 
 [Term]
 id: MS:1001472
 name: selected ion monitoring chromatogram
 def: "Representation of an array of the measurements of a selectively monitored ion versus time." [PSI:MS]
-synonym: "SIM chromatogram" EXACT []
 is_a: MS:1000810 ! ion current chromatogram
 
 [Term]
 id: MS:1001473
 name: selected reaction monitoring chromatogram
 def: "Representation of an array of the measurements of a selectively monitored reaction versus time." [PSI:MS]
-synonym: "SRM chromatogram" EXACT []
 is_a: MS:1000810 ! ion current chromatogram
 
 [Term]
 id: MS:1001474
 name: consecutive reaction monitoring chromatogram
 def: "OBSOLETE Representation of an array of the measurements of a series of monitored reactions versus time." [PSI:MS]
-comment: This term was made obsolete because, by design, it can't be properly represented in mzML 1.1. CRM experiments must be represented in a spectrum-centric way.
-synonym: "CRM chromatogram" EXACT []
 is_a: MS:1000810 ! ion current chromatogram
-is_obsolete: true
 
 [Term]
 id: MS:1001475
@@ -9443,6 +9152,7 @@ name: percolator:Q value
 def: "Percolator:Q value." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001492
@@ -9450,6 +9160,7 @@ name: percolator:score
 def: "Percolator:score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001493
@@ -9457,6 +9168,7 @@ name: percolator:PEP
 def: "Posterior error probability." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001494
@@ -9470,6 +9182,7 @@ name: ProteinScape:SearchResultId
 def: "The SearchResultId of this peptide as SearchResult in the ProteinScape database." [PSI:PI]
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type: xsd\:positiveInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001496
@@ -9477,6 +9190,7 @@ name: ProteinScape:SearchEventId
 def: "The SearchEventId of the SearchEvent in the ProteinScape database." [PSI:PI]
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type: xsd\:positiveInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001497
@@ -9484,6 +9198,7 @@ name: ProteinScape:ProfoundProbability
 def: "The Profound probability score stored by ProteinScape." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001498
@@ -9491,6 +9206,7 @@ name: Profound:z value
 def: "The Profound z value." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001499
@@ -9498,6 +9214,7 @@ name: Profound:Cluster
 def: "The Profound cluster score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001500
@@ -9505,6 +9222,7 @@ name: Profound:ClusterRank
 def: "The Profound cluster rank." [PSI:PI]
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type: xsd\:positiveInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001501
@@ -9512,6 +9230,7 @@ name: MSFit:Mowse score
 def: "The MSFit Mowse score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001502
@@ -9519,6 +9238,7 @@ name: Sonar:Score
 def: "The Sonar score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001503
@@ -9526,6 +9246,7 @@ name: ProteinScape:PFFSolverExp
 def: "The ProteinSolver exp value stored by ProteinScape." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001504
@@ -9533,6 +9254,7 @@ name: ProteinScape:PFFSolverScore
 def: "The ProteinSolver score stored by ProteinScape." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001505
@@ -9540,6 +9262,7 @@ name: ProteinScape:IntensityCoverage
 def: "The intensity coverage of the identified peaks in the spectrum calculated by ProteinScape." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001506
@@ -9547,6 +9270,7 @@ name: ProteinScape:SequestMetaScore
 def: "The SEQUEST meta score calculated by ProteinScape from the original SEQUEST scores." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001507
@@ -9554,6 +9278,7 @@ name: ProteinExtractor:Score
 def: "The score calculated by ProteinExtractor." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001508
@@ -9591,6 +9316,7 @@ name: DB sequence filter pattern
 def: "DB sequence filter pattern." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001512 ! Sequence database filters
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001514
@@ -9598,6 +9324,7 @@ name: DB accession filter string
 def: "DB accession filter string." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001512 ! Sequence database filters
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001515
@@ -9659,7 +9386,8 @@ name: fragment neutral loss
 def: "This term can describe a neutral loss m/z value that is lost from an ion." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001471 ! peptide modification details
-relationship: has_units UO:0000221 ! dalton
+relationship: has_units: UO:0000221 ! dalton
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001525
@@ -9667,13 +9395,13 @@ name: precursor neutral loss
 def: "This term can describe a neutral loss m/z value that is lost from an ion." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001471 ! peptide modification details
-relationship: has_units UO:0000221 ! dalton
+relationship: has_units: UO:0000221 ! dalton
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001526
 name: spectrum from database integer nativeID format
 def: "Native format defined by databasekey=xsd:long." [PSI:MS]
-comment: A unique identifier of a spectrum stored in a database (e.g. a PRIMARY KEY identifier).
 is_a: MS:1000767 ! native spectrum identifier format
 
 [Term]
@@ -9686,7 +9414,6 @@ is_a: MS:1000560 ! mass spectrometer file format
 id: MS:1001528
 name: Mascot query number
 def: "Native format defined by query=xsd:nonNegativeInteger." [PSI:MS]
-comment: The spectrum (query) number in a Mascot results file, starting from 1.
 is_a: MS:1000767 ! native spectrum identifier format
 is_a: MS:1001405 ! spectrum identification result details
 
@@ -9700,14 +9427,12 @@ is_a: MS:1001249 ! search input details
 id: MS:1001530
 name: mzML unique identifier
 def: "Native format defined by mzMLid=xsd:IDREF." [PSI:MS]
-comment: A unique identifier of a spectrum stored in an mzML file.
 is_a: MS:1001529 ! spectra data details
 
 [Term]
 id: MS:1001531
 name: spectrum from ProteinScape database nativeID format
 def: "Native format defined by databasekey=xsd:long." [PSI:MS]
-comment: A unique identifier of a spectrum stored in a ProteinScape database.
 is_a: MS:1000767 ! native spectrum identifier format
 is_a: MS:1001529 ! spectra data details
 
@@ -9715,7 +9440,6 @@ is_a: MS:1001529 ! spectra data details
 id: MS:1001532
 name: spectrum from database string nativeID format
 def: "Native format defined by databasekey=xsd:string." [PSI:MS]
-comment: A unique identifier of a spectrum stored in a database (e.g. a PRIMARY KEY identifier).
 is_a: MS:1000767 ! native spectrum identifier format
 is_a: MS:1001529 ! spectra data details
 
@@ -9926,6 +9650,7 @@ name: Scaffold:Peptide Probability
 def: "Scaffold peptide probability score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001569
@@ -9933,6 +9658,7 @@ name: IdentityE Score
 def: "Waters IdentityE peptide score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001570
@@ -9940,6 +9666,7 @@ name: ProteinLynx:Log Likelihood
 def: "ProteinLynx log likelihood score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001571
@@ -9947,6 +9674,7 @@ name: ProteinLynx:Ladder Score
 def: "Waters ProteinLynx Ladder score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001572
@@ -9954,6 +9682,7 @@ name: SpectrumMill:Score
 def: "Spectrum mill peptide score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001573
@@ -9961,6 +9690,7 @@ name: SpectrumMill:SPI
 def: "SpectrumMill SPI score (%)." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001574
@@ -9974,6 +9704,7 @@ name: Scaffold: Minimum Peptide Count
 def: "Minimum number of peptides a protein must have to be accepted." [PSI:PI]
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1002106 ! Scaffold input parameter
+relationship: has_value_type: xsd\:positiveInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001576
@@ -9981,6 +9712,7 @@ name: Scaffold: Minimum Protein Probability
 def: "Minimum protein probability a protein must have to be accepted." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002106 ! Scaffold input parameter
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001577
@@ -9988,6 +9720,7 @@ name: Scaffold: Minimum Peptide Probability
 def: "Minimum probability a peptide must have to be accepted for protein scoring." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002106 ! Scaffold input parameter
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001578
@@ -9995,6 +9728,7 @@ name: minimum number of enzymatic termini
 def: "Minimum number of enzymatic termini a peptide must have to be accepted." [PSI:PI]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1002094 ! common search engine input parameter
+relationship: has_value_type: xsd\:nonNegativeInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001579
@@ -10002,6 +9736,7 @@ name: Scaffold:Protein Probability
 def: "Scaffold protein probability score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001580
@@ -10009,15 +9744,16 @@ name: SpectrumMill:Discriminant Score
 def: "Discriminant score from Agilent SpectrumMill software." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001581
 name: FAIMS compensation voltage
 def: "The DC potential applied to the asymmetric waveform in FAIMS that compensates for the difference between high and low field mobility of an ion." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-synonym: "FAIMS CV" EXACT []
 is_a: MS:1002892 ! ion mobility attribute
-relationship: has_units UO:0000218 ! volt
+relationship: has_units: UO:0000218 ! volt
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001582
@@ -10067,16 +9803,12 @@ is_a: MS:1001456 ! analysis software
 id: MS:1001589
 name: MyriMatch:MVH
 def: "Using the multivariate hypergeometric distribution and a peak list divided into several intensity classes, this score is the negative natural log probability that the predicted peaks matched to experimental peaks by random chance." [PSI:MS]
-synonym: "Pepitome:MVH" EXACT []
-synonym: "TagRecon:MVH" EXACT []
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 
 [Term]
 id: MS:1001590
 name: MyriMatch:mzFidelity
 def: "The negative natural log probability that predicted peaks match to experimental peaks by random chance by scoring the m/z delta of the matches in a multinomial distribution." [PSI:MS]
-synonym: "Pepitome:mzFidelity" EXACT []
-synonym: "TagRecon:mzFidelity" EXACT []
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 
 [Term]
@@ -10085,6 +9817,7 @@ name: anchor protein
 def: "A representative protein selected from a set of sequence same-set or spectrum same-set proteins." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001101 ! protein group or subset relationship
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001592
@@ -10092,6 +9825,7 @@ name: family member protein
 def: "A protein with significant homology to another protein, but some distinguishing peptide matches." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001101 ! protein group or subset relationship
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001593
@@ -10105,6 +9839,7 @@ name: sequence same-set protein
 def: "A protein which is indistinguishable or equivalent to another protein, having matches to an identical set of peptide sequences." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001101 ! protein group or subset relationship
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001595
@@ -10112,6 +9847,7 @@ name: spectrum same-set protein
 def: "A protein which is indistinguishable or equivalent to another protein, having matches to a set of peptide sequences that cannot be distinguished using the evidence in the mass spectra." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001101 ! protein group or subset relationship
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001596
@@ -10119,6 +9855,7 @@ name: sequence sub-set protein
 def: "A protein with a sub-set of the peptide sequence matches for another protein, and no distinguishing peptide matches." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001101 ! protein group or subset relationship
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001597
@@ -10126,6 +9863,7 @@ name: spectrum sub-set protein
 def: "A protein with a sub-set of the matched spectra for another protein, where the matches cannot be distinguished using the evidence in the mass spectra, and no distinguishing peptide matches." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001101 ! protein group or subset relationship
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001598
@@ -10133,6 +9871,7 @@ name: sequence subsumable protein
 def: "A sequence same-set or sequence sub-set protein where the matches are distributed across two or more proteins." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001101 ! protein group or subset relationship
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001599
@@ -10140,6 +9879,7 @@ name: spectrum subsumable protein
 def: "A spectrum same-set or spectrum sub-set protein where the matches are distributed across two or more proteins." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001101 ! protein group or subset relationship
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001600
@@ -10147,42 +9887,39 @@ name: protein inference confidence category
 def: "Confidence category of inferred protein (conclusive, non conclusive, ambiguous group or indistinguishable)." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001101 ! protein group or subset relationship
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001601
 name: ProteomeDiscoverer:Spectrum Files:Raw File names
 def: "OBSOLETE Name and location of the .raw file or files." [PSI:MS]
-comment: This term was made obsolete because it's recommended to use one of the 'mass spectrometer file format' terms (MS:1000560) instead.
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-is_obsolete: true
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001602
 name: ProteomeDiscoverer:SRF File Selector:SRF File Path
 def: "OBSOLETE Path and name of the .srf (SEQUEST Result Format) file." [PSI:MS]
-comment: This term was made obsolete. Use attribute in mzIdentML / mzQuantML instead.
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-is_obsolete: true
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001603
 name: ProteomeDiscoverer:Spectrum Selector:Ionization Source
 def: "OBSOLETE Ionization source (electro-, nano-, thermospray, electron impact, APCI, MALDI, FAB etc)." [PSI:MS]
-comment: This term was made obsolete because it's recommended to use one of the 'inlet type' (MS:1000007) or 'ionization type' (MS:1000008) terms instead.
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-is_obsolete: true
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001604
 name: ProteomeDiscoverer:Activation Type
 def: "OBSOLETE Fragmentation method used (CID, MPD, ECD, PQD, ETD, HCD, Any)." [PSI:MS]
-comment: This term was made obsolete because it's recommended to use one of the 'ionization type' terms (MS:1000008) instead.
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-is_obsolete: true
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001605
@@ -10190,15 +9927,15 @@ name: ProteomeDiscoverer:Spectrum Selector:Lower RT Limit
 def: "Lower retention-time limit." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001606
 name: ProteomeDiscoverer:Mass Analyzer
 def: "OBSOLETE Type of mass spectrometer used (ITMS, FTMS, TOFMS, SQMS, TQMS, SectorMS)." [PSI:MS]
-comment: This term was made obsolete because it's recommended to use mass analyzer type (MS:1000443) instead.
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-is_obsolete: true
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001607
@@ -10206,6 +9943,7 @@ name: ProteomeDiscoverer:Max Precursor Mass
 def: "Maximum mass limit of a singly charged precursor ion." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001608
@@ -10213,6 +9951,7 @@ name: ProteomeDiscoverer:Min Precursor Mass
 def: "Minimum mass limit of a singly charged precursor ion." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001609
@@ -10220,24 +9959,23 @@ name: ProteomeDiscoverer:Spectrum Selector:Minimum Peak Count
 def: "Minimum number of peaks in a tandem mass spectrum that is allowed to pass the filter and to be subjected to further processing in the workflow." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001610
 name: ProteomeDiscoverer:MS Order
 def: "OBSOLETE Level of the mass spectrum (MS2 ... MS10)." [PSI:MS]
-comment: This term was made obsolete because it's recommended to use MS1 spectrum (MS:1000579) or MSn spectrum (MS:1000580) instead.
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-is_obsolete: true
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001611
 name: ProteomeDiscoverer:Polarity Mode
 def: "OBSOLETE Polarity mode (positive or negative)." [PSI:MS]
-comment: This term was made obsolete because it's recommended to use scan polarity (MS:1000465) instead.
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-is_obsolete: true
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001612
@@ -10245,6 +9983,7 @@ name: ProteomeDiscoverer:Spectrum Selector:Precursor Selection
 def: "Determines which precursor mass to use for a given MSn scan. This option applies only to higher-order MSn scans (n >= 3)." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001613
@@ -10252,15 +9991,15 @@ name: ProteomeDiscoverer:SN Threshold
 def: "Signal-to-Noise ratio below which peaks are removed." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001614
 name: ProteomeDiscoverer:Scan Type
 def: "OBSOLETE Scan type for the precursor ion (full, Single Ion Monitoring (SIM), Single Reaction Monitoring (SRM))." [PSI:MS]
-comment: This term was made obsolete because it's recommended to use MS1 spectrum (MS:1000579), MSn spectrum (MS:1000580), CRM spectrum (MS:1000581), SIM spectrum (MS:1000582) or SRM spectrum (MS:1000583) instead.
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-is_obsolete: true
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001615
@@ -10268,6 +10007,7 @@ name: ProteomeDiscoverer:Spectrum Selector:Total Intensity Threshold
 def: "Used to filter out tandem mass spectra that have a total intensity current(sum of the intensities of all peaks in a spectrum) below the specified value." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001616
@@ -10275,6 +10015,7 @@ name: ProteomeDiscoverer:Spectrum Selector:Unrecognized Activation Type Replacem
 def: "Specifies the fragmentation method to use in the search algorithm if it is not included in the scan header." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001617
@@ -10282,6 +10023,7 @@ name: ProteomeDiscoverer:Spectrum Selector:Unrecognized Charge Replacements
 def: "Specifies the charge state of the precursor ions, if it is not defined in the scan header." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001618
@@ -10289,6 +10031,7 @@ name: ProteomeDiscoverer:Spectrum Selector:Unrecognized Mass Analyzer Replacemen
 def: "Specifies the mass spectrometer to use to produce the spectra, if it is not included in the scan header." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001619
@@ -10296,6 +10039,7 @@ name: ProteomeDiscoverer:Spectrum Selector:Unrecognized MS Order Replacements
 def: "Specifies the MS scan order used to produce the product spectra, if it is not included in the scan header." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001620
@@ -10303,6 +10047,7 @@ name: ProteomeDiscoverer:Spectrum Selector:Unrecognized Polarity Replacements
 def: "Specifies the polarity of the ions monitored if it is not included in the scan header." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001621
@@ -10310,6 +10055,7 @@ name: ProteomeDiscoverer:Spectrum Selector:Upper RT Limit
 def: "Upper retention-time limit." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001622
@@ -10317,6 +10063,7 @@ name: ProteomeDiscoverer:Non-Fragment Filter:Mass Window Offset
 def: "Specifies the size of the mass-to-charge ratio (m/z) window in daltons used to remove precursors." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001623
@@ -10324,6 +10071,7 @@ name: ProteomeDiscoverer:Non-Fragment Filter:Maximum Neutral Loss Mass
 def: "Maximum allowed mass of a neutral loss." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001624
@@ -10331,6 +10079,7 @@ name: ProteomeDiscoverer:Non-Fragment Filter:Remove Charge Reduced Precursor
 def: "Determines whether the charge-reduced precursor peaks found in an ETD or ECD spectrum are removed." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001625
@@ -10338,6 +10087,7 @@ name: ProteomeDiscoverer:Non-Fragment Filter:Remove Neutral Loss Peaks
 def: "Determines whether neutral loss peaks are removed from ETD and ECD spectra." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001626
@@ -10345,6 +10095,7 @@ name: ProteomeDiscoverer:Non-Fragment Filter:Remove Only Known Masses
 def: "Determines whether overtone peaks are removed from LTQ FT or LTQ FT Ultra ECD spectra." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001627
@@ -10352,6 +10103,7 @@ name: ProteomeDiscoverer:Non-Fragment Filter:Remove Precursor Overtones
 def: "Determines whether precursor overtone peaks in the spectrum are removed from the input spectrum." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001628
@@ -10359,6 +10111,7 @@ name: ProteomeDiscoverer:Non-Fragment Filter:Remove Precursor Peak
 def: "Determines whether precursor artifact peaks from the MS2 input spectra are removed." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001629
@@ -10366,6 +10119,7 @@ name: ProteomeDiscoverer:Spectrum Grouper:Allow Mass Analyzer Mismatch
 def: "Determines whether the fragment spectrum for scans with the same precursor mass is grouped, regardless of mass analyzer and activation type." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001630
@@ -10373,15 +10127,15 @@ name: ProteomeDiscoverer:Spectrum Grouper:Allow MS Order Mismatch
 def: "Determines whether spectra from different MS order scans can be grouped together." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001631
 name: ProteomeDiscoverer:Spectrum Grouper:Max RT Difference
 def: "OBSOLETE Chromatographic window where precursors to be grouped must reside to be considered the same species." [PSI:MS]
-comment: This term was made obsolete because it's recommended to use retention time window width (MS:1001907) instead.
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-is_obsolete: true
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001632
@@ -10389,6 +10143,7 @@ name: ProteomeDiscoverer:Spectrum Grouper:Precursor Mass Criterion
 def: "Groups spectra measured within the given mass and retention-time tolerances into a single spectrum for analysis." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001633
@@ -10396,15 +10151,15 @@ name: ProteomeDiscoverer:Xtract:Highest Charge
 def: "Highest charge state that is allowed for the deconvolution of multiply charged data." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001634
 name: ProteomeDiscoverer:Xtract:Highest MZ
 def: "OBSOLETE Highest mass-to-charge (mz) value for spectral peaks in the measured spectrum that are considered for Xtract." [PSI:MS]
-comment: This term was made obsolete because it's recommended to use scan window upper limit (MS:1000500) instead.
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-is_obsolete: true
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001635
@@ -10412,15 +10167,15 @@ name: ProteomeDiscoverer:Xtract:Lowest Charge
 def: "Lowest charge state that is allowed for the deconvolution of multiply charged data." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001636
 name: ProteomeDiscoverer:Xtract:Lowest MZ
 def: "OBSOLETE Lowest mass-to-charge (mz) value for spectral peaks in the measured spectrum that are considered for Xtract." [PSI:MS]
-comment: This term was made obsolete because it's recommended to use scan window lower limit (MS:1000501) instead.
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-is_obsolete: true
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001637
@@ -10428,6 +10183,7 @@ name: ProteomeDiscoverer:Xtract:Monoisotopic Mass Only
 def: "Determines whether the isotopic pattern, i.e. all isotopes of a mass are removed from the spectrum." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001638
@@ -10435,6 +10191,7 @@ name: ProteomeDiscoverer:Xtract:Overlapping Remainder
 def: "Fraction of the more abundant peak that an overlapping multiplet must exceed in order to be processed (deconvoluted)." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001639
@@ -10442,6 +10199,7 @@ name: ProteomeDiscoverer:Xtract:Required Fitting Accuracy
 def: "Accuracy required for a pattern fit to be considered valid." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001640
@@ -10449,6 +10207,7 @@ name: ProteomeDiscoverer:Xtract:Resolution At 400
 def: "Resolution at mass 400." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001641
@@ -10456,6 +10215,7 @@ name: ProteomeDiscoverer:Lowest Charge State
 def: "Minimum charge state below which peptides are filtered out." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001642
@@ -10463,6 +10223,7 @@ name: ProteomeDiscoverer:Highest Charge State
 def: "Maximum charge above which peptides are filtered out." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001643
@@ -10470,6 +10231,7 @@ name: ProteomeDiscoverer:Spectrum Score Filter:Let Pass Above Scores
 def: "Determines whether spectra with scores above the threshold score are retained rather than filtered out." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001644
@@ -10477,6 +10239,7 @@ name: ProteomeDiscoverer:Dynamic Modification
 def: "Determine dynamic post-translational modifications (PTMs)." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001645
@@ -10484,15 +10247,15 @@ name: ProteomeDiscoverer:Static Modification
 def: "Static Modification to all occurrences of a named amino acid." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001646
 name: ProteomeDiscoverer:Mascot:Decoy Search
 def: "OBSOLETE Determines whether the Proteome Discoverer application searches an additional decoy database." [PSI:MS]
-comment: This term was made obsolete because it's recommended to use quality estimation with decoy database (MS:1001194) instead.
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-is_obsolete: true
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001647
@@ -10500,6 +10263,7 @@ name: ProteomeDiscoverer:Mascot:Error tolerant Search
 def: "Determines whether to search error-tolerant." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001648
@@ -10507,6 +10271,7 @@ name: ProteomeDiscoverer:Mascot:Max MGF File Size
 def: "Maximum size of the .mgf (Mascot Generic Format) file in MByte." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001649
@@ -10514,6 +10279,7 @@ name: ProteomeDiscoverer:Mascot:Mascot Server URL
 def: "URL (Uniform resource Locator) of the Mascot server." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001650
@@ -10521,6 +10287,7 @@ name: ProteomeDiscoverer:Mascot:Number of attempts to submit the search
 def: "Number of attempts to submit the Mascot search." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001651
@@ -10528,15 +10295,15 @@ name: ProteomeDiscoverer:Mascot:X Static Modification
 def: "Number of attempts to submit the Mascot search." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001652
 name: ProteomeDiscoverer:Mascot:User Name
 def: "OBSOLETE Name of the user submitting the Mascot search." [PSI:MS]
-comment: This term was made obsolete because it's recommended to use researcher (MS:1001271) instead.
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-is_obsolete: true
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001653
@@ -10544,24 +10311,23 @@ name: ProteomeDiscoverer:Mascot:Time interval between attempts to submit a searc
 def: "Time interval between attempts to submit a search in seconds." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001654
 name: ProteomeDiscoverer:Enzyme Name
 def: "OBSOLETE Specifies the enzyme reagent used for protein digestion." [PSI:MS]
-comment: This term was made obsolete because it's recommended to use cleavage agent name (MS:1001045) instead.
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-is_obsolete: true
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001655
 name: ProteomeDiscoverer:Fragment Mass Tolerance
 def: "OBSOLETE Mass tolerance used for matching fragment peaks in Da or mmu." [PSI:MS]
-comment: This term was made obsolete because it's recommended to use search tolerance minus value (MS:1001413) or search tolerance plus value (MS:1001412) instead.
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-is_obsolete: true
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001656
@@ -10569,6 +10335,7 @@ name: Mascot:Instrument
 def: "Type of instrument used to acquire the data in the raw file." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002095 ! Mascot input parameter
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001657
@@ -10576,6 +10343,7 @@ name: ProteomeDiscoverer:Maximum Missed Cleavage Sites
 def: "Maximum number of missed cleavage sites to consider during the digest." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001658
@@ -10583,15 +10351,15 @@ name: ProteomeDiscoverer:Mascot:Peptide CutOff Score
 def: "Minimum score in the IonScore column that each peptide must exceed in order to be reported." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001659
 name: ProteomeDiscoverer:Precursor Mass Tolerance
 def: "OBSOLETE Mass window for which precursor ions are considered to be the same species." [PSI:MS]
-comment: This term was made obsolete because it's recommended to use search tolerance minus value (MS:1001413) or search tolerance plus value (MS:1001412) instead.
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-is_obsolete: true
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001660
@@ -10599,15 +10367,15 @@ name: ProteomeDiscoverer:Mascot:Protein CutOff Score
 def: "Minimum protein score in the IonScore column that each protein must exceed in order to be reported." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001661
 name: ProteomeDiscoverer:Protein Database
 def: "OBSOLETE Database to use in the search (configured on the Mascot server)." [PSI:MS]
-comment: This term was made obsolete because it's recommended to use database name (MS:1001013) instead.
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-is_obsolete: true
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001662
@@ -10615,6 +10383,7 @@ name: ProteomeDiscoverer:Mascot:Protein Relevance Factor
 def: "Specifies a factor that is used in calculating a threshold that determines whether a protein appears in the results report." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001663
@@ -10622,6 +10391,7 @@ name: ProteomeDiscoverer:Target FDR Relaxed
 def: "Specifies the relaxed target false discovery rate (FDR, 0.0 - 1.0) for peptide hits with moderate confidence." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001664
@@ -10629,33 +10399,31 @@ name: ProteomeDiscoverer:Target FDR Strict
 def: "Specifies the strict target false discovery rate (FDR, 0.0 - 1.0) for peptide hits with high confidence." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001665
 name: ProteomeDiscoverer:Mascot:Taxonomy
 def: "OBSOLETE Limits searches to entries from a particular species or group of species." [PSI:MS]
-comment: This term was made obsolete because it's recommended to use taxonomy: scientific name (MS:1001469) instead.
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-is_obsolete: true
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001666
 name: ProteomeDiscoverer:Use Average Precursor Mass
 def: "OBSOLETE Use average mass for the precursor." [PSI:MS]
-comment: This term was made obsolete because it's recommended to use parent mass type average (MS:1001212) instead.
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-is_obsolete: true
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001667
 name: Mascot:use MudPIT scoring
 def: "OBSOLETE Determines whether to use MudPIT or normal scoring." [PSI:MS]
-comment: This term was made obsolete because it's recommended to use Mascot:ProteinScoringMethod (MS:1001318) instead.
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002095 ! Mascot input parameter
-is_obsolete: true
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001668
@@ -10663,6 +10431,7 @@ name: ProteomeDiscoverer:Absolute XCorr Threshold
 def: "Minimum cross-correlation threshold that determines whether peptides in an .srf file are imported." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001669
@@ -10670,6 +10439,7 @@ name: ProteomeDiscoverer:SEQUEST:Calculate Probability Score
 def: "Determines whether to calculate a probability score for every peptide match." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001670
@@ -10677,6 +10447,7 @@ name: ProteomeDiscoverer:SEQUEST:CTerminal Modification
 def: "Dynamic C-terminal modification that is used during the search." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001671
@@ -10684,6 +10455,7 @@ name: ProteomeDiscoverer:SEQUEST:Fragment Ion Cutoff Percentage
 def: "Percentage of the theoretical ions that must be found in order for a peptide to be scored and retained." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001672
@@ -10691,6 +10463,7 @@ name: ProteomeDiscoverer:SEQUEST:Max Identical Modifications Per Peptide
 def: "Maximum number of identical modifications that a single peptide can have." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001673
@@ -10698,6 +10471,7 @@ name: ProteomeDiscoverer:Max Modifications Per Peptide
 def: "Maximum number of different modifications that a peptide can have, e.g. because of steric hindrance." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001674
@@ -10705,6 +10479,7 @@ name: ProteomeDiscoverer:SEQUEST:Maximum Peptides Considered
 def: "Maximum number of peptides that are searched and scored per spectrum." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001675
@@ -10712,6 +10487,7 @@ name: ProteomeDiscoverer:Maximum Peptides Output
 def: "Maximum number of peptide matches reported per spectrum." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001676
@@ -10719,6 +10495,7 @@ name: ProteomeDiscoverer:Maximum Protein References Per Peptide
 def: "Maximum number of proteins that a single identified peptide can be associated with during protein assembly." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001677
@@ -10726,6 +10503,7 @@ name: ProteomeDiscoverer:SEQUEST:NTerminal Modification
 def: "Dynamic N-terminal modification that is used during the search." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001678
@@ -10733,6 +10511,7 @@ name: ProteomeDiscoverer:Peptide CTerminus
 def: "Static modification for the C terminal of the peptide used during the search." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001679
@@ -10740,6 +10519,7 @@ name: ProteomeDiscoverer:Peptide NTerminus
 def: "Static modification for the N terminal of the peptide used during the search." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001680
@@ -10747,6 +10527,7 @@ name: ProteomeDiscoverer:SEQUEST:Peptide Relevance Factor
 def: "Specifies a factor to apply to the protein score." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001681
@@ -10754,15 +10535,15 @@ name: ProteomeDiscoverer:Protein Relevance Threshold
 def: "Specifies a peptide threshold that determines whether the protein that it is a part of is scored and retained in the report." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001682
 name: ProteomeDiscoverer:Search Against Decoy Database
 def: "OBSOLETE Determines whether the Proteome Discoverer application searches against a decoy database." [PSI:MS]
-comment: This term was made obsolete because it's recommended to use quality estimation with decoy database (MS:1001194) instead.
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-is_obsolete: true
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001683
@@ -10770,6 +10551,7 @@ name: ProteomeDiscoverer:SEQUEST:Use Average Fragment Masses
 def: "Use average masses for the fragments." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001684
@@ -10777,6 +10559,7 @@ name: ProteomeDiscoverer:Use Neutral Loss a Ions
 def: "Determines whether a ions with neutral loss are used for spectrum matching." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001685
@@ -10784,6 +10567,7 @@ name: ProteomeDiscoverer:Use Neutral Loss b Ions
 def: "Determines whether b ions with neutral loss are used for spectrum matching." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001686
@@ -10791,6 +10575,7 @@ name: ProteomeDiscoverer:Use Neutral Loss y Ions
 def: "Determines whether y ions with neutral loss are used for spectrum matching." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001687
@@ -10798,6 +10583,7 @@ name: ProteomeDiscoverer:Use Neutral Loss z Ions
 def: "Determines whether z ions with neutral loss are used for spectrum matching." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001688
@@ -10805,6 +10591,7 @@ name: ProteomeDiscoverer:SEQUEST:Weight of a Ions
 def: "Uses a ions for spectrum matching with this relative factor." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001689
@@ -10812,6 +10599,7 @@ name: ProteomeDiscoverer:SEQUEST:Weight of b Ions
 def: "Uses b ions for spectrum matching with this relative factor." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001690
@@ -10819,6 +10607,7 @@ name: ProteomeDiscoverer:SEQUEST:Weight of c Ions
 def: "Uses c ions for spectrum matching with this relative factor." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001691
@@ -10826,6 +10615,7 @@ name: ProteomeDiscoverer:SEQUEST:Weight of d Ions
 def: "Uses c ions for spectrum matching with this relative factor." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001692
@@ -10833,6 +10623,7 @@ name: ProteomeDiscoverer:SEQUEST:Weight of v Ions
 def: "Uses c ions for spectrum matching with this relative factor." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001693
@@ -10840,6 +10631,7 @@ name: ProteomeDiscoverer:SEQUEST:Weight of w Ions
 def: "Uses c ions for spectrum matching with this relative factor." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001694
@@ -10847,6 +10639,7 @@ name: ProteomeDiscoverer:SEQUEST:Weight of x Ions
 def: "Uses x ions for spectrum matching with this relative factor." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001695
@@ -10854,6 +10647,7 @@ name: ProteomeDiscoverer:SEQUEST:Weight of y Ions
 def: "Uses y ions for spectrum matching with this relative factor." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001696
@@ -10861,6 +10655,7 @@ name: ProteomeDiscoverer:SEQUEST:Weight of z Ions
 def: "Uses z ions for spectrum matching with this relative factor." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001697
@@ -10868,6 +10663,7 @@ name: ProteomeDiscoverer:ZCore:Protein Score Cutoff
 def: "Sets a minimum protein score that each protein must exceed in order to be reported." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001698
@@ -10875,6 +10671,7 @@ name: ProteomeDiscoverer:Reporter Ions Quantizer:Integration Method
 def: "Specifies which peak to select if more than one peak is found inside the integration window." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001699
@@ -10882,6 +10679,7 @@ name: ProteomeDiscoverer:Reporter Ions Quantizer:Integration Window Tolerance
 def: "Specifies the mass-to-charge window that enables one to look for the reporter peaks." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001700
@@ -10889,15 +10687,15 @@ name: ProteomeDiscoverer:Reporter Ions Quantizer:Quantitation Method
 def: "Quantitation method for isobarically labeled quantitation." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001701
 name: ProteomeDiscoverer:Spectrum Exporter:Export Format
 def: "OBSOLETE Format of the exported spectra (dta, mgf or mzData)." [PSI:MS]
-comment: This term was made obsolete because it's recommended to use one of the 'mass spectrometer file format' terms (MS:1000560) instead.
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-is_obsolete: true
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001702
@@ -10905,6 +10703,7 @@ name: ProteomeDiscoverer:Spectrum Exporter:File name
 def: "Name of the output file that contains the exported data." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001703
@@ -10912,6 +10711,7 @@ name: ProteomeDiscoverer:Search Modifications Only For Identified Proteins
 def: "Influences the modifications search." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001704
@@ -10919,6 +10719,7 @@ name: ProteomeDiscoverer:SEQUEST:Std High Confidence XCorr Charge1
 def: "Standard high confidence XCorr parameter for charge = 1." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001705
@@ -10926,6 +10727,7 @@ name: ProteomeDiscoverer:SEQUEST:Std High Confidence XCorr Charge2
 def: "Standard high confidence XCorr parameter for charge = 2." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001706
@@ -10933,6 +10735,7 @@ name: ProteomeDiscoverer:SEQUEST:Std High Confidence XCorr Charge3
 def: "Standard high confidence XCorr parameter for charge = 3." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001707
@@ -10940,6 +10743,7 @@ name: ProteomeDiscoverer:SEQUEST:Std High Confidence XCorr Charge4
 def: "Standard high confidence XCorr parameter for charge >= 4." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001708
@@ -10947,6 +10751,7 @@ name: ProteomeDiscoverer:SEQUEST:Std Medium Confidence XCorr Charge1
 def: "Standard medium confidence XCorr parameter for charge = 1." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001709
@@ -10954,6 +10759,7 @@ name: ProteomeDiscoverer:SEQUEST:Std Medium Confidence XCorr Charge2
 def: "Standard medium confidence XCorr parameter for charge = 2." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001710
@@ -10961,6 +10767,7 @@ name: ProteomeDiscoverer:SEQUEST:Std Medium Confidence XCorr Charge3
 def: "Standard medium confidence XCorr parameter for charge = 3." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001711
@@ -10968,6 +10775,7 @@ name: ProteomeDiscoverer:SEQUEST:Std Medium Confidence XCorr Charge4
 def: "Standard medium confidence XCorr parameter for charge >= 4." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001712
@@ -10975,6 +10783,7 @@ name: ProteomeDiscoverer:SEQUEST:FT High Confidence XCorr Charge1
 def: "FT high confidence XCorr parameter for charge = 1." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001713
@@ -10982,6 +10791,7 @@ name: ProteomeDiscoverer:SEQUEST:FT High Confidence XCorr Charge2
 def: "FT high confidence XCorr parameter for charge = 2." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001714
@@ -10989,6 +10799,7 @@ name: ProteomeDiscoverer:SEQUEST:FT High Confidence XCorr Charge3
 def: "FT high confidence XCorr parameter for charge = 3." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001715
@@ -10996,6 +10807,7 @@ name: ProteomeDiscoverer:SEQUEST:FT High Confidence XCorr Charge4
 def: "FT high confidence XCorr parameter for charge >= 4." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001716
@@ -11003,6 +10815,7 @@ name: ProteomeDiscoverer:SEQUEST:FT Medium Confidence XCorr Charge1
 def: "FT medium confidence XCorr parameter for charge = 1." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001717
@@ -11010,6 +10823,7 @@ name: ProteomeDiscoverer:SEQUEST:FT Medium Confidence XCorr Charge2
 def: "FT medium confidence XCorr parameter for charge = 2." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001718
@@ -11017,6 +10831,7 @@ name: ProteomeDiscoverer:SEQUEST:FT Medium Confidence XCorr Charge3
 def: "FT medium confidence XCorr parameter for charge = 3." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001719
@@ -11024,42 +10839,39 @@ name: ProteomeDiscoverer:SEQUEST:FT Medium Confidence XCorr Charge4
 def: "FT medium confidence XCorr parameter for charge >= 4." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001720
 name: ProteomeDiscoverer:1. Dynamic Modification
 def: "OBSOLETE ProteomeDiscoverer's 1st dynamic post-translational modification (PTM) input parameter." [PSI:PI]
-comment: This term was made obsolete because it's recommended to use ProteomeDiscoverer:Dynamic Modification (MS:1001644) instead.
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-is_obsolete: true
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001721
 name: ProteomeDiscoverer:2. Dynamic Modification
 def: "OBSOLETE ProteomeDiscoverer's 2nd dynamic post-translational modification (PTM) input parameter." [PSI:PI]
-comment: This term was made obsolete because it's recommended to use ProteomeDiscoverer:Dynamic Modification (MS:1001644) instead.
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-is_obsolete: true
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001722
 name: ProteomeDiscoverer:3. Dynamic Modification
 def: "OBSOLETE ProteomeDiscoverer's 3rd dynamic post-translational modification (PTM) input parameter." [PSI:PI]
-comment: This term was made obsolete because it's recommended to use ProteomeDiscoverer:Dynamic Modification (MS:1001644) instead.
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-is_obsolete: true
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001723
 name: ProteomeDiscoverer:4. Dynamic Modification
 def: "OBSOLETE ProteomeDiscoverer's 4th dynamic post-translational modification (PTM) input parameter." [PSI:PI]
-comment: This term was made obsolete because it's recommended to use ProteomeDiscoverer:Dynamic Modification (MS:1001644) instead.
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-is_obsolete: true
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001724
@@ -11067,6 +10879,7 @@ name: ProteomeDiscoverer:Static Modification for X
 def: "Static Modification for X." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001725
@@ -11074,6 +10887,7 @@ name: ProteomeDiscoverer:Initial minimal peptide probability
 def: "Minimal initial peptide probability to contribute to analysis." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001726
@@ -11081,6 +10895,7 @@ name: ProteomeDiscoverer:Minimal peptide probability
 def: "Minimum adjusted peptide probability contributing to protein probability." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001727
@@ -11088,6 +10903,7 @@ name: ProteomeDiscoverer:Minimal peptide weight
 def: "Minimum peptide weight contributing to protein probability." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001728
@@ -11095,6 +10911,7 @@ name: ProteomeDiscoverer:Number of input1 spectra
 def: "Number of spectra from 1+ precursor ions." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001729
@@ -11102,6 +10919,7 @@ name: ProteomeDiscoverer:Number of input2 spectra
 def: "Number of spectra from 2+ precursor ions." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001730
@@ -11109,6 +10927,7 @@ name: ProteomeDiscoverer:Number of input3 spectra
 def: "Number of spectra from 3+ precursor ions." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001731
@@ -11116,6 +10935,7 @@ name: ProteomeDiscoverer:Number of input4 spectra
 def: "Number of spectra from 4+ precursor ions." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001732
@@ -11123,6 +10943,7 @@ name: ProteomeDiscoverer:Number of input5 spectra
 def: "Number of spectra from 5+ precursor ions." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001733
@@ -11130,24 +10951,23 @@ name: ProteomeDiscoverer:Number of predicted correct proteins
 def: "Total number of predicted correct protein ids (sum of probabilities)." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001734
 name: ProteomeDiscoverer:Organism
 def: "OBSOLETE Sample organism (used for annotation purposes)." [PSI:MS]
-comment: This term was made obsolete because it's recommended to use taxonomy: scientific name (MS:1001469) instead.
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-is_obsolete: true
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001735
 name: ProteomeDiscoverer:Reference Database
 def: "OBSOLETE Full path database name." [PSI:MS]
-comment: This term was made obsolete. Use attribute in mzIdentML / mzQuantML instead.
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-is_obsolete: true
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001736
@@ -11155,33 +10975,31 @@ name: ProteomeDiscoverer:Residue substitution list
 def: "Residues considered equivalent when comparing peptides." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001737
 name: ProteomeDiscoverer:Source file extension
 def: "OBSOLETE File type (if not pepXML)." [PSI:MS]
-comment: This term was made obsolete because it's recommended to use mass spectrometer file format (MS:1000560) instead.
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-is_obsolete: true
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001738
 name: ProteomeDiscoverer:Source Files
 def: "OBSOLETE Input pepXML files." [PSI:MS]
-comment: This term was made obsolete because it's recommended to use pepXML file (MS:1001421) instead.
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-is_obsolete: true
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001739
 name: ProteomeDiscoverer:Source Files old
 def: "OBSOLETE Input pepXML files (old)." [PSI:MS]
-comment: This term was made obsolete because it's recommended to use pepXML file (MS:1001421) instead.
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-is_obsolete: true
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001740
@@ -11189,6 +11007,7 @@ name: ProteomeDiscoverer:WinCyg reference database
 def: "Windows full path for database." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001741
@@ -11196,6 +11015,7 @@ name: ProteomeDiscoverer:WinCyg source files
 def: "Windows pepXML file names." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001742
@@ -11209,6 +11029,7 @@ name: ProteomeDiscoverer:Mascot:Weight of A Ions
 def: "Determines if to use A ions for spectrum matching." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001744
@@ -11216,6 +11037,7 @@ name: ProteomeDiscoverer:Mascot:Weight of B Ions
 def: "Determines if to use B ions for spectrum matching." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001745
@@ -11223,6 +11045,7 @@ name: ProteomeDiscoverer:Mascot:Weight of C Ions
 def: "Determines if to use C ions for spectrum matching." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001746
@@ -11230,6 +11053,7 @@ name: ProteomeDiscoverer:Mascot:Weight of D Ions
 def: "Determines if to use D ions for spectrum matching." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001747
@@ -11237,6 +11061,7 @@ name: ProteomeDiscoverer:Mascot:Weight of V Ions
 def: "Determines if to use V ions for spectrum matching." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001748
@@ -11244,6 +11069,7 @@ name: ProteomeDiscoverer:Mascot:Weight of W Ions
 def: "Determines if to use W ions for spectrum matching." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001749
@@ -11251,6 +11077,7 @@ name: ProteomeDiscoverer:Mascot:Weight of X Ions
 def: "Determines if to use X ions for spectrum matching." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001750
@@ -11258,6 +11085,7 @@ name: ProteomeDiscoverer:Mascot:Weight of Y Ions
 def: "Determines if to use Y ions for spectrum matching." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001751
@@ -11265,6 +11093,7 @@ name: ProteomeDiscoverer:Mascot:Weight of Z Ions
 def: "Determines if to use z ions for spectrum matching." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001752
@@ -11272,6 +11101,7 @@ name: ProteomeDiscoverer:Spectrum Selector:Use New Precursor Reevaluation
 def: "Determines if to use precursor reevaluation." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001753
@@ -11279,6 +11109,7 @@ name: ProteomeDiscoverer:Spectrum Selector:SN Threshold FTonly
 def: "Signal-to-Noise ratio below which peaks are removed (in FT mode only)." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001754
@@ -11286,6 +11117,7 @@ name: ProteomeDiscoverer:Mascot:Please Do not Touch this
 def: "Unknown Mascot parameter which ProteomeDiscoverer uses for mascot searches." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001755
@@ -11293,6 +11125,7 @@ name: contact phone number
 def: "Phone number of the contact person or organization." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000585 ! contact attribute
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001756
@@ -11300,6 +11133,7 @@ name: contact fax number
 def: "Fax number for the contact person or organization." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000585 ! contact attribute
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001757
@@ -11307,6 +11141,7 @@ name: contact toll-free phone number
 def: "Toll-free phone number of the contact person or organization." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000585 ! contact attribute
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001758
@@ -11314,6 +11149,7 @@ name: Mascot:SigThresholdType
 def: "Significance threshold type used in Mascot reporting (either 'identity' or 'homology')." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002095 ! Mascot input parameter
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001759
@@ -11321,6 +11157,7 @@ name: Mascot:ProteinGrouping
 def: "Strategy used by Mascot to group proteins with same peptide matches (one of 'none', 'Occam's razor' or 'family clustering')." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002095 ! Mascot input parameter
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001760
@@ -11328,6 +11165,7 @@ name: Percolator:features
 def: "List of Percolator features that were used in processing the peptide matches. Typical Percolator features are 'retentionTime', 'dM', 'mScore', 'lgDScore', 'mrCalc', 'charge' and 'dMppm'." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002107 ! Percolator input parameter
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001761
@@ -11527,6 +11365,7 @@ name: Mascot:PreferredTaxonomy
 def: "NCBI TaxID taxonomy ID to prefer when two or more proteins match the same set of peptides or when protein entry in database represents multiple sequences." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002095 ! Mascot input parameter
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001795
@@ -11548,9 +11387,6 @@ is_a: MS:1001457 ! data processing software
 id: MS:1001797
 name: travelling wave ion mobility mass spectrometer
 def: "OBSOLETE An ion mobility mass spectrometry technique based on the superimposition of travelling voltage waves on a radially-confining RF voltage in a gas-filled, stacked-ring ion guide." [PSI:MS]
-comment: This child of the former purgatory term ion mobility spectrometry was made obsolete.
-synonym: "TWIMS" EXACT []
-is_obsolete: true
 
 [Term]
 id: MS:1001798
@@ -11621,6 +11457,7 @@ name: technical replicate
 def: "The study variable is 'technical replicate'. The string value denotes the category of technical replicate, e.g. 'run generated from same sample'." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001807 ! study variable attribute
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001809
@@ -11658,6 +11495,7 @@ name: generic experimental condition
 def: "The experimental condition is given in the value of this term." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001807 ! study variable attribute
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001815
@@ -11665,6 +11503,7 @@ name: time series, time point X
 def: "The experimental design followed a time series design. The time point of this run is given in the value of this term." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1001807 ! study variable attribute
+relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001816
@@ -11672,6 +11511,7 @@ name: dilution series, concentration X
 def: "The experimental design followed a dilution series design. The concentration of this run is given in the value of this term." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001807 ! study variable attribute
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001817
@@ -11751,6 +11591,7 @@ name: SRM transition ID
 def: "Identifier for an SRM transition in an external document describing additional information about the transition." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001828 ! feature attribute
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001830
@@ -11771,6 +11612,7 @@ name: quantitation software comment or customizations
 def: "Quantitation software comment or any customizations to the default setup of the software." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001129 ! quantification information
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001833
@@ -11820,6 +11662,7 @@ name: LC-MS feature intensity
 def: "Maximum peak intensity of the LC-MS feature." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002735 ! feature-level quantification datatype
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001841
@@ -11827,6 +11670,7 @@ name: LC-MS feature volume
 def: "Real (intensity times area) volume of the LC-MS feature." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002735 ! feature-level quantification datatype
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001842
@@ -11834,6 +11678,7 @@ name: sequence-level spectral count
 def: "The number of MS2 spectra identified for a raw peptide sequence without PTMs and charge state in spectral counting." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002737 ! peptide-level quantification datatype
+relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001843
@@ -11841,6 +11686,7 @@ name: MS1 feature maximum intensity
 def: "Maximum intensity of MS1 feature." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002735 ! feature-level quantification datatype
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001844
@@ -11848,15 +11694,15 @@ name: MS1 feature area
 def: "Area of MS1 feature." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002735 ! feature-level quantification datatype
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001845
 name: peak area
 def: "OBSOLETE Area of MS1 peak (e.g. SILAC, 15N)." [PSI:PI]
-comment: This term was made obsolete because it was a duplication of MS:1001844.
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
-is_obsolete: true
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001846
@@ -11864,6 +11710,7 @@ name: isotopic pattern area
 def: "Area of all peaks belonging to the isotopic pattern of light or heavy peak (e.g. 15N)." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001847
@@ -11871,6 +11718,7 @@ name: reporter ion intensity
 def: "Intensity of MS2 reporter ion (e.g. iTraq)." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001848
@@ -11882,10 +11730,9 @@ is_a: MS:1002066 ! ratio calculation method
 id: MS:1001849
 name: sum of MatchedFeature values
 def: "OBSOLETE Peptide quantification value calculated as sum of MatchedFeature quantification values." [PSI:PI]
-comment: This term was made obsolete because the concept MatchedFeature was dropped.
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002735 ! feature-level quantification datatype
-is_obsolete: true
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001850
@@ -11893,6 +11740,7 @@ name: normalized peptide value
 def: "Normalized peptide value." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002737 ! peptide-level quantification datatype
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001851
@@ -11900,6 +11748,7 @@ name: protein value: sum of peptide values
 def: "Protein quantification value calculated as sum of peptide values." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002738 ! protein-level quantification datatype
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001852
@@ -11907,6 +11756,7 @@ name: normalized protein value
 def: "Normalized protein value." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002738 ! protein-level quantification datatype
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001853
@@ -11914,6 +11764,7 @@ name: max fold change
 def: "Global datatype: Maximum of all pair-wise fold changes of group means (e.g. Progenesis)." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001854
@@ -11921,6 +11772,7 @@ name: ANOVA p-value
 def: "Global datatype: p-value of ANOVA of group means (e.g. Progenesis)." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002072 ! p-value
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001855
@@ -11928,6 +11780,7 @@ name: t-test p-value
 def: "P-value of t-Test of two groups." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002072 ! p-value
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001856
@@ -11935,6 +11788,7 @@ name: reporter ion raw value
 def: "Intensity (or area) of MS2 reporter ion (e.g. iTraq)." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001857
@@ -11942,6 +11796,7 @@ name: reporter ion normalized value
 def: "Normalized value of MS2 reporter ion (e.g. iTraq)." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001858
@@ -11949,6 +11804,7 @@ name: XIC area
 def: "Area of the extracted ion chromatogram (e.g. of a transition in SRM)." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001859
@@ -11956,6 +11812,7 @@ name: normalized XIC area
 def: "Normalized area of the extracted ion chromatogram (e.g. of a transition in SRM)." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001860
@@ -11963,12 +11820,13 @@ name: protein value: mean of peptide ratios
 def: "Protein quantification value calculated as mean of peptide ratios." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002738 ! protein-level quantification datatype
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001861
 name: quantification data processing
 def: "Terms used to describe types of quantification data processing." [PSI:MS]
-relationship: part_of MS:1001000 ! spectrum interpretation
+relationship: part_of: MS:1001000 ! spectrum interpretation
 
 [Term]
 id: MS:1001862
@@ -12012,7 +11870,8 @@ name: distinct peptide-level q-value
 def: "Estimation of the q-value for distinct peptides once redundant identifications of the same peptide have been removed (id est multiple PSMs, possibly with different mass modifications, mapping to the same sequence have been collapsed to one entry)." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002484 ! peptide-level statistical threshold
-relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_domain: MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001869
@@ -12020,7 +11879,8 @@ name: protein-level q-value
 def: "Estimation of the q-value for proteins." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001116 ! single protein identification statistic
-relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_domain: MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001870
@@ -12028,7 +11888,8 @@ name: peptide sequence-level p-value
 def: "Estimation of the p-value for distinct peptides once redundant identifications of the same peptide have been removed (id est multiple PSMs have been collapsed to one entry)." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001092 ! peptide sequence-level identification statistic
-relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_domain: MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001871
@@ -12036,7 +11897,8 @@ name: protein-level p-value
 def: "Estimation of the p-value for proteins." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001116 ! single protein identification statistic
-relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_domain: MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001872
@@ -12044,7 +11906,8 @@ name: peptide sequence-level e-value
 def: "Estimation of the e-value for distinct peptides once redundant identifications of the same peptide have been removed (id est multiple PSMs have been collapsed to one entry)." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001092 ! peptide sequence-level identification statistic
-relationship: has_domain MS:1002306 ! value greater than zero
+relationship: has_domain: MS:1002306 ! value greater than zero
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001873
@@ -12052,17 +11915,17 @@ name: protein-level e-value
 def: "Estimation of the e-value for proteins." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001116 ! single protein identification statistic
-relationship: has_domain MS:1002306 ! value greater than zero
+relationship: has_domain: MS:1002306 ! value greater than zero
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001874
 name: FDRScore
 def: "OBSOLETE A smoothing of the distribution of q-values calculated for PSMs from individual search engines, such that ordering of result quality is maintained and all FDRScore values are guaranteed to have a value > 0." [PMID:19253293]
-comment: This term was made obsolete because it was split into the more specific terms for PSM-level FDRScore (1002355), distinct peptide-level FDRScore (MS:1002360), protein-level FDRScore (MS:1002365) and protein group-level FDRScore (MS:1002374).
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1001153 ! search engine specific score
-is_obsolete: true
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001875
@@ -12070,6 +11933,7 @@ name: modification motif
 def: "The regular expression describing the sequence motif for a modification." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001056 ! modification specificity rule
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001876
@@ -12098,7 +11962,8 @@ name: offset voltage
 def: "The potential difference between two adjacent interface voltages affecting in-source collision induced dissociation." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000482 ! source attribute
-relationship: has_units UO:0000218 ! volt
+relationship: has_units: UO:0000218 ! volt
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001880
@@ -12116,7 +11981,7 @@ is_a: MS:1000560 ! mass spectrometer file format
 id: MS:1001882
 name: transition validation attribute
 def: "Attributes of the quality of a transition that affect its selection as appropriate." [PSI:MS]
-relationship: part_of MS:1000908 ! transition
+relationship: part_of: MS:1000908 ! transition
 
 [Term]
 id: MS:1001883
@@ -12124,6 +11989,7 @@ name: coefficient of variation
 def: "Variation of a set of signal measurements calculated as the standard deviation relative to the mean." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1001882 ! transition validation attribute
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001884
@@ -12131,6 +11997,7 @@ name: signal-to-noise ratio
 def: "Unitless number providing the ratio of the total measured intensity of a signal relative to the estimated noise level for that signal." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1001882 ! transition validation attribute
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001885
@@ -12138,6 +12005,7 @@ name: command-line parameters
 def: "Parameters string passed to a command-line interface software application, omitting the executable name." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000630 ! data processing parameter
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001886
@@ -12170,6 +12038,7 @@ name: Progenesis:protein normalised abundance
 def: "The data type normalised abundance for proteins produced by Progenesis LC-MS." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002738 ! protein-level quantification datatype
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001891
@@ -12177,6 +12046,7 @@ name: Progenesis:peptide normalised abundance
 def: "The data type normalised abundance for peptides produced by Progenesis LC-MS." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002737 ! peptide-level quantification datatype
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001892
@@ -12184,6 +12054,7 @@ name: Progenesis:protein raw abundance
 def: "The data type raw abundance for proteins produced by Progenesis LC-MS." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002738 ! protein-level quantification datatype
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001893
@@ -12191,6 +12062,7 @@ name: Progenesis:peptide raw abundance
 def: "The data type raw abundance for peptide produced by Progenesis LC-MS." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002737 ! peptide-level quantification datatype
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001894
@@ -12198,6 +12070,7 @@ name: Progenesis:confidence score
 def: "The data type confidence score produced by Progenesis LC-MS." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001895
@@ -12205,6 +12078,7 @@ name: Progenesis:peptide count
 def: "The data type peptide count produced by Progenesis LC-MS." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002737 ! peptide-level quantification datatype
+relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001896
@@ -12212,6 +12086,7 @@ name: Progenesis:feature intensity
 def: "The data type feature intensity produced by Progenesis LC-MS." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002735 ! feature-level quantification datatype
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001897
@@ -12219,6 +12094,7 @@ name: MaxQuant:peptide counts (unique)
 def: "The data type peptide counts (unique) produced by MaxQuant." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002737 ! peptide-level quantification datatype
+relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001898
@@ -12226,6 +12102,7 @@ name: MaxQuant:peptide counts (all)
 def: "The data type peptide counts (all) produced by MaxQuant." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002737 ! peptide-level quantification datatype
+relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001899
@@ -12233,6 +12110,7 @@ name: MaxQuant:peptide counts (razor+unique)
 def: "The data type peptide counts (razor+unique) produced by MaxQuant." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002737 ! peptide-level quantification datatype
+relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001900
@@ -12240,6 +12118,7 @@ name: MaxQuant:sequence length
 def: "The data type sequence length produced by MaxQuant." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002737 ! peptide-level quantification datatype
+relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001901
@@ -12247,6 +12126,7 @@ name: MaxQuant:PEP
 def: "The data type PEP (posterior error probability) produced by MaxQuant." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001902
@@ -12254,6 +12134,7 @@ name: MaxQuant:LFQ intensity
 def: "The data type LFQ intensity produced by MaxQuant." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001903
@@ -12261,6 +12142,7 @@ name: MaxQuant:feature intensity
 def: "The data type feature intensity produced by MaxQuant." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002735 ! feature-level quantification datatype
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001904
@@ -12268,6 +12150,7 @@ name: MaxQuant:MS/MS count
 def: "The data type MS2 count produced by MaxQuant." [PSI:MS]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
+relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001905
@@ -12275,6 +12158,7 @@ name: emPAI value
 def: "The emPAI value of protein abundance, produced from the emPAI algorithm." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002738 ! protein-level quantification datatype
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001906
@@ -12282,6 +12166,7 @@ name: APEX value
 def: "The APEX value of protein abundance, produced from the APEX software." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002738 ! protein-level quantification datatype
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001907
@@ -12289,8 +12174,9 @@ name: retention time window width
 def: "The full width of a retention time window for a chromatographic peak." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000915 ! retention time window attribute
-relationship: has_units UO:0000010 ! second
-relationship: has_units UO:0000031 ! minute
+relationship: has_units: UO:0000010 ! second
+relationship: has_units: UO:0000031 ! minute
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001908
@@ -12330,7 +12216,8 @@ name: S-lens voltage
 def: "Potential difference setting of the Thermo Scientific S-lens stacked-ring ion guide in volts." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000482 ! source attribute
-relationship: has_units UO:0000218 ! volt
+relationship: has_units: UO:0000218 ! volt
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001914
@@ -12343,30 +12230,28 @@ id: MS:1001915
 name: leukocyte elastase
 def: "Enzyme leukocyte elastase (EC 3.4.21.37)." [BRENDA:3.4.21.37]
 is_a: MS:1001045 ! cleavage agent name
-relationship: has_regexp MS:1001957 ! (?<=[ALIV])(?!P)
+relationship: has_regexp: MS:1001957 ! (?<=[ALIV])(?!P)
 
 [Term]
 id: MS:1001916
 name: proline endopeptidase
 def: "Enzyme proline endopeptidase (EC 3.4.21.26)." [BRENDA:3.4.21.26]
 is_a: MS:1001045 ! cleavage agent name
-relationship: has_regexp MS:1001958 ! (?<=[HKR]P)(?!P)
+relationship: has_regexp: MS:1001958 ! (?<=[HKR]P)(?!P)
 
 [Term]
 id: MS:1001917
 name: glutamyl endopeptidase
 def: "Enzyme glutamyl endopeptidase (EC 3.4.21.19)." [BRENDA:3.4.21.19]
-synonym: "staphylococcal protease" EXACT []
-synonym: "Glu-C" EXACT []
 is_a: MS:1001045 ! cleavage agent name
-relationship: has_regexp MS:1001959 ! (?<=[^E]E)
+relationship: has_regexp: MS:1001959 ! (?<=[^E]E)
 
 [Term]
 id: MS:1001918
 name: 2-iodobenzoate
 def: "Chemical iodobenzoate. Cleaves after W." [PubChem_Compound:4739928]
 is_a: MS:1001045 ! cleavage agent name
-relationship: has_regexp MS:1001960 ! (?<=W)
+relationship: has_regexp: MS:1001960 ! (?<=W)
 
 [Term]
 id: MS:1001919
@@ -12374,6 +12259,7 @@ name: ProteomeXchange accession number
 def: "Main identifier of a ProteomeXchange dataset." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001921
@@ -12381,15 +12267,16 @@ name: ProteomeXchange accession number version number
 def: "Version number of a ProteomeXchange accession number." [PSI:PI]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
+relationship: has_value_type: xsd\:nonNegativeInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001922
 name: Digital Object Identifier (DOI)
 def: "DOI unique identifier of a publication." [PSI:PI, http://dx.doi.org]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
-synonym: "doi" EXACT []
 is_a: MS:1000878 ! external reference identifier
-relationship: has_regexp MS:1002480 ! (10[.][0-9]\{4,\}(?:[.][0-9]+)*/(?:(?![\"&\'<>])[^ \t\\r\n\\v\\f])+)
+relationship: has_regexp: MS:1002480 ! (10[.][0-9]\{4,\}(?:[.][0-9]+)*/(?:(?![\"&\'<>])[^ \t\\r\n\\v\\f])+)
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001923
@@ -12397,6 +12284,7 @@ name: external reference keyword
 def: "Free text attribute that can enrich the information about an entity." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002840 ! external reference data
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001924
@@ -12404,6 +12292,7 @@ name: journal article keyword
 def: "Keyword present in a scientific publication." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001923 ! external reference keyword
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001925
@@ -12411,6 +12300,7 @@ name: submitter keyword
 def: "Keyword assigned by the data submitter." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001923 ! external reference keyword
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001926
@@ -12418,6 +12308,7 @@ name: curator keyword
 def: "Keyword assigned by a data curator." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001923 ! external reference keyword
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001927
@@ -12425,6 +12316,7 @@ name: Tranche file hash
 def: "Hash assigned by the Tranche resource to an individual file." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001928
@@ -12432,6 +12324,7 @@ name: Tranche project hash
 def: "Hash assigned by the Tranche resource to a whole project." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001929
@@ -12439,6 +12332,7 @@ name: PRIDE experiment URI
 def: "URI that allows the access to one experiment in the PRIDE database." [PSI:PI]
 xref: value-type:xsd\:anyURI "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
+relationship: has_value_type: xsd\:anyURI ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001930
@@ -12446,58 +12340,63 @@ name: PRIDE project URI
 def: "URI that allows the access to one project in the PRIDE database." [PSI:PI]
 xref: value-type:xsd\:anyURI "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
+relationship: has_value_type: xsd\:anyURI ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001931
 name: source interface
 def: "The source interface." [PSI:MS]
-relationship: part_of MS:1000458 ! source
+relationship: part_of: MS:1000458 ! source
 
 [Term]
 id: MS:1001932
 name: source interface model
 def: "The source interface model." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
-relationship: part_of MS:1001931 ! source interface
+relationship: part_of: MS:1001931 ! source interface
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001933
 name: source sprayer
 def: "The source sprayer." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
-relationship: part_of MS:1000458 ! source
+relationship: part_of: MS:1000458 ! source
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001934
 name: source sprayer type
 def: "The source sprayer type." [PSI:MS]
-relationship: part_of MS:1001933 ! source sprayer
+relationship: part_of: MS:1001933 ! source sprayer
 
 [Term]
 id: MS:1001935
 name: source sprayer manufacturer
 def: "The source sprayer manufacturer." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
-relationship: part_of MS:1001933 ! source sprayer
+relationship: part_of: MS:1001933 ! source sprayer
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001936
 name: source sprayer model
 def: "The source sprayer model." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
-relationship: part_of MS:1001933 ! source sprayer
+relationship: part_of: MS:1001933 ! source sprayer
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001937
 name: sample plate
 def: "Plate where the sample solution is spotted in a MALDI or similar instrument." [PSI:MS]
-relationship: part_of MS:1000458 ! source
+relationship: part_of: MS:1000458 ! source
 
 [Term]
 id: MS:1001938
 name: sample plate type
 def: "The sample plate type." [PSI:MS]
-relationship: part_of MS:1001937 ! sample plate
+relationship: part_of: MS:1001937 ! sample plate
 
 [Term]
 id: MS:1001939
@@ -12515,7 +12414,7 @@ is_a: MS:1001938 ! sample plate type
 id: MS:1001941
 name: electrospray supply type
 def: "Whether the sprayer is fed or is loaded with sample once." [PSI:MS]
-relationship: part_of MS:1000458 ! source
+relationship: part_of: MS:1000458 ! source
 
 [Term]
 id: MS:1001942
@@ -12535,8 +12434,8 @@ name: Collision cell exit potential
 def: "Potential difference between Q2 and Q3 in a triple quadrupole instrument in volts." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000510 ! precursor activation attribute
-relationship: has_units UO:0000218 ! volt
-synonym: "CXP" EXACT []
+relationship: has_units: UO:0000218 ! volt
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001945
@@ -12580,6 +12479,7 @@ name: PEAKS:peptideScore
 def: "The PEAKS peptide '-10lgP Score'." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001951
@@ -12587,6 +12487,7 @@ name: PEAKS:proteinScore
 def: "The PEAKS protein '-10lgP Score'." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001952
@@ -12594,20 +12495,23 @@ name: ZCore:probScore
 def: "The ZCore probability score." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001953
 name: source interface manufacturer
 def: "The source interface manufacturer." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
-relationship: part_of MS:1001931 ! source interface
+relationship: part_of: MS:1001931 ! source interface
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001954
 name: acquisition parameter
 def: "Parameters used in the mass spectrometry acquisition." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
-relationship: part_of MS:1001458 ! spectrum generation information
+relationship: part_of: MS:1001458 ! spectrum generation information
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001955
@@ -12650,7 +12554,8 @@ id: MS:1001961
 name: peptide spectrum match scoring algorithm
 def: "Algorithm used to score the match between a spectrum and a peptide ion." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
-relationship: part_of MS:1001458 ! spectrum generation information
+relationship: part_of: MS:1001458 ! spectrum generation information
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001962
@@ -12658,6 +12563,7 @@ name: Mascot:C13 counts
 def: "C13 peaks to use in peak detection." [PSI:MS]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1002095 ! Mascot input parameter
+relationship: has_value_type: xsd\:nonNegativeInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001963
@@ -12665,6 +12571,7 @@ name: ProteinExtractor:Weighting
 def: "Weighting factor for protein list compilation by ProteinExtractor." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001964
@@ -12672,6 +12579,7 @@ name: ProteinScape:second round Mascot
 def: "Flag indicating a second round search with Mascot." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002100 ! ProteinScape input parameter
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001965
@@ -12679,6 +12587,7 @@ name: ProteinScape:second round Phenyx
 def: "Flag indicating a second round search with Phenyx." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002100 ! ProteinScape input parameter
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001966
@@ -12692,9 +12601,8 @@ name: product ion drift time
 def: "OBSOLETE The ion drift time of an MS2 product ion." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002222 ! SRM transition attribute
-relationship: has_units UO:0000028 ! millisecond
-comment: This term was made obsolete because it was replaced by ion mobility drift time (MS:1002476).
-is_obsolete: true
+relationship: has_units: UO:0000028 ! millisecond
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001968
@@ -12708,7 +12616,8 @@ name: phosphoRS score
 def: "phosphoRS score for PTM site location at the PSM-level." [DOI:10.1021/pr200611n, PMID:22073976]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001968 ! PTM localization PSM-level statistic
-relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
+relationship: has_regexp: MS:1002505 ! regular expression for modification localization scoring
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001970
@@ -12716,7 +12625,8 @@ name: phosphoRS sequence probability
 def: "Probability that the respective isoform is correct." [DOI:10.1021/pr200611n, PMID:22073976]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001968 ! PTM localization PSM-level statistic
-relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
+relationship: has_regexp: MS:1002505 ! regular expression for modification localization scoring
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001971
@@ -12724,7 +12634,8 @@ name: phosphoRS site probability
 def: "Estimate of the probability that the respective site is truly phosphorylated." [DOI:10.1021/pr200611n, PMID:22073976]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001968 ! PTM localization PSM-level statistic
-relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
+relationship: has_regexp: MS:1002505 ! regular expression for modification localization scoring
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001972
@@ -12732,6 +12643,7 @@ name: PTM scoring algorithm version
 def: "Version of the post-translational modification scoring algorithm." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001471 ! peptide modification details
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001973
@@ -12746,29 +12658,30 @@ def: "Score specific to DeBunker." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001968 ! PTM localization PSM-level statistic
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
+relationship: has_regexp: MS:1002505 ! regular expression for modification localization scoring
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001975
 name: delta m/z
 def: "The difference between a theoretically calculated m/z and the corresponding experimentally measured m/z. It can be expressed as absolute or relative value." [PSI:MS]
-synonym: "m/z difference" EXACT []
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001405 ! spectrum identification result details
-relationship: has_units UO:0000166 ! parts per notation unit
-relationship: has_units UO:0000187 ! percent
-relationship: has_units UO:0000221 ! dalton
+relationship: has_units: UO:0000166 ! parts per notation unit
+relationship: has_units: UO:0000187 ! percent
+relationship: has_units: UO:0000221 ! dalton
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001976
 name: delta M
 def: "The difference between a theoretically calculated molecular mass M and the corresponding experimentally measured M. It can be expressed as absolute or relative value." [PSI:MS]
-synonym: "mass difference" EXACT []
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001405 ! spectrum identification result details
-relationship: has_units UO:0000166 ! parts per notation unit
-relationship: has_units UO:0000187 ! percent
-relationship: has_units UO:0000221 ! dalton
+relationship: has_units: UO:0000166 ! parts per notation unit
+relationship: has_units: UO:0000187 ! percent
+relationship: has_units: UO:0000221 ! dalton
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001977
@@ -12782,7 +12695,8 @@ name: MSQuant:PTM-score
 def: "The PTM score from MSQuant software." [DOI:10.1021/pr900721e, PMID:19888749]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001968 ! PTM localization PSM-level statistic
-relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
+relationship: has_regexp: MS:1002505 ! regular expression for modification localization scoring
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001979
@@ -12790,7 +12704,8 @@ name: MaxQuant:PTM Score
 def: "The PTM score from MaxQuant software." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001968 ! PTM localization PSM-level statistic
-relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
+relationship: has_regexp: MS:1002505 ! regular expression for modification localization scoring
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001980
@@ -12798,7 +12713,8 @@ name: MaxQuant:Phospho (STY) Probabilities
 def: "The Phospho (STY) Probabilities from MaxQuant software." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001968 ! PTM localization PSM-level statistic
-relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
+relationship: has_regexp: MS:1002505 ! regular expression for modification localization scoring
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001981
@@ -12806,6 +12722,7 @@ name: MaxQuant:Phospho (STY) Score Diffs
 def: "The Phospho (STY) Score Diffs from MaxQuant software." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001968 ! PTM localization PSM-level statistic
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001982
@@ -12813,7 +12730,8 @@ name: MaxQuant:P-site localization probability
 def: "The P-site localization probability value from MaxQuant software." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001968 ! PTM localization PSM-level statistic
-relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
+relationship: has_regexp: MS:1002505 ! regular expression for modification localization scoring
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001983
@@ -12821,7 +12739,8 @@ name: MaxQuant:PTM Delta Score
 def: "The PTM Delta Score value from MaxQuant software (Difference between highest scoring site and second highest)." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001968 ! PTM localization PSM-level statistic
-relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
+relationship: has_regexp: MS:1002505 ! regular expression for modification localization scoring
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001984
@@ -12835,7 +12754,8 @@ name: Ascore
 def: "A-score for PTM site location at the PSM-level." [DOI:10.1038/nbt1240, PMID:16964243]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001968 ! PTM localization PSM-level statistic
-relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
+relationship: has_regexp: MS:1002505 ! regular expression for modification localization scoring
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001986
@@ -12843,7 +12763,8 @@ name: H-Score
 def: "H-Score for peptide phosphorylation site location." [DOI:10.1021/pr1006813, PMID:20836569]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001968 ! PTM localization PSM-level statistic
-relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
+relationship: has_regexp: MS:1002505 ! regular expression for modification localization scoring
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1001987
@@ -12915,7 +12836,6 @@ is_a: MS:1000592 ! smoothing
 id: MS:1001998
 name: sophisticated numerical annotation procedure
 def: "It searches for known patterns in the measured spectrum." [DOI:10.1021/ac951158i, PMID:21619291]
-synonym: "SNAP" EXACT []
 is_a: MS:1000801 ! area peak picking
 
 [Term]
@@ -12936,6 +12856,7 @@ name: MS1 label-based raw feature quantitation
 def: "MS1 label-based raw feature quantitation." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002018 ! MS1 label-based analysis
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002002
@@ -12943,6 +12864,7 @@ name: MS1 label-based peptide level quantitation
 def: "MS1 label-based peptide level quantitation." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002018 ! MS1 label-based analysis
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002003
@@ -12950,6 +12872,7 @@ name: MS1 label-based protein level quantitation
 def: "MS1 label-based protein level quantitation." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002018 ! MS1 label-based analysis
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002004
@@ -12957,6 +12880,7 @@ name: MS1 label-based proteingroup level quantitation
 def: "MS1 label-based proteingroup level quantitation." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002018 ! MS1 label-based analysis
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002005
@@ -12968,21 +12892,18 @@ is_a: MS:1000901 ! retention time normalization standard
 id: MS:1002006
 name: SRM transition type
 def: "The type of the transitions, e.g. target or decoy." [PSI:MS]
-synonym: "MRM transition type" EXACT []
-relationship: part_of MS:1000908 ! transition
+relationship: part_of: MS:1000908 ! transition
 
 [Term]
 id: MS:1002007
 name: target SRM transition
 def: "A transition used to target a specific compound that may be in the sample." [PSI:MS]
-synonym: "target MRM transition" EXACT []
 is_a: MS:1002006 ! SRM transition type
 
 [Term]
 id: MS:1002008
 name: decoy SRM transition
 def: "A transition not expected to be present in the sample and used to calculate statistical confidence of target transition detections in some workflows." [PSI:MS]
-synonym: "decoy MRM transition" EXACT []
 is_a: MS:1002006 ! SRM transition type
 
 [Term]
@@ -13001,7 +12922,6 @@ is_a: MS:1002009 ! isobaric label quantitation analysis
 id: MS:1002011
 name: desorption electrospray ionization
 def: "Combination of electrospray and desorption ionization method that ionizes gases, liquids and solids in open air under atmospheric pressure." [DOI:10.1126/science.1104404, PMID:15486296]
-synonym: "DESI" EXACT []
 is_a: MS:1000240 ! atmospheric pressure ionization
 
 [Term]
@@ -13010,7 +12930,8 @@ name: Mascot:PTM site assignment confidence
 def: "Relative probability that PTM site assignment is correct, derived from the Mascot score difference between matches to the same spectrum (Mascot Delta Score)." [http://www.matrixscience.com/help/pt_mods_help.html#SITE]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001968 ! PTM localization PSM-level statistic
-relationship: has_units UO:0000187 ! percent
+relationship: has_units: UO:0000187 ! percent
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002013
@@ -13018,7 +12939,8 @@ name: collision energy ramp start
 def: "Collision energy at the start of the collision energy ramp." [PSI:PI]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000045 ! collision energy
-relationship: has_units UO:0000266 ! electronvolt
+relationship: has_units: UO:0000266 ! electronvolt
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002014
@@ -13026,7 +12948,8 @@ name: collision energy ramp end
 def: "Collision energy at the end of the collision energy ramp." [PSI:PI]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000045 ! collision energy
-relationship: has_units UO:0000266 ! electronvolt
+relationship: has_units: UO:0000266 ! electronvolt
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002015
@@ -13034,6 +12957,7 @@ name: spectral count peptide level quantitation
 def: "Spectral count peptide level quantitation." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001836 ! spectral counting quantitation analysis
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002016
@@ -13041,6 +12965,7 @@ name: spectral count protein level quantitation
 def: "Spectral count protein level quantitation." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001836 ! spectral counting quantitation analysis
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002017
@@ -13048,6 +12973,7 @@ name: spectral count proteingroup level quantitation
 def: "Spectral count proteingroup level quantitation." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001836 ! spectral counting quantitation analysis
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002018
@@ -13061,6 +12987,7 @@ name: label-free raw feature quantitation
 def: "Label-free raw feature quantitation." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001834 ! LC-MS label-free quantitation analysis
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002020
@@ -13068,6 +12995,7 @@ name: label-free peptide level quantitation
 def: "Label-free peptide level quantitation." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001834 ! LC-MS label-free quantitation analysis
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002021
@@ -13075,6 +13003,7 @@ name: label-free protein level quantitation
 def: "Label-free protein level quantitation." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001834 ! LC-MS label-free quantitation analysis
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002022
@@ -13082,6 +13011,7 @@ name: label-free proteingroup level quantitation
 def: "Label-free proteingroup level quantitation." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001834 ! LC-MS label-free quantitation analysis
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002023
@@ -13095,6 +13025,7 @@ name: MS2 tag-based feature level quantitation
 def: "MS2 tag-based feature level quantitation." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002023 ! MS2 tag-based analysis
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002025
@@ -13102,6 +13033,7 @@ name: MS2 tag-based peptide level quantitation
 def: "MS2 tag-based peptide level quantitation." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002023 ! MS2 tag-based analysis
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002026
@@ -13109,6 +13041,7 @@ name: MS2 tag-based protein level quantitation
 def: "MS2 tag-based protein level quantitation." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002023 ! MS2 tag-based analysis
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002027
@@ -13116,6 +13049,7 @@ name: MS2 tag-based proteingroup level quantitation
 def: "MS2 tag-based proteingroup level quantitation." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002023 ! MS2 tag-based analysis
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002028
@@ -13123,6 +13057,7 @@ name: nucleic acid base modification
 def: "Nucleic acid base modification (substitution, insertion or deletion)." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001471 ! peptide modification details
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002029
@@ -13130,6 +13065,7 @@ name: original nucleic acid sequence
 def: "Specification of the original nucleic acid sequence, prior to a modification. The value slot should hold the DNA or RNA sequence." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001471 ! peptide modification details
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002030
@@ -13137,6 +13073,7 @@ name: modified nucleic acid sequence
 def: "Specification of the modified nucleic acid sequence. The value slot should hold the DNA or RNA sequence." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001471 ! peptide modification details
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002031
@@ -13144,6 +13081,7 @@ name: PASSEL transition group browser URI
 def: "URI to retrieve transition group data for a PASSEL (PeptideAtlas SRM Experiment Library) experiment." [PSI:PI]
 xref: value-type:xsd\:anyURI "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
+relationship: has_value_type: xsd\:anyURI ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002032
@@ -13151,6 +13089,7 @@ name: PeptideAtlas dataset URI
 def: "URI that allows access to a PeptideAtlas dataset." [PSI:PI]
 xref: value-type:xsd\:anyURI "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
+relationship: has_value_type: xsd\:anyURI ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002033
@@ -13186,7 +13125,6 @@ is_a: MS:1002033 ! contact role
 id: MS:1002038
 name: label free sample
 def: "A sample that has not been labelled or modified. This is often referred to as \"light\" to distinguish from \"heavy\"." [PSI:PI]
-synonym: "light sample" EXACT []
 is_a: MS:1000548 ! sample attribute
 
 [Term]
@@ -13194,7 +13132,7 @@ id: MS:1002039
 name: inlet attribute
 def: "Inlet properties that are associated with a value." [PSI:MS]
 is_a: MS:1000547 ! object attribute
-relationship: part_of MS:1000458 ! source
+relationship: part_of: MS:1000458 ! source
 
 [Term]
 id: MS:1002040
@@ -13203,8 +13141,9 @@ def: "The temperature of the inlet of a mass spectrometer." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000482 ! source attribute
 is_a: MS:1002039 ! inlet attribute
-relationship: has_units UO:0000012 ! kelvin
-relationship: has_units UO:0000027 ! degree Celsius
+relationship: has_units: UO:0000012 ! kelvin
+relationship: has_units: UO:0000027 ! degree Celsius
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002041
@@ -13212,8 +13151,9 @@ name: source temperature
 def: "The temperature of the source of a mass spectrometer." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000482 ! source attribute
-relationship: has_units UO:0000012 ! kelvin
-relationship: has_units UO:0000027 ! degree Celsius
+relationship: has_units: UO:0000012 ! kelvin
+relationship: has_units: UO:0000027 ! degree Celsius
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002042
@@ -13221,8 +13161,9 @@ name: modulation time
 def: "The duration of a complete cycle of modulation in a comprehensive two-dimensional separation system, equals the length of a second dimension chromatogram, i.e., the time between two successive injections into the second column." [http://chromatographyonline.findanalytichem.com/lcgc/Column:+Coupling+Matters/Nomenclature-and-Conventions-in-Comprehensive-Mult/ArticleStandard/Article/detail/58429]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000857 ! run attribute
-relationship: has_units UO:0000010 ! second
-relationship: has_units UO:0000031 ! minute
+relationship: has_units: UO:0000010 ! second
+relationship: has_units: UO:0000031 ! minute
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002043
@@ -13236,6 +13177,7 @@ name: ProteinProspector:score
 def: "The ProteinProspector result 'Score'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002045
@@ -13243,6 +13185,7 @@ name: ProteinProspector:expectation value
 def: "The ProteinProspector result 'Expectation value'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002046
@@ -13250,6 +13193,7 @@ name: native source path
 def: "The original source path used for directory-based sources." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001458 ! spectrum generation information
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002047
@@ -13260,7 +13204,6 @@ is_a: MS:1001456 ! analysis software
 [Term]
 id: MS:1002048
 name: MS-GF+
-synonym: "MS-GFDB" EXACT []
 def: "MS-GF+ software used to analyze the spectra." [PSI:PI]
 is_a: MS:1001456 ! analysis software
 
@@ -13270,6 +13213,7 @@ name: MS-GF:RawScore
 def: "MS-GF raw score." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002050
@@ -13277,6 +13221,7 @@ name: MS-GF:DeNovoScore
 def: "MS-GF de novo score." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
+relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002051
@@ -13284,6 +13229,7 @@ name: MS-GF:Energy
 def: "MS-GF energy score." [PSI:PI]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type: xsd\:nonNegativeInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002052
@@ -13292,7 +13238,8 @@ def: "MS-GF spectral E-value." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002353 ! PSM-level e-value
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_order MS:1002109 ! lower score better
+relationship: has_order: MS:1002109 ! lower score better
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002053
@@ -13301,7 +13248,8 @@ def: "MS-GF E-value." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002353 ! PSM-level e-value
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_order MS:1002109 ! lower score better
+relationship: has_order: MS:1002109 ! lower score better
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002054
@@ -13310,6 +13258,7 @@ def: "MS-GF Q-value." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002354 ! PSM-level q-value
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002055
@@ -13317,6 +13266,7 @@ name: MS-GF:PepQValue
 def: "MS-GF peptide-level Q-value." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002056
@@ -13324,6 +13274,7 @@ name: MS-GF:PEP
 def: "MS-GF posterior error probability." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002057
@@ -13353,8 +13304,6 @@ is_a: MS:1002126 ! database UniProtKB
 id: MS:1002061
 name: decoy DB from UniProtKB/TrEMBL
 def: "OBSOLETE Decoy database from a TrEMBL protein sequence database." [PSI:PI]
-comment: This term was made obsolete, because a combination of database name, DB composition , decoy DB type , decoy DB generation algorithm, decoy DB accession regexp and decoy DB details suffices.
-is_obsolete: true
 
 [Term]
 id: MS:1002062
@@ -13374,6 +13323,7 @@ name: peptide consensus RT
 def: "Peptide consensus retention time." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002737 ! peptide-level quantification datatype
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002065
@@ -13381,6 +13331,7 @@ name: peptide consensus m/z
 def: "Peptide consensus mass/charge ratio." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002737 ! peptide-level quantification datatype
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002066
@@ -13388,6 +13339,7 @@ name: ratio calculation method
 def: "Method used to calculate the ratio." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002067
@@ -13395,6 +13347,7 @@ name: protein value: median of peptide ratios
 def: "Protein quantification value calculated as median of peptide ratios." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002738 ! protein-level quantification datatype
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002068
@@ -13408,6 +13361,7 @@ name: metabolic labelling purity
 def: "Metabolic labelling: Description of labelling purity. Usually the purity of feeding material (e.g. 95%), or the inclusion rate derived from isotopic peak pattern shape." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001055 ! modification parameters
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002070
@@ -13415,6 +13369,7 @@ name: t-test
 def: "Perform a t-test (two groups). Specify in string value, whether paired / unpaired, variance equal / different, one- / two-sided version is performed." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001861 ! quantification data processing
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002071
@@ -13422,6 +13377,7 @@ name: ANOVA-test
 def: "Perform an ANOVA-test (more than two groups). Specify in string value, which version is performed." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001861 ! quantification data processing
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002072
@@ -13429,7 +13385,8 @@ name: p-value
 def: "P-value as result of one of the processing steps described. Specify in the description, which processing step it was." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
-relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_domain: MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002073
@@ -13465,19 +13422,17 @@ is_a: MS:1001536 ! Bruker Daltonics micrOTOF series
 id: MS:1002078
 name: ProteomeDiscoverer:1. Static Modification
 def: "OBSOLETE ProteomeDiscoverer's 1st static post-translational modification (PTM) input parameter." [PSI:PI]
-comment: This term was made obsolete because it's recommended to use ProteomeDiscoverer:Static Modification (MS:1001645) instead.
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-is_obsolete: true
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002079
 name: ProteomeDiscoverer:2. Static Modification
 def: "OBSOLETE ProteomeDiscoverer's 2nd static post-translational modification (PTM) input parameter." [PSI:PI]
-comment: This term was made obsolete because it's recommended to use ProteomeDiscoverer:Static Modification (MS:1001645) instead.
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-is_obsolete: true
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002080
@@ -13485,7 +13440,8 @@ name: ProteomeDiscoverer:Spectrum Selector:Precursor Clipping Range Before
 def: "Precursor clipping range before." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_units UO:0000221 ! dalton
+relationship: has_units: UO:0000221 ! dalton
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002081
@@ -13493,7 +13449,8 @@ name: ProteomeDiscoverer:Spectrum Selector:Precursor Clipping Range After
 def: "Precursor clipping range after." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_units UO:0000221 ! dalton
+relationship: has_units: UO:0000221 ! dalton
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002082
@@ -13501,8 +13458,9 @@ name: first column elution time
 def: "The time of elution from the first chromatographic column in the chromatographic separation step, relative to the start of chromatography on the first column." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000503 ! scan attribute
-relationship: has_units UO:0000010 ! second
-relationship: has_units UO:0000031 ! minute
+relationship: has_units: UO:0000010 ! second
+relationship: has_units: UO:0000031 ! minute
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002083
@@ -13510,8 +13468,9 @@ name: second column elution time
 def: "The time of elution from the second chromatographic column in the chromatographic separation step, relative to the start of the chromatography on the second column." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000503 ! scan attribute
-relationship: has_units UO:0000010 ! second
-relationship: has_units UO:0000031 ! minute
+relationship: has_units: UO:0000010 ! second
+relationship: has_units: UO:0000031 ! minute
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002084
@@ -13549,6 +13508,7 @@ name: ProteomeDiscoverer:Peptide Without Protein XCorr Threshold
 def: "XCorr threshold for storing peptides that do not belong to a protein." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002090
@@ -13556,6 +13516,7 @@ name: Calculate Probability Scores
 def: "Flag indicating that a probability score for the assessment that a reported peptide match is a random occurrence is calculated." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002094 ! common search engine input parameter
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002091
@@ -13563,6 +13524,7 @@ name: ProteomeDiscoverer:Maximum Delta Cn
 def: "Delta Cn threshold for filtering out PSM's." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002092
@@ -13570,6 +13532,7 @@ name: Percolator:Validation based on
 def: "Algorithm (e.g. q-value or PEP) used for calculation of the validation score using Percolator." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002107 ! Percolator input parameter
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002093
@@ -13659,13 +13622,13 @@ is_a: MS:1002105 ! software specific input parameter
 id: MS:1002108
 name: higher score better
 def: "Indicates that a higher score is better." [PSI:PI]
-relationship: part_of MS:1001153 ! search engine specific score
+relationship: part_of: MS:1001153 ! search engine specific score
 
 [Term]
 id: MS:1002109
 name: lower score better
 def: "Indicates that a lower score is better." [PSI:PI]
-relationship: part_of MS:1001153 ! search engine specific score
+relationship: part_of: MS:1001153 ! search engine specific score
 
 [Term]
 id: MS:1002110
@@ -13761,11 +13724,10 @@ is_a: MS:1001139 ! quantitation software name
 id: MS:1002125
 name: combined FDRScore
 def: "OBSOLETE FDRScore values specifically obtained for distinct combinations of single, pairs or triplets of search engines making a given PSM, used for integrating results from these distinct pools." [PMID:19253293]
-comment: This term was made obsolete because it was split into the more specific terms for PSM-level combined FDRScore (MS:1002356), distinct peptide-level combined FDRScore (MS:1002361), protein-level combined FDRScore (MS:1002366) and protein group-level combined FDRScore (MS:1002375).
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1001153 ! search engine specific score
-is_obsolete: true
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002126
@@ -13936,6 +13898,7 @@ name: protein level PSM counts
 def: "The number of spectra identified for this protein in spectral counting." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002738 ! protein-level quantification datatype
+relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002154
@@ -14298,6 +14261,7 @@ name: PAnalyzer:conclusive protein
 def: "A protein identified by at least one unique (distinct, discrete) peptide (peptides are considered different only if they can be distinguished by evidence in mass spectrum)." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001600 ! protein inference confidence category
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002214
@@ -14305,6 +14269,7 @@ name: PAnalyzer:indistinguishable protein
 def: "A member of a group of proteins sharing all peptides that are exclusive to the group (peptides are considered different only if they can be distinguished by evidence in mass spectrum)." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001600 ! protein inference confidence category
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002215
@@ -14312,6 +14277,7 @@ name: PAnalyzer:non-conclusive protein
 def: "A protein sharing all its matched peptides with either conclusive or indistinguishable proteins (peptides are considered different only if they can be distinguished by evidence in mass spectrum)." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001600 ! protein inference confidence category
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002216
@@ -14319,6 +14285,7 @@ name: PAnalyzer:ambiguous group member
 def: "A protein sharing at least one peptide not matched to either conclusive or indistinguishable proteins (peptides are considered different only if they can be distinguished by evidence in mass spectrum)." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001600 ! protein inference confidence category
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002217
@@ -14326,6 +14293,7 @@ name: decoy peptide
 def: "A putative identified peptide issued from a decoy sequence database." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001105 ! peptide sequence-level identification attribute
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002218
@@ -14333,7 +14301,8 @@ name: percent collision energy ramp start
 def: "Collision energy at the start of the collision energy ramp in percent, normalized to the mass of the ion." [PSI:PI]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000138 ! normalized collision energy
-relationship: has_units UO:0000187 ! percent
+relationship: has_units: UO:0000187 ! percent
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002219
@@ -14341,7 +14310,8 @@ name: percent collision energy ramp end
 def: "Collision energy at the end of the collision energy ramp in percent, normalized to the mass of the ion." [PSI:PI]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000138 ! normalized collision energy
-relationship: has_units UO:0000187 ! percent
+relationship: has_units: UO:0000187 ! percent
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002220
@@ -14361,7 +14331,7 @@ id: MS:1002222
 name: SRM transition attribute
 def: "Attribute associated with a SRM transition." [PSI:MS]
 is_a: MS:1000455 ! ion selection attribute
-relationship: part_of MS:1000908 ! transition
+relationship: part_of: MS:1000908 ! transition
 
 [Term]
 id: MS:1002223
@@ -14369,6 +14339,7 @@ name: precursor ion detection probability
 def: "Probability of detecting precursor when parent protein is present." [PSI:PI]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002222 ! SRM transition attribute
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002224
@@ -14376,26 +14347,27 @@ name: product ion detection probability
 def: "Probability of detecting product ion when precursor ion is present." [PSI:PI]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002222 ! SRM transition attribute
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002225
 name: average product ion intensity
 def: "Average value of product ion intensity in a collection of identified spectra." [PSI:PI]
 is_a: MS:1001226 ! product ion intensity
-relationship: has_units MS:1000131 ! number of detector counts
-relationship: has_units MS:1000132 ! percent of base peak
-relationship: has_units MS:1000814 ! counts per second
-relationship: has_units MS:1000905 ! percent of base peak times 100
+relationship: has_units: MS:1000131 ! number of detector counts
+relationship: has_units: MS:1000132 ! percent of base peak
+relationship: has_units: MS:1000814 ! counts per second
+relationship: has_units: MS:1000905 ! percent of base peak times 100
 
 [Term]
 id: MS:1002226
 name: product ion intensity standard deviation
 def: "Standard deviation of product ion intensity in a collection of identified spectra." [PSI:PI]
 is_a: MS:1001226 ! product ion intensity
-relationship: has_units MS:1000131 ! number of detector counts
-relationship: has_units MS:1000132 ! percent of base peak
-relationship: has_units MS:1000814 ! counts per second
-relationship: has_units MS:1000905 ! percent of base peak times 100
+relationship: has_units: MS:1000131 ! number of detector counts
+relationship: has_units: MS:1000132 ! percent of base peak
+relationship: has_units: MS:1000814 ! counts per second
+relationship: has_units: MS:1000905 ! percent of base peak times 100
 
 [Term]
 id: MS:1002227
@@ -14403,6 +14375,7 @@ name: number of product ion observations
 def: "The number of times the specific product ion has been observed in a series of SRM experiments." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002222 ! SRM transition attribute
+relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002228
@@ -14410,6 +14383,7 @@ name: number of precursor ion observations
 def: "The number of times the specific precursor ion has been observed in a series of SRM experiments." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002222 ! SRM transition attribute
+relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002229
@@ -14417,6 +14391,7 @@ name: ProteomeDiscoverer:Mascot:Significance Middle
 def: "Calculated relaxed significance when performing a decoy search for high-confidence peptides." [PSI:PI]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002230
@@ -14424,6 +14399,7 @@ name: ProteomeDiscoverer:Mascot:Significance High
 def: "Calculated relaxed significance when performing a decoy search for medium-confidence peptides." [PSI:PI]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002231
@@ -14436,7 +14412,7 @@ id: MS:1002232
 name: ProteomeDiscoverer:Default FDR calculator
 def: "The default FDR calculator as globally unique identifier (GUID)." [PSI:PI]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_regexp MS:1002231 ! regular expressions for a GUID
+relationship: has_regexp: MS:1002231 ! regular expressions for a GUID
 
 [Term]
 id: MS:1002233
@@ -14444,15 +14420,16 @@ name: ProteomeDiscoverer:SEQUEST:Low resolution spectra contained
 def: "Flag indicating if low-resolution spectra are taken into consideration." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002234
 name: selected precursor m/z
 def: "Mass-to-charge ratio of a precursor ion selected for fragmentation." [PSI:PI]
-synonym: "selected ion m/z" RELATED []
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000455 ! ion selection attribute
-relationship: has_units MS:1000040 ! m/z
+relationship: has_units: MS:1000040 ! m/z
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002235
@@ -14460,6 +14437,7 @@ name: ProteoGrouper:PDH score
 def: "A score assigned to a single protein accession (modelled as ProteinDetectionHypothesis in mzIdentML), based on summed peptide level scores." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002236
@@ -14467,6 +14445,7 @@ name: ProteoGrouper:PAG score
 def: "A score assigned to a protein group (modelled as ProteinAmbiguityGroup in mzIdentML), based on all summed peptide level scores that have been assigned to the group as unique or razor peptides." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002368 ! search engine specific score for protein groups
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002237
@@ -14540,6 +14519,7 @@ name: SEQUEST:spscore
 def: "The SEQUEST result 'SpScore'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002249
@@ -14547,6 +14527,7 @@ name: SEQUEST:sprank
 def: "The SEQUEST result 'SpRank'." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002250
@@ -14554,6 +14535,7 @@ name: SEQUEST:deltacnstar
 def: "The SEQUEST result 'DeltaCnStar'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002251
@@ -14567,7 +14549,8 @@ name: Comet:xcorr
 def: "The Comet result 'XCorr'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_order MS:1002108 ! higher score better
+relationship: has_order: MS:1002108 ! higher score better
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002253
@@ -14575,6 +14558,7 @@ name: Comet:deltacn
 def: "The Comet result 'DeltaCn'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002254
@@ -14582,6 +14566,7 @@ name: Comet:deltacnstar
 def: "The Comet result 'DeltaCnStar'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002255
@@ -14589,6 +14574,7 @@ name: Comet:spscore
 def: "The Comet result 'SpScore'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002256
@@ -14596,6 +14582,7 @@ name: Comet:sprank
 def: "The Comet result 'SpRank'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002257
@@ -14603,6 +14590,7 @@ name: Comet:expectation value
 def: "The Comet result 'Expectation value'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001153 ! search engine specific score
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002258
@@ -14610,6 +14598,7 @@ name: Comet:matched ions
 def: "The Comet result 'Matched Ions'." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002259
@@ -14617,6 +14606,7 @@ name: Comet:total ions
 def: "The Comet result 'Total Ions'." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002260
@@ -14624,6 +14614,7 @@ name: PSM:FDR threshold
 def: "False-discovery rate threshold for peptide-spectrum matches." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002483 ! PSM-level statistical threshold
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002261
@@ -14637,7 +14628,8 @@ name: Byonic:Score
 def: "The Byonic score is the primary indicator of PSM correctness. The Byonic score reflects the absolute quality of the peptide-spectrum match, not the relative quality compared to other candidate peptides. Byonic scores range from 0 to about 1000, with 300 a good score, 400 a very good score, and PSMs with scores over 500 almost sure to be correct." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_order MS:1002108 ! higher score better
+relationship: has_order: MS:1002108 ! higher score better
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002263
@@ -14645,7 +14637,8 @@ name: Byonic:Delta Score
 def: "The drop in Byonic score from the top-scoring peptide to the next peptide with distinct sequence. In this computation, the same peptide with different modifications is not considered distinct." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_order MS:1002108 ! higher score better
+relationship: has_order: MS:1002108 ! higher score better
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002264
@@ -14653,7 +14646,8 @@ name: Byonic:DeltaMod Score
 def: "The drop in Byonic score from the top-scoring peptide to the next peptide different in any way, including placement of modifications. DeltaMod gives an indication of whether modifications are confidently localized; DeltaMod over 10.0 means that there is high likelihood that all modification placements are correct." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_order MS:1002108 ! higher score better
+relationship: has_order: MS:1002108 ! higher score better
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002265
@@ -14661,7 +14655,8 @@ name: Byonic:PEP
 def: "Byonic posterior error probability." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_order MS:1002109 ! lower score better
+relationship: has_order: MS:1002109 ! lower score better
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002266
@@ -14669,7 +14664,8 @@ name: Byonic:Peptide LogProb
 def: "The log p-value of the PSM. This is the log of the probability that the PSM with such a score and delta would arise by chance in a search of this size (the size of the protein database, as expanded by the modification rules). A log p-value of -3.0 should happen by chance on only one of a thousand spectra. Caveat: it is very hard to compute a p-value that works for all searches and all spectra, so read Byonic p-values with a certain amount of skepticism." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_order MS:1002109 ! lower score better
+relationship: has_order: MS:1002109 ! lower score better
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002267
@@ -14678,7 +14674,8 @@ def: "The log p-value of the protein." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_order MS:1002109 ! lower score better
+relationship: has_order: MS:1002109 ! lower score better
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002268
@@ -14687,7 +14684,8 @@ def: "Best (most negative) log p-value of an individual PSM." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001116 ! single protein identification statistic
 is_a: MS:1001153 ! search engine specific score
-relationship: has_order MS:1002109 ! lower score better
+relationship: has_order: MS:1002109 ! lower score better
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002269
@@ -14695,7 +14693,8 @@ name: Byonic:Best Score
 def: "Best (largest) Byonic score of a PSM." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_order MS:1002108 ! higher score better
+relationship: has_order: MS:1002108 ! higher score better
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002270
@@ -14721,7 +14720,8 @@ name: detector potential
 def: "Detector potential difference in volts." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000481 ! detector attribute
-relationship: has_units UO:0000218 ! volt
+relationship: has_units: UO:0000218 ! volt
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002274
@@ -14793,7 +14793,6 @@ is_a: MS:1001838 ! SRM quantitation analysis
 id: MS:1002285
 name: Trans-Proteomic Pipeline
 def: "A suite of open source tools for the processing of MS2 proteomics data developed by the Seattle Proteome Center at the Institute for Systems Biology." [PSI:PI]
-synonym: "TPP" EXACT []
 is_a: MS:1001456 ! analysis software
 
 [Term]
@@ -14801,7 +14800,7 @@ id: MS:1002286
 name: Trans-Proteomic Pipeline software
 def: "A software program that is a component of the Trans-Proteomic Pipeline." [PSI:PI]
 is_a: MS:1001456 ! analysis software
-relationship: part_of MS:1002285 ! Trans-Proteomic Pipeline
+relationship: part_of: MS:1002285 ! Trans-Proteomic Pipeline
 
 [Term]
 id: MS:1002287
@@ -14813,7 +14812,6 @@ is_a: MS:1002286 ! Trans-Proteomic Pipeline software
 id: MS:1002288
 name: iProphet
 def: "A program in the TPP that calculates distinct peptide probabilities based on several lines of corroborating evidence including search results from multiple search engines via the pepXML format." [PMID:21876204]
-synonym: "InterProphet" EXACT []
 is_a: MS:1002286 ! Trans-Proteomic Pipeline software
 
 [Term]
@@ -14906,12 +14904,13 @@ name: Bruker Container nativeID format
 def: "Native identifier (UUID)." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000767 ! native spectrum identifier format
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002304
 name: domain range
 def: "Domain range of a numerical value." [PSI:PI]
-relationship: part_of MS:0000000 ! Proteomics Standards Initiative Mass Spectrometry Vocabularies
+relationship: part_of: MS:0000000 ! Proteomics Standards Initiative Mass Spectrometry Vocabularies
 
 [Term]
 id: MS:1002305
@@ -14943,7 +14942,8 @@ name: Byonic: Peptide AbsLogProb
 def: "The absolute value of the log-base10 of the Byonic posterior error probability (PEP) of the PSM." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_order MS:1002108 ! higher score better
+relationship: has_order: MS:1002108 ! higher score better
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002310
@@ -14951,7 +14951,8 @@ name: Byonic: Protein AbsLogProb
 def: "The absolute value of the log-base10 of the Byonic posterior error probability (PEP) of the protein." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_order MS:1002108 ! higher score better
+relationship: has_order: MS:1002108 ! higher score better
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002311
@@ -14959,7 +14960,8 @@ name: Byonic: Peptide AbsLogProb2D
 def: "The absolute value of the log-base10 Byonic two-dimensional posterior error probability (PEP) of the PSM. The two-dimensional PEP takes into account protein ranking information as well as PSM information." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_order MS:1002108 ! higher score better
+relationship: has_order: MS:1002108 ! higher score better
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002312
@@ -14991,6 +14993,7 @@ name: ProteomeDiscoverer:Amanda:high confidence threshold
 def: "Strict confidence probability score." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002317
@@ -14998,6 +15001,7 @@ name: ProteomeDiscoverer:Amanda:middle confidence threshold
 def: "Relaxed confidence probability score." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002318
@@ -15005,6 +15009,7 @@ name: ProteomeDiscoverer:automatic workload
 def: "Flag indicating automatic estimation of the workload level." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002319
@@ -15012,6 +15017,7 @@ name: Amanda:AmandaScore
 def: "The Amanda score of the scoring function for a PSM." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002320
@@ -15019,6 +15025,7 @@ name: ProteomeDiscoverer:max differential modifications
 def: "Maximum dynamic modifications per PSM." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002321
@@ -15026,6 +15033,7 @@ name: ProteomeDiscoverer:max equal modifications
 def: "Maximum equal modifications per PSM." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002322
@@ -15033,6 +15041,7 @@ name: ProteomeDiscoverer:min peptide length
 def: "Minimum peptide length." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002323
@@ -15040,6 +15049,7 @@ name: ProteomeDiscoverer:max peptide length
 def: "Maximum peptide length." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002324
@@ -15047,6 +15057,7 @@ name: ProteomeDiscoverer:max number neutral loss
 def: "Maximum number of same neutral losses." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002325
@@ -15054,6 +15065,7 @@ name: ProteomeDiscoverer:max number neutral loss modifications
 def: "Max number of same neutral losses of modifications." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002326
@@ -15061,6 +15073,7 @@ name: ProteomeDiscoverer:use flanking ions
 def: "Flag for usage of flanking ions." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002327
@@ -15068,6 +15081,7 @@ name: ProteomeDiscoverer:max number of same modifs
 def: "The maximum number of possible equal modifications per PSM." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002328
@@ -15075,6 +15089,7 @@ name: ProteomeDiscoverer:perform deisotoping
 def: "Defines whether a simple deisotoping shall be performed." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002329
@@ -15082,24 +15097,23 @@ name: ProteomeDiscoverer:ion settings
 def: "Specifies the fragment ions and neutral losses that are calculated." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002330
 name: ProteomeDiscoverer:3. Static Modification
 def: "OBSOLETE ProteomeDiscoverer's 3rd static post-translational modification (PTM) input parameter." [PSI:PI]
-comment: This term was made obsolete because it's recommended to use ProteomeDiscoverer:Static Modification (MS:1001645) instead.
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-is_obsolete: true
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002331
 name: ProteomeDiscoverer:5. Dynamic Modification
 def: "OBSOLETE ProteomeDiscoverer's 5th dynamic post-translational modification (PTM) input parameter." [PSI:PI]
-comment: This term was made obsolete because it's recommended to use ProteomeDiscoverer:Dynamic Modification (MS:1001644) instead.
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-is_obsolete: true
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002332
@@ -15143,7 +15157,8 @@ name: Andromeda:score
 def: "The probability based score of the Andromeda search engine." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_order MS:1002108 ! higher score better
+relationship: has_order: MS:1002108 ! higher score better
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002339
@@ -15151,6 +15166,7 @@ name: site:global FDR
 def: "Estimation of global false discovery rate of peptides with a post-translational modification." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001405 ! spectrum identification result details
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002340
@@ -15158,6 +15174,7 @@ name: ProteomeXchange project tag
 def: "Tag that can be added to a ProteomeXchange dataset, to enable the grouping of datasets. One tag can be used for indicating that a given dataset is part of a bigger project, like e.g. the Human Proteome Project." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002341
@@ -15165,6 +15182,7 @@ name: second-pass peptide identification
 def: "A putative identified peptide found in a second-pass search of protein sequences selected from a first-pass search." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001105 ! peptide sequence-level identification attribute
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002342
@@ -15177,8 +15195,6 @@ is_a: MS:1001457 ! data processing software
 id: MS:1002343
 name: ion stability type
 def: "OBSOLETE Stability type of the ion." [PSI:PI]
-comment: This child of the former purgatory term ion was made obsolete.
-is_obsolete: true
 
 [Term]
 id: MS:1002344
@@ -15223,7 +15239,8 @@ name: PSM-level global FDR
 def: "Estimation of the global false discovery rate of peptide spectrum matches." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002701 ! PSM-level result list statistic
-relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_domain: MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002351
@@ -15231,7 +15248,8 @@ name: PSM-level local FDR
 def: "Estimation of the local false discovery rate of peptide spectrum matches." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002347 ! PSM-level identification statistic
-relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_domain: MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002352
@@ -15239,7 +15257,8 @@ name: PSM-level p-value
 def: "Estimation of the p-value for peptide spectrum matches." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002347 ! PSM-level identification statistic
-relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_domain: MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002353
@@ -15247,7 +15266,8 @@ name: PSM-level e-value
 def: "Estimation of the e-value for peptide spectrum matches." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002347 ! PSM-level identification statistic
-relationship: has_domain MS:1002306 ! value greater than zero
+relationship: has_domain: MS:1002306 ! value greater than zero
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002354
@@ -15255,7 +15275,8 @@ name: PSM-level q-value
 def: "Estimation of the q-value for peptide spectrum matches." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002347 ! PSM-level identification statistic
-relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_domain: MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002355
@@ -15264,7 +15285,8 @@ def: "mzidLibrary FDRScore for peptide spectrum matches." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_domain MS:1002349 ! value greater than zero but less than or equal to 1
+relationship: has_domain: MS:1002349 ! value greater than zero but less than or equal to 1
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002356
@@ -15273,7 +15295,8 @@ def: "mzidLibrary Combined FDRScore for peptide spectrum matches specifically ob
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_domain MS:1002349 ! value greater than zero but less than or equal to 1
+relationship: has_domain: MS:1002349 ! value greater than zero but less than or equal to 1
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002357
@@ -15281,7 +15304,8 @@ name: PSM-level probability
 def: "Probability that the reported peptide ion is truly responsible for some or all of the components of the specified mass spectrum." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002347 ! PSM-level identification statistic
-relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_domain: MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002358
@@ -15295,7 +15319,8 @@ name: peptide sequence-level local FDR
 def: "Estimation of the local false discovery rate for distinct peptides once redundant identifications of the same peptide have been removed (id est multiple PSMs have been collapsed to one entry)." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001092 ! peptide sequence-level identification statistic
-relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_domain: MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002360
@@ -15304,7 +15329,8 @@ def: "MzidLibrary FDRScore for distinct peptides once redundant identifications 
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002358 ! search engine specific peptide sequence-level identification statistic
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_domain MS:1002349 ! value greater than zero but less than or equal to one
+relationship: has_domain: MS:1002349 ! value greater than zero but less than or equal to one
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002361
@@ -15313,7 +15339,8 @@ def: "Combined FDRScore for peptides once redundant identifications of the same 
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002358 ! search engine specific peptide sequence-level identification statistic
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_domain MS:1002349 ! value greater than zero but less than or equal to one
+relationship: has_domain: MS:1002349 ! value greater than zero but less than or equal to one
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002362
@@ -15321,7 +15348,8 @@ name: peptide sequence-level probability
 def: "Probability that the reported distinct peptide sequence (irrespective of mass modifications) has been correctly identified via the referenced PSMs." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001092 ! peptide sequence-level identification statistic
-relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_domain: MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002363
@@ -15335,6 +15363,7 @@ name: protein-level local FDR
 def: "Estimation of the local false discovery rate of proteins." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001116 ! single protein identification statistic
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002365
@@ -15342,7 +15371,8 @@ name: FDRScore for proteins
 def: "MzidLibrary FDRScore for proteins specifically obtained for distinct combinations of single, pairs or triplets of search engines making a given PSM, used for integrating results from these distinct pools." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_domain MS:1002349 ! value greater than zero but less than or equal to one
+relationship: has_domain: MS:1002349 ! value greater than zero but less than or equal to one
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002366
@@ -15350,7 +15380,8 @@ name: combined FDRScore for proteins
 def: "MzidLibrary Combined FDRScore for proteins." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_domain MS:1002349 ! value greater than zero but less than or equal to one
+relationship: has_domain: MS:1002349 ! value greater than zero but less than or equal to one
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002367
@@ -15358,7 +15389,8 @@ name: probability for proteins
 def: "Probability that a specific protein sequence has been correctly identified from the PSM and distinct peptide evidence, and based on the available protein sequences presented to the analysis software." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001116 ! single protein identification statistic
-relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_domain: MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002368
@@ -15372,6 +15404,7 @@ name: protein group-level global FDR
 def: "Estimation of the global false discovery rate of protein groups." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002706 ! protein group-level result list statistic
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002370
@@ -15379,6 +15412,7 @@ name: protein group-level local FDR
 def: "Estimation of the local false discovery rate of protein groups." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002348 ! protein group-level identification statistic
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002371
@@ -15386,7 +15420,8 @@ name: protein group-level p-value
 def: "Estimation of the p-value for protein groups." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002348 ! protein group-level identification statistic
-relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_domain: MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002372
@@ -15394,7 +15429,8 @@ name: protein group-level e-value
 def: "Estimation of the e-value for protein groups." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002348 ! protein group-level identification statistic
-relationship: has_domain MS:1002306 ! value greater than zero
+relationship: has_domain: MS:1002306 ! value greater than zero
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002373
@@ -15402,7 +15438,8 @@ name: protein group-level q-value
 def: "Estimation of the q-value for protein groups." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002348 ! protein group-level identification statistic
-relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_domain: MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002374
@@ -15410,7 +15447,8 @@ name: protein group-level FDRScore
 def: "mzidLibrary FDRScore for protein groups." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002368 ! search engine specific score for protein groups
-relationship: has_domain MS:1002349 ! value greater than zero but less than or equal to one
+relationship: has_domain: MS:1002349 ! value greater than zero but less than or equal to one
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002375
@@ -15418,7 +15456,8 @@ name: protein group-level combined FDRScore
 def: "mzidLibrary Combined FDRScore for proteins specifically obtained for distinct combinations of single, pairs or triplets of search engines making a given PSM, used for integrating results from these distinct pools." [PMID:19253293]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002368 ! search engine specific score for protein groups
-relationship: has_domain MS:1002349 ! value greater than zero but less than or equal to one
+relationship: has_domain: MS:1002349 ! value greater than zero but less than or equal to one
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002376
@@ -15426,7 +15465,8 @@ name: protein group-level probability
 def: "Probability that at least one of the members of a group of protein sequences has been correctly identified from the PSM and distinct peptide evidence, and based on the available protein sequences presented to the analysis software." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002348 ! protein group-level identification statistic
-relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_domain: MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002377
@@ -15434,6 +15474,7 @@ name: ProteomeDiscoverer:Relaxed Score Threshold
 def: "Specifies the threshold value for relaxed scoring." [PSI:PI]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002378
@@ -15441,6 +15482,7 @@ name: ProteomeDiscoverer:Strict Score Threshold
 def: "Specifies the threshold value for strict scoring." [PSI:PI]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002379
@@ -15448,6 +15490,7 @@ name: ProteomeDiscoverer:Peptide Without Protein Cut Off Score
 def: "Cut off score for storing peptides that do not belong to a protein." [PSI:PI]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002380
@@ -15455,6 +15498,7 @@ name: false localization rate
 def: "Estimation of the false localization rate for modification site assignment." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001405 ! spectrum identification result details
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002381
@@ -15523,6 +15567,7 @@ name: PIA:FDRScore calculated
 def: "Indicates whether the FDR score was calculated for the input file." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002389 ! PIA workflow parameter
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002391
@@ -15530,6 +15575,7 @@ name: PIA:Combined FDRScore calculated
 def: "Indicates whether the combined FDR score was calculated for the PIA compilation." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002389 ! PIA workflow parameter
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002392
@@ -15537,6 +15583,7 @@ name: PIA:PSM sets created
 def: "Indicates whether PSM sets were created." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002389 ! PIA workflow parameter
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002393
@@ -15544,6 +15591,7 @@ name: PIA:used top identifications for FDR
 def: "The number of top identifications per spectrum used for the FDR calculation, 0 means all." [PSI:PI]
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1002389 ! PIA workflow parameter
+relationship: has_value_type: xsd\:positiveInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002394
@@ -15551,7 +15599,8 @@ name: PIA:protein score
 def: "The score given to a protein by any protein inference." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_order MS:1002108 ! higher score better
+relationship: has_order: MS:1002108 ! higher score better
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002395
@@ -15559,6 +15608,7 @@ name: PIA:protein inference
 def: "The used algorithm for the protein inference using PIA." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002389 ! PIA workflow parameter
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002396
@@ -15566,6 +15616,7 @@ name: PIA:protein inference filter
 def: "A filter used by PIA for the protein inference." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002389 ! PIA workflow parameter
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002397
@@ -15573,6 +15624,7 @@ name: PIA:protein inference scoring
 def: "The used scoring method for the protein inference using PIA." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002389 ! PIA workflow parameter
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002398
@@ -15580,6 +15632,7 @@ name: PIA:protein inference used score
 def: "The used base score for the protein inference using PIA." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002389 ! PIA workflow parameter
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002399
@@ -15587,6 +15640,7 @@ name: PIA:protein inference used PSMs
 def: "The method to determine the PSMs used for scoring by the protein inference." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002389 ! PIA workflow parameter
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002400
@@ -15594,6 +15648,7 @@ name: PIA:filter
 def: "A filter used for the report generation." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002389 ! PIA workflow parameter
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002401
@@ -15619,6 +15674,7 @@ name: count of identified proteins
 def: "The number of proteins that have been identified, which must match the number of groups that pass the threshold in the file." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002704 ! protein-level result list attribute
+relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002405
@@ -15632,6 +15688,7 @@ name: count of identified clusters
 def: "The number of protein clusters that have been identified, which must match the number of clusters that pass the threshold in the file." [DOI:10.1002/pmic.201400080, PMID:25092112]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002405 ! protein group-level result list attribute
+relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002407
@@ -15639,6 +15696,7 @@ name: cluster identifier
 def: "An identifier applied to protein groups to indicate that they are linked by shared peptides." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002698 ! protein cluster identification attribute
+relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002408
@@ -15646,6 +15704,7 @@ name: number of distinct protein sequences
 def: "The number of protein clusters that have been identified, which must match the number of clusters that pass the threshold in the file." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002405 ! protein group-level result list attribute
+relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002409
@@ -15672,6 +15731,7 @@ name: total XIC area
 def: "Summed area of all the extracted ion chromatogram for the peptide (e.g. of all the transitions in SRM)." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002737 ! peptide-level quantification datatype
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002413
@@ -15679,6 +15739,7 @@ name: product background
 def: "The background area for the quantified transition." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002414
@@ -15692,6 +15753,7 @@ name: protein group passes threshold
 def: "A Boolean attribute to determine whether the protein group has passed the threshold indicated in the file." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002346 ! protein group-level identification attribute
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002416
@@ -15723,6 +15785,7 @@ name: PASSEL experiment URI
 def: "URI that allows access to a PASSEL experiment." [PSI:PI]
 xref: value-type:xsd\:anyURI "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
+relationship: has_value_type: xsd\:anyURI ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002421
@@ -15736,6 +15799,7 @@ name: Paragon: sample type
 def: "The Paragon method setting indicating the type of sample at the high level, generally meaning the type of quantitation labelling or lack thereof. 'Identification' is indicated for samples without any labels for quantitation." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002421 ! Paragon input parameter
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002423
@@ -15743,6 +15807,7 @@ name: Paragon: cysteine alkylation
 def: "The Paragon method setting indicating the actual cysteine alkylation agent; 'None' is indicated if there was no cysteine alkylation." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002421 ! Paragon input parameter
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002424
@@ -15750,6 +15815,7 @@ name: Paragon: instrument setting
 def: "The Paragon method setting (translating to a large number of lower level settings) indicating the instrument used or a category of instrument." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002421 ! Paragon input parameter
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002425
@@ -15757,6 +15823,7 @@ name: Paragon: search effort
 def: "The Paragon method setting that controls the two major modes of search effort of the Paragon algorithm: the Rapid mode uses a conventional database search, while the Thorough mode uses a hybrid search, starting with the same approach as the Rapid mode but then follows it with a separate tag-based approach enabling a more extensive search." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002421 ! Paragon input parameter
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002426
@@ -15764,6 +15831,7 @@ name: Paragon: ID focus
 def: "A Paragon method setting that allows the inclusion of large sets of features such as biological modification or substitutions." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002421 ! Paragon input parameter
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002427
@@ -15771,6 +15839,7 @@ name: Paragon: FDR analysis
 def: "The Paragon method setting that controls whether FDR analysis is conducted." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002421 ! Paragon input parameter
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002428
@@ -15778,6 +15847,7 @@ name: Paragon: quantitation
 def: "The Paragon method setting that controls whether quantitation analysis is conducted." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002421 ! Paragon input parameter
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002429
@@ -15785,6 +15855,7 @@ name: Paragon: background correction
 def: "The Paragon method setting that controls whether the 'Background Correction' analysis is conducted; this processing estimates a correction to the attenuation in extremity ratios that can occur in isobaric quantatitation workflows on complex samples." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002421 ! Paragon input parameter
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002430
@@ -15792,6 +15863,7 @@ name: Paragon: bias correction
 def: "The Paragon method setting that controls whether 'Bias Correction' is invoked in quantitation analysis; this correction is a normalization to set the central tendency of protein ratios to unity." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002421 ! Paragon input parameter
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002431
@@ -15799,6 +15871,7 @@ name: Paragon: channel to use as denominator in ratios
 def: "The Paragon method setting that controls which label channel is used as the denominator in calculating relative expression ratios." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002421 ! Paragon input parameter
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002432
@@ -15812,6 +15885,7 @@ name: Paragon: modified data dictionary or parameter translation
 def: "This metric detects if any changes have been made to the originally installed key control files for the software; if no changes have been made, then the software version and settings are sufficient to enable exact reproduction; if changes have been made, then the modified ParameterTranslation- and ProteinPilot DataDictionary-XML files much also be provided in order to exactly reproduce a result." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002432 ! search engine specific input metadata
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002434
@@ -15819,6 +15893,7 @@ name: number of spectra searched
 def: "Number of spectra in a search." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1001249 ! search input details
+relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002435
@@ -15826,6 +15901,7 @@ name: data processing start time
 def: "The time that a data processing action was started." [PSI:MS]
 xref: value-type:xsd\:dateTime "The allowed value-type for this CV term."
 is_a: MS:1000630 ! data processing parameter
+relationship: has_value_type: xsd\:dateTime ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002436
@@ -15833,6 +15909,7 @@ name: Paragon: digestion
 def: "The Paragon method setting indicating the actual digestion agent - unlike other search tools, this setting does not include options that control partial specificity like 'semitrypsin'; if trypsin is used, trypsin is set, and partially conforming peptides are found in the Thorough mode of search; 'None' should be indicated only if there was really no digestion done." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001249 ! search input details
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002437
@@ -15840,12 +15917,13 @@ name: number of decoy sequences
 def: "The number of decoy sequences, if the concatenated target-decoy approach is used." [PSI:PI]
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1001011 ! search database details
+relationship: has_value_type: xsd\:positiveInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002438
 name: spectrum identification list result details
 def: "Information about the list of PSMs (SpectrumIdentificationList)." [PSI:PI]
-relationship: part_of MS:1001000 ! spectrum interpretation
+relationship: part_of: MS:1001000 ! spectrum interpretation
 
 [Term]
 id: MS:1002439
@@ -15901,6 +15979,7 @@ name: Paragon:special factor
 def: "The Paragon method setting indicating a list of one or more 'special factors', which generally capture secondary effects (relative to other settings) as a set of probabilities of modification features that override the assumed levels. For example the 'gel-based ID' special factor causes an increase probability of oxidation on several resides because of the air exposure impact on a gel, in addition to other effects." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002421 ! Paragon input parameter
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002448
@@ -15908,6 +15987,7 @@ name: PEAKS:inChorusPeptideScore
 def: "The PEAKS inChorus peptide score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002449
@@ -15915,6 +15995,7 @@ name: PEAKS:inChorusProteinScore
 def: "The PEAKS inChorus protein score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002450
@@ -15951,28 +16032,22 @@ is_a: MS:1002094 ! common search engine input parameter
 id: MS:1002455
 name: H2O neutral loss
 def: "OBSOLETE Neutral loss of water." [PSI:PI]
-comment: This term was obsoleted because it should be replaced by MS:1000336 with value H2O.
 is_a: MS:1000336 ! neutral loss
 is_a: MS:1002473 ! ion series considered in search
-is_obsolete: true
 
 [Term]
 id: MS:1002456
 name: NH3 neutral loss
 def: "OBSOLETE Neutral loss of ammonia." [PSI:PI]
-comment: This term was obsoleted because it should be replaced by MS:1000336 with value NH3.
 is_a: MS:1000336 ! neutral loss
 is_a: MS:1002473 ! ion series considered in search
-is_obsolete: true
 
 [Term]
 id: MS:1002457
 name: H3PO4 neutral loss
 def: "OBSOLETE Neutral loss of phosphoric acid." [PSI:PI]
-comment: This term was obsoleted because it should be replaced by MS:1000336 with value H3PO4.
 is_a: MS:1000336 ! neutral loss
 is_a: MS:1002473 ! ion series considered in search
-is_obsolete: true
 
 [Term]
 id: MS:1002458
@@ -15991,7 +16066,7 @@ id: MS:1002460
 name: protein group-level global FNR
 def: "Estimation of the global false negative rate of protein groups." [PSI:PI]
 is_a: MS:1002706 ! protein group-level result list statistic
-relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_domain: MS:1002305 ! value between 0 and 1 inclusive
 
 [Term]
 id: MS:1002461
@@ -16004,7 +16079,7 @@ id: MS:1002462
 name: peptide sequence-level global FNR
 def: "Estimation of the global false negative rate for distinct peptides once redundant identifications of the same peptide have been removed (id est multiple PSMs have been collapsed to one entry)." [PSI:PI]
 is_a: MS:1002703 ! peptide sequence-level result list statistic
-relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_domain: MS:1002305 ! value between 0 and 1 inclusive
 
 [Term]
 id: MS:1002463
@@ -16017,7 +16092,7 @@ id: MS:1002464
 name: PSM-level global FNR
 def: "Estimation of the global false negative rate of peptide spectrum matches." [PSI:PI]
 is_a: MS:1002701 ! PSM-level result list statistic
-relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_domain: MS:1002305 ! value between 0 and 1 inclusive
 
 [Term]
 id: MS:1002465
@@ -16031,7 +16106,8 @@ name: PeptideShaker PSM score
 def: "The probability based PeptideShaker PSM score." [PSI:PI]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_order MS:1002108 ! higher score better
+relationship: has_order: MS:1002108 ! higher score better
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002467
@@ -16039,7 +16115,8 @@ name: PeptideShaker PSM confidence
 def: "The probability based PeptideShaker PSM confidence." [PSI:PI]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_order MS:1002108 ! higher score better
+relationship: has_order: MS:1002108 ! higher score better
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002468
@@ -16048,7 +16125,8 @@ def: "The probability based PeptideShaker peptide score." [PSI:PI]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002358 ! search engine specific peptide sequence-level identification statistic
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_order MS:1002108 ! higher score better
+relationship: has_order: MS:1002108 ! higher score better
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002469
@@ -16056,7 +16134,8 @@ name: PeptideShaker peptide confidence
 def: "The probability based PeptideShaker peptide confidence." [PSI:PI]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_order MS:1002108 ! higher score better
+relationship: has_order: MS:1002108 ! higher score better
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002470
@@ -16065,7 +16144,8 @@ def: "The probability based PeptideShaker protein group score." [PSI:PI]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
 is_a: MS:1002368 ! search engine specific score for protein groups
-relationship: has_order MS:1002108 ! higher score better
+relationship: has_order: MS:1002108 ! higher score better
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002471
@@ -16073,7 +16153,8 @@ name: PeptideShaker protein group confidence
 def: "The probability based PeptideShaker protein group confidence." [PSI:PI]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_order MS:1002108 ! higher score better
+relationship: has_order: MS:1002108 ! higher score better
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002472
@@ -16093,7 +16174,8 @@ name: ProteoAnnotator:non-canonical gene model score
 def: "The sum of peptide-level scores for peptides mapped only to non-canonical gene models within the group." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002368 ! search engine specific score for protein groups
-relationship: has_order MS:1002108 ! higher score better
+relationship: has_order: MS:1002108 ! higher score better
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002475
@@ -16101,6 +16183,7 @@ name: ProteoAnnotator:count alternative peptides
 def: "The count of the number of peptide sequences mapped to non-canonical gene models only within the group." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002368 ! search engine specific score for protein groups
+relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002476
@@ -16109,7 +16192,8 @@ def: "Drift time of an ion or spectrum of ions as measured in an ion mobility ma
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000455 ! ion selection attribute
 is_a: MS:1002892 ! ion mobility attribute
-relationship: has_units UO:0000028 ! millisecond
+relationship: has_units: UO:0000028 ! millisecond
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002477
@@ -16117,8 +16201,9 @@ name: mean ion mobility drift time array
 def: "Array of population mean ion mobility values from a drift time device, reported in seconds (or milliseconds), corresponding to a spectrum of individual peaks encoded with an m/z array." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002893 ! ion mobility array
-relationship: has_units UO:0000028 ! millisecond
-relationship: has_units UO:0000010 ! second
+relationship: has_units: UO:0000028 ! millisecond
+relationship: has_units: UO:0000010 ! second
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002478
@@ -16131,7 +16216,7 @@ is_a: MS:1000513 ! binary data array
 id: MS:1002479
 name: regular expression
 def: "Regular expression." [PSI:PI]
-relationship: part_of MS:0000000 ! Proteomics Standards Initiative Mass Spectrometry Vocabularies
+relationship: part_of: MS:0000000 ! Proteomics Standards Initiative Mass Spectrometry Vocabularies
 
 [Term]
 id: MS:1002480
@@ -16181,6 +16266,7 @@ name: MassIVE dataset identifier
 def: "Dataset identifier issued by the MassIVE repository. A dataset can refer to either a single sample as part of a study, or all samples that are part of the study corresponding to a publication." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002488
@@ -16188,13 +16274,14 @@ name: MassIVE dataset URI
 def: "URI that allows the access to one dataset in the MassIVE repository. A dataset can refer to either a single sample as part of a study, or all samples that are part of the study corresponding to a publication." [PSI:PI]
 xref: value-type:xsd\:anyURI "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
+relationship: has_value_type: xsd\:anyURI ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002489
 name: special processing
 def: "Details describing a special processing." [PSI:PI]
 is_a: MS:1001080 ! search type
-relationship: part_of MS:1001000 ! spectrum interpretation
+relationship: part_of: MS:1001000 ! spectrum interpretation
 
 [Term]
 id: MS:1002490
@@ -16254,9 +16341,7 @@ is_a: MS:1002658 ! identification parameter
 id: MS:1002499
 name: peptide level score
 def: "OBSOLETE Peptide level score." [PSI:PI]
-comment: This term was obsoleted because it was never intended to go in the CV.
 is_a: MS:1002358 ! search engine specific peptide sequence-level identification statistic
-is_obsolete: true
 
 [Term]
 id: MS:1002500
@@ -16264,6 +16349,7 @@ name: peptide passes threshold
 def: "A Boolean attribute to determine whether the peptide has passed the threshold indicated in the file." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001105 ! peptide sequence-level identification attribute
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002501
@@ -16289,6 +16375,7 @@ name: modification index
 def: "The order of modifications to be referenced elsewhere in the document." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1001055 ! modification parameters
+relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002505
@@ -16308,7 +16395,8 @@ name: modification rescoring:false localization rate
 def: "Mod position score: false localization rate." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002506 ! modification position score
-relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
+relationship: has_regexp: MS:1002505 ! regular expression for modification localization scoring
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002508
@@ -16322,6 +16410,7 @@ name: cross-link donor
 def: "The Cross-linking donor, assigned according to the following rules: the export software SHOULD use the following rules to choose the cross-link donor as the: longer peptide, then higher peptide neutral mass, then alphabetical order." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002508 ! cross-linking attribute
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002510
@@ -16329,6 +16418,7 @@ name: cross-link acceptor
 def: "Cross-linking acceptor, assigned according to the following rules: the export software SHOULD use the following rules to choose the cross-link donor as the: longer peptide, then higher peptide neutral mass, then alphabetical order." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002508 ! cross-linking attribute
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002511
@@ -16336,6 +16426,7 @@ name: cross-link spectrum identification item
 def: "Cross-linked spectrum identification item." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002508 ! cross-linking attribute
+relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002512
@@ -16343,6 +16434,7 @@ name: cross-linking score
 def: "Cross-linking scoring value." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002513
@@ -16350,6 +16442,7 @@ name: molecules per cell
 def: "The absolute abundance of protein in a cell." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002514
@@ -16363,6 +16456,7 @@ name: internal peptide reference used
 def: "States whether an internal peptide reference is used or not in absolute quantitation analysis." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001832 ! quantitation software comment or customizations
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002516
@@ -16370,6 +16464,7 @@ name: internal protein reference used
 def: "States whether an internal protein reference is used or not in absolute quantitation analysis." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001832 ! quantitation software comment or customizations
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002517
@@ -16377,6 +16472,7 @@ name: internal reference abundance
 def: "The absolute abundance of the spiked in reference peptide or protein used for absolute quantitation analysis." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002518
@@ -16384,6 +16480,7 @@ name: Progenesis:protein group normalised abundance
 def: "The data type normalised abundance for protein groups produced by Progenesis LC-MS." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002739 ! protein group-level quantification datatype
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002519
@@ -16391,6 +16488,7 @@ name: Progenesis:protein group raw abundance
 def: "The data type raw abundance for protein groups produced by Progenesis LC-MS." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002739 ! protein group-level quantification datatype
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002520
@@ -16398,6 +16496,7 @@ name: peptide group ID
 def: "Peptide group identifier for peptide-level stats." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001105 ! peptide sequence-level identification attribute
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002521
@@ -16411,6 +16510,7 @@ name: ProteomeDiscoverer:1. Static Terminal Modification
 def: "Determine 1st static terminal post-translational modifications (PTMs)." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002523
@@ -16446,7 +16546,6 @@ is_a: MS:1000503 ! scan attribute
 id: MS:1002528
 name: synchronous prefilter selection
 def: "Synchronous prefilter selection." [PSI:PI]
-synonym: "SPS" EXACT []
 is_a: MS:1002527 ! instrument specific scan attribute
 
 [Term]
@@ -16489,7 +16588,8 @@ name: ProLuCID:xcorr
 def: "The ProLuCID result 'XCorr'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_order MS:1002108 ! higher score better
+relationship: has_order: MS:1002108 ! higher score better
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002535
@@ -16497,6 +16597,7 @@ name: ProLuCID:deltacn
 def: "The ProLuCID result 'DeltaCn'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002536
@@ -16504,7 +16605,8 @@ name: D-Score
 def: "D-Score for PTM site location at the PSM-level." [PMID:23307401]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001968 ! PTM localization PSM-level statistic
-relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
+relationship: has_regexp: MS:1002505 ! regular expression for modification localization scoring
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002537
@@ -16512,7 +16614,8 @@ name: MD-Score
 def: "MD-Score for PTM site location at the PSM-level." [PMID:21057138]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001968 ! PTM localization PSM-level statistic
-relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
+relationship: has_regexp: MS:1002505 ! regular expression for modification localization scoring
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002538
@@ -16520,6 +16623,7 @@ name: PTM localization confidence metric
 def: "Localization confidence metric for a post translational modification (PTM)." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001405 ! spectrum identification result details
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002539
@@ -16527,6 +16631,7 @@ name: PeptideShaker PTM confidence type
 def: "PeptideShaker quality criteria for the confidence of PTM localizations." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002538 ! PTM localization confidence metric
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002540
@@ -16534,6 +16639,7 @@ name: PeptideShaker PSM confidence type
 def: "PeptideShaker quality criteria for the confidence of PSM's." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002347 ! PSM-level identification statistic
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002541
@@ -16541,6 +16647,7 @@ name: PeptideShaker peptide confidence type
 def: "PeptideShaker quality criteria for the confidence of peptide identifications." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002358 ! search engine specific peptide sequence-level identification statistic
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002542
@@ -16548,6 +16655,7 @@ name: PeptideShaker protein confidence type
 def: "PeptideShaker quality criteria for the confidence of protein identifications." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001116 ! single protein identification statistic
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002543
@@ -16567,7 +16675,8 @@ name: xi:score
 def: "The xi result 'Score'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_order MS:1002108 ! higher score better
+relationship: has_order: MS:1002108 ! higher score better
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002546
@@ -16600,7 +16709,8 @@ name: peptide:phosphoRS score
 def: "phosphoRS score for PTM site location at the peptide-level." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002549 ! PTM localization distinct peptide-level statistic
-relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
+relationship: has_regexp: MS:1002505 ! regular expression for modification localization scoring
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002551
@@ -16608,7 +16718,8 @@ name: peptide:Ascore
 def: "A-score for PTM site location at the peptide-level." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002549 ! PTM localization distinct peptide-level statistic
-relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
+relationship: has_regexp: MS:1002505 ! regular expression for modification localization scoring
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002552
@@ -16616,7 +16727,8 @@ name: peptide:H-Score
 def: "H-Score for peptide phosphorylation site location at the peptide-level." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002549 ! PTM localization distinct peptide-level statistic
-relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
+relationship: has_regexp: MS:1002505 ! regular expression for modification localization scoring
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002553
@@ -16624,7 +16736,8 @@ name: peptide:D-Score
 def: "D-Score for PTM site location at the peptide-level." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002549 ! PTM localization distinct peptide-level statistic
-relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
+relationship: has_regexp: MS:1002505 ! regular expression for modification localization scoring
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002554
@@ -16632,7 +16745,8 @@ name: peptide:MD-Score
 def: "MD-Score for PTM site location at the peptide-level." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002549 ! PTM localization distinct peptide-level statistic
-relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
+relationship: has_regexp: MS:1002505 ! regular expression for modification localization scoring
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002555
@@ -16646,6 +16760,7 @@ name: Ascore threshold
 def: "Threshold for Ascore PTM site location score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002555 ! PTM localization score threshold
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002557
@@ -16653,6 +16768,7 @@ name: D-Score threshold
 def: "Threshold for D-score PTM site location score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002555 ! PTM localization score threshold
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002558
@@ -16660,6 +16776,7 @@ name: MD-Score threshold
 def: "Threshold for MD-score PTM site location score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002555 ! PTM localization score threshold
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002559
@@ -16667,6 +16784,7 @@ name: H-Score threshold
 def: "Threshold for H-score PTM site location score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002555 ! PTM localization score threshold
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002560
@@ -16674,6 +16792,7 @@ name: DeBunker:score threshold
 def: "Threshold for DeBunker PTM site location score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002555 ! PTM localization score threshold
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002561
@@ -16681,6 +16800,7 @@ name: Mascot:PTM site assignment confidence threshold
 def: "Threshold for Mascot PTM site assignment confidence." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002555 ! PTM localization score threshold
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002562
@@ -16688,6 +16808,7 @@ name: MSQuant:PTM-score threshold
 def: "Threshold for MSQuant:PTM-score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002555 ! PTM localization score threshold
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002563
@@ -16695,6 +16816,7 @@ name: MaxQuant:PTM Score threshold
 def: "Threshold for MaxQuant:PTM Score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002555 ! PTM localization score threshold
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002564
@@ -16702,6 +16824,7 @@ name: MaxQuant:P-site localization probability threshold
 def: "Threshold for MaxQuant:P-site localization probability." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002555 ! PTM localization score threshold
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002565
@@ -16709,6 +16832,7 @@ name: MaxQuant:PTM Delta Score threshold
 def: "Threshold for MaxQuant:PTM Delta Score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002555 ! PTM localization score threshold
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002566
@@ -16716,6 +16840,7 @@ name: MaxQuant:Phospho (STY) Probabilities threshold
 def: "Threshold for MaxQuant:Phospho (STY) Probabilities." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002555 ! PTM localization score threshold
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002567
@@ -16723,6 +16848,7 @@ name: phosphoRS score threshold
 def: "Threshold for phosphoRS score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002555 ! PTM localization score threshold
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002568
@@ -16730,6 +16856,7 @@ name: phosphoRS site probability threshold
 def: "Threshold for phosphoRS site probability." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002555 ! PTM localization score threshold
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002569
@@ -16737,6 +16864,7 @@ name: ProteomeDiscoverer:Number of Spectra Processed At Once
 def: "Number of spectra processed at once in a ProteomeDiscoverer search." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002570
@@ -16744,6 +16872,7 @@ name: sequence multiply subsumable protein
 def: "A protein for which the matched peptide sequences are the same, or a subset of, the matched peptide sequences for two or more other proteins combined. These other proteins need not all be in the same group." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001101 ! protein group or subset relationship
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002571
@@ -16751,6 +16880,7 @@ name: spectrum multiply subsumable protein
 def: "A protein for which the matched spectra are the same, or a subset of, the matched spectra for two or more other proteins combined. These other proteins need not all be in the same group." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001101 ! protein group or subset relationship
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002572
@@ -16920,6 +17050,7 @@ name: splash key
 def: "Spectral Hash key, an unique identifier for spectra." [PMID:27824832]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001405 ! spectrum identification result details
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002600
@@ -17113,7 +17244,6 @@ is_a: MS:1002622 ! iTRAQ reagent
 id: MS:1002631
 name: Electron-Transfer/Higher-Energy Collision Dissociation (EThcD)
 def: "A dissociation process combining electron-transfer and higher-energy collision dissociation (EThcD). It combines ETD (reaction time) followed by HCD (activation energy)." [PSI:PI]
-synonym: "EThcD" EXACT []
 is_a: MS:1000044 ! dissociation method
 
 [Term]
@@ -17122,6 +17252,7 @@ name: jPOST dataset identifier
 def: "Dataset identifier issued by the jPOST repository. A dataset can refer to either a single sample as part of a study, or all samples that are part of the study corresponding to a publication." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002633
@@ -17129,6 +17260,7 @@ name: jPOST dataset URI
 def: "URI that allows the access to one dataset in the jPOST repository. A dataset can refer to either a single sample as part of a study, or all samples that are part of the study corresponding to a publication." [PSI:PI]
 xref: value-type:xsd\:anyURI "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
+relationship: has_value_type: xsd\:anyURI ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002634
@@ -17154,6 +17286,7 @@ name: chromosome name
 def: "The name or number of the chromosome to which a given peptide has been mapped." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002636 ! proteogenomics attribute
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002638
@@ -17161,15 +17294,15 @@ name: chromosome strand
 def: "The strand (+ or -) to which the peptide has been mapped." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002636 ! proteogenomics attribute
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002639
 name: peptide start on chromosome
 def: "OBSOLETE The overall start position on the chromosome to which a peptide has been mapped i.e. the position of the first base of the first codon, using a zero-based counting system." [PSI:PI]
-comment: This term was obsoleted because it contains redundant info contained in term MS:1002643 - peptide start positions on chromosome.
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002636 ! proteogenomics attribute
-is_obsolete: true
+relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002640
@@ -17177,6 +17310,7 @@ name: peptide end on chromosome
 def: "The overall end position on the chromosome to which a peptide has been mapped i.e. the position of the third base of the last codon, using a zero-based counting system." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002636 ! proteogenomics attribute
+relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002641
@@ -17184,6 +17318,7 @@ name: peptide exon count
 def: "The number of exons to which the peptide has been mapped." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002636 ! proteogenomics attribute
+relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002642
@@ -17191,6 +17326,7 @@ name: peptide exon nucleotide sizes
 def: "A comma separated list of the number of DNA bases within each exon to which a peptide has been mapped. Assuming standard operation of a search engine, the peptide exon sizes should sum to exactly three times the peptide length." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002636 ! proteogenomics attribute
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002643
@@ -17198,6 +17334,7 @@ name: peptide start positions on chromosome
 def: "A comma separated list of start positions within exons to which the peptide has been mapped, relative to peptide-chromosome start, assuming a zero-based counting system. The first value MUST match the value in peptide start on chromosome." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002636 ! proteogenomics attribute
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002644
@@ -17205,6 +17342,7 @@ name: genome reference version
 def: "The reference genome and versioning string as used for mapping. All coordinates are within this frame of reference." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002636 ! proteogenomics attribute
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002645
@@ -17217,8 +17355,7 @@ is_a: MS:1001457 ! data processing software
 id: MS:1002646
 name: native spectrum identifier format, combined spectra
 def: "Describes how the native spectrum identifiers that have been combined prior to searching or interpretation are formated." [PSI:PI]
-synonym: "nativeID format, combined spectra" EXACT []
-relationship: part_of MS:1000577 ! source data file
+relationship: part_of: MS:1000577 ! source data file
 
 [Term]
 id: MS:1002647
@@ -17226,6 +17363,7 @@ name: Thermo nativeID format, combined spectra
 def: "Thermo comma separated list of spectra that have been combined prior to searching or interpretation." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002646 ! native spectrum identifier format, combined spectra
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002648
@@ -17233,6 +17371,7 @@ name: Waters nativeID format, combined spectra
 def: "Waters comma separated list of spectra that have been combined prior to searching or interpretation." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002646 ! native spectrum identifier format, combined spectra
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002649
@@ -17240,6 +17379,7 @@ name: WIFF nativeID format, combined spectra
 def: "WIFF comma separated list of spectra that have been combined prior to searching or interpretation." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002646 ! native spectrum identifier format, combined spectra
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002650
@@ -17247,6 +17387,7 @@ name: Bruker/Agilent YEP nativeID format, combined spectra
 def: "Bruker/Agilent comma separated list of spectra that have been combined prior to searching or interpretation." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002646 ! native spectrum identifier format, combined spectra
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002651
@@ -17254,60 +17395,61 @@ name: Bruker BAF nativeID format, combined spectra
 def: "Bruker BAF comma separated list of spectra that have been combined prior to searching or interpretation." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002646 ! native spectrum identifier format, combined spectra
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002652
 name: Bruker FID nativeID format, combined spectra
 def: "Bruker FID comma separated list of spectra that have been combined prior to searching or interpretation." [PSI:PI]
-comment: The nativeID must be the same as the source file ID.
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002646 ! native spectrum identifier format, combined spectra
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002653
 name: multiple peak list nativeID format, combined spectra
 def: "Comma separated list of spectra that have been combined prior to searching or interpretation." [PSI:PI]
-comment: Used for conversion of peak list files with multiple spectra, i.e. MGF, PKL, merged DTA files. Index is the spectrum number in the file, starting from 0.
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002646 ! native spectrum identifier format, combined spectra
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002654
 name: single peak list nativeID format, combined spectra
 def: "Comma separated list of spectra that have been combined prior to searching or interpretation." [PSI:PI]
-comment: The nativeID must be the same as the source file ID. Used for conversion of peak list files with one spectrum per file, typically folder of PKL or DTAs, each sourceFileRef is different.
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002646 ! native spectrum identifier format, combined spectra
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002655
 name: scan number only nativeID format, combined spectra
 def: "Comma separated list of spectra that have been combined prior to searching or interpretation." [PSI:PI]
-comment: Used for conversion from mzXML, or DTA folder where native scan numbers can be derived.
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002646 ! native spectrum identifier format, combined spectra
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002656
 name: spectrum identifier nativeID format, combined spectra
 def: "Comma separated list of spectra that have been combined prior to searching or interpretation." [PSI:PI]
-comment: Used for conversion from mzData. The spectrum id attribute is referenced.
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002646 ! native spectrum identifier format, combined spectra
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002657
 name: mzML unique identifier, combined spectra
 def: "Comma separated list of spectra that have been combined prior to searching or interpretation." [PSI:PI]
-comment: A unique identifier of a spectrum stored in an mzML file.
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002646 ! native spectrum identifier format, combined spectra
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002658
 name: identification parameter
 def: "Identification parameter for the search engine run." [PSI:PI]
-relationship: part_of MS:1001000 ! spectrum interpretation
+relationship: part_of: MS:1001000 ! spectrum interpretation
 
 [Term]
 id: MS:1002659
@@ -17334,7 +17476,8 @@ name: Morpheus:Morpheus score
 def: "Morpheus score for PSMs." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_order MS:1002108 ! higher score better
+relationship: has_order: MS:1002108 ! higher score better
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002663
@@ -17342,7 +17485,8 @@ name: Morpheus:summed Morpheus score
 def: "Summed Morpheus score for protein groups." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002368 ! search engine specific score for protein groups
-relationship: has_order MS:1002108 ! higher score better
+relationship: has_order: MS:1002108 ! higher score better
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002664
@@ -17350,7 +17494,8 @@ name: interaction score derived from cross-linking
 def: "Parent term for interaction scores derived from cross-linking." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002675 ! cross-linking result details
-relationship: has_regexp MS:1002665 ! ([:digit:]+[.][a|b]:[:digit:]+:[:digit:]+[.][:digit:]+([Ee][+-][0-9]+)*:(true|false]\{1\}))
+relationship: has_regexp: MS:1002665 ! ([:digit:]+[.][a|b]:[:digit:]+:[:digit:]+[.][:digit:]+([Ee][+-][0-9]+)*:(true|false]\{1\}))
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002665
@@ -17376,6 +17521,7 @@ name: frag: iTRAQ 4plex reporter ion
 def: "Standard reporter ion for iTRAQ 4Plex. The value slot holds the integer mass of the iTRAQ 4Plex reporter ion, e.g. 114." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002307 ! fragmentation ion type
+relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002669
@@ -17383,6 +17529,7 @@ name: frag: iTRAQ 8plex reporter ion
 def: "Standard reporter ion for iTRAQ 8Plex. The value slot holds the integer mass of the iTRAQ 8Plex reporter ion, e.g. 113." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002307 ! fragmentation ion type
+relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002670
@@ -17390,6 +17537,7 @@ name: frag: TMT reporter ion
 def: "Standard reporter ion for TMT. The value slot holds the integer mass of the TMT reporter ion and can be suffixed with either N or C, indicating whether the mass difference is encoded at a Nitrogen or Carbon atom, e.g. 127N." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002307 ! fragmentation ion type
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002671
@@ -17397,6 +17545,7 @@ name: frag: TMT ETD reporter ion
 def: "Standard reporter ion for TMT with ETD fragmentation. The value slot holds the integer mass of the TMT ETD reporter ion and can be suffixed with either N or C, indicating whether the mass difference is encoded at a Nitrogen or Carbon atom, e.g. 127C." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002307 ! fragmentation ion type
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002672
@@ -17420,7 +17569,7 @@ is_a: MS:1000121 ! SCIEX instrument model
 id: MS:1002675
 name: cross-linking result details
 def: "This subsection describes terms which can describe details of cross-linking results." [PSI:PI]
-relationship: part_of MS:1001000 ! spectrum interpretation
+relationship: part_of: MS:1001000 ! spectrum interpretation
 
 [Term]
 id: MS:1002676
@@ -17428,8 +17577,9 @@ name: protein-pair-level global FDR
 def: "Estimation of the global false discovery rate of proteins-pairs in cross-linking experiments." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002664 ! interaction score derived from cross-linking
-relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
-relationship: has_regexp MS:1002665 ! ([:digit:]+[.][a|b]:[:digit:]+:[:digit:]+[.][:digit:]+([Ee][+-][0-9]+)*:(true|false]\{1\}))
+relationship: has_domain: MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_regexp: MS:1002665 ! ([:digit:]+[.][a|b]:[:digit:]+:[:digit:]+[.][:digit:]+([Ee][+-][0-9]+)*:(true|false]\{1\}))
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002677
@@ -17437,8 +17587,9 @@ name: residue-pair-level global FDR
 def: "Estimation of the global false discovery rate of residue-pairs in cross-linking experiments." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002664 ! interaction score derived from cross-linking
-relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
-relationship: has_regexp MS:1002665 ! ([:digit:]+[.][a|b]:[:digit:]+:[:digit:]+[.][:digit:]+([Ee][+-][0-9]+)*:(true|false]\{1\}))
+relationship: has_domain: MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_regexp: MS:1002665 ! ([:digit:]+[.][a|b]:[:digit:]+:[:digit:]+[.][:digit:]+([Ee][+-][0-9]+)*:(true|false]\{1\}))
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002678
@@ -17458,7 +17609,8 @@ name: supplemental collision energy
 def: "Energy for an ion experiencing supplemental collision with a stationary gas particle resulting in dissociation of the ion." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000510 ! precursor activation attribute
-relationship: has_units UO:0000266 ! electronvolt
+relationship: has_units: UO:0000266 ! electronvolt
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002681
@@ -17467,7 +17619,8 @@ def: "OpenXQuest's combined score for a cross-link spectrum match." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1001153 ! search engine specific score
-relationship: has_order MS:1002108 ! higher score better
+relationship: has_order: MS:1002108 ! higher score better
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002682
@@ -17476,7 +17629,8 @@ def: "OpenXQuest's cross-correlation of cross-linked ions subscore." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1001153 ! search engine specific score
-relationship: has_order MS:1002108 ! higher score better
+relationship: has_order: MS:1002108 ! higher score better
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002683
@@ -17485,7 +17639,8 @@ def: "OpenXQuest's cross-correlation of unlinked ions subscore." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1001153 ! search engine specific score
-relationship: has_order MS:1002108 ! higher score better
+relationship: has_order: MS:1002108 ! higher score better
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002684
@@ -17494,8 +17649,9 @@ def: "OpenXQuest's match-odds subscore." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1001153 ! search engine specific score
-relationship: has_order MS:1002108 ! higher score better
-relationship: has_domain MS:1002306 ! value greater than zero
+relationship: has_order: MS:1002108 ! higher score better
+relationship: has_domain: MS:1002306 ! value greater than zero
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002685
@@ -17504,8 +17660,9 @@ def: "OpenXQuest's sum of matched peak intensity subscore." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1001153 ! search engine specific score
-relationship: has_order MS:1002108 ! higher score better
-relationship: has_domain MS:1002306 ! value greater than zero
+relationship: has_order: MS:1002108 ! higher score better
+relationship: has_domain: MS:1002306 ! value greater than zero
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002686
@@ -17514,8 +17671,9 @@ def: "OpenXQuest's weighted percent of total ion current subscore." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1001153 ! search engine specific score
-relationship: has_order MS:1002108 ! higher score better
-relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_order: MS:1002108 ! higher score better
+relationship: has_domain: MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002687
@@ -17641,9 +17799,46 @@ is_a: MS:1001180 ! Cleavage agent regular expression
 id: MS:1002708
 name: LysargiNase
 def: "Metalloproteinase found in Methanosarcina acetivorans that cleaves on the N-terminal side of lysine and arginine residues." [PMID:25419962]
-synonym: "Tryp-N" EXACT []
 is_a: MS:1001045 ! cleavage agent name
-relationship: has_regexp MS:1002707 ! (?=[KR])
+relationship: has_regexp: MS:1002707 ! (?=[KR])
+
+[Term]
+id: MS:1002709
+name: compound data type
+def: "A data type representing more than a single value." []
+
+[Term]
+id: MS:1002710
+name: list of type
+def: "A data type defining a list of values of a single type." []
+is_a: MS:1002709 ! compound data type
+
+[Term]
+id: MS:1002710
+name: list of type
+def: "A data type defining a list of values of a single type." []
+is_a: MS:1002709 ! compound data type
+
+[Term]
+id: MS:1002711
+name: list of strings
+def: "A list of xsd:string." []
+is_a: MS:1002710 ! list of type
+relationship: has_value_type: xsd\:string
+
+[Term]
+id: MS:1002712
+name: list of integers
+def: "A list of xsd:integer." []
+is_a: MS:1002710 ! list of type
+relationship: has_value_type: xsd\:integer
+
+[Term]
+id: MS:1002713
+name: list of floats
+def: "A list of xsd:float." []
+is_a: MS:1002710 ! list of type
+relationship: has_value_type: xsd\:float
 
 [Term]
 id: MS:1002719
@@ -17664,7 +17859,8 @@ def: "MSPathFinder spectral E-value." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002353 ! PSM-level e-value
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_order MS:1002109 ! lower score better
+relationship: has_order: MS:1002109 ! lower score better
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002722
@@ -17673,7 +17869,8 @@ def: "MSPathFinder E-value." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002353 ! PSM-level e-value
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_order MS:1002109 ! lower score better
+relationship: has_order: MS:1002109 ! lower score better
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002723
@@ -17682,6 +17879,7 @@ def: "MSPathFinder Q-value." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002354 ! PSM-level q-value
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002724
@@ -17689,6 +17887,7 @@ name: MSPathFinder:PepQValue
 def: "MSPathFinder peptide-level Q-value." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002725
@@ -17696,6 +17895,7 @@ name: MSPathFinder:RawScore
 def: "MSPathFinder raw score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002726
@@ -17745,6 +17945,7 @@ name: peptide-level spectral count
 def: "The number of MS2 spectra identified for a peptide sequence specified by the amino acid one-letter codes plus optional PTMs in spectral counting." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002737 ! peptide-level quantification datatype
+relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002734
@@ -17752,6 +17953,7 @@ name: peptide ion-level spectral count
 def: "The number of MS2 spectra identified for a molecular ion defined by the peptide sequence represented by the amino acid one-letter codes, plus optional PTMs plus optional charged aducts plus the charge state, in spectral counting." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002737 ! peptide-level quantification datatype
+relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002735
@@ -17810,7 +18012,7 @@ def: "A data array of parallel, independent m/z values for a sampling of noise a
 xref: binary-data-type:MS\:1000521 "32-bit float"
 xref: binary-data-type:MS\:1000523 "64-bit float"
 is_a: MS:1000513 ! binary data array
-relationship: has_units MS:1000040 ! m/z
+relationship: has_units: MS:1000040 ! m/z
 
 [Term]
 id: MS:1002744
@@ -17819,7 +18021,7 @@ def: "A data array of intensity values for the amplitude of noise variation supe
 xref: binary-data-type:MS\:1000521 "32-bit float"
 xref: binary-data-type:MS\:1000523 "64-bit float"
 is_a: MS:1000513 ! binary data array
-relationship: has_units MS:1000131 ! number of detector counts
+relationship: has_units: MS:1000131 ! number of detector counts
 
 [Term]
 id: MS:1002745
@@ -17853,6 +18055,7 @@ name: Mascot:IntegratedSpectralLibrarySearch
 def: "Means that Mascot has integrated the search results of database and spectral library search into a single data set." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002095 ! Mascot input parameter
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002750
@@ -17883,8 +18086,8 @@ id: MS:1002754
 name: MSPepSearch:score
 def: "MSPepSearch score (0 for entirely dissimilar and 1000 for identical observed spectrum and library spectrum." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_order MS:1002108 ! higher score better
-relationship: has_domain MS:1002753 ! value between 0 and 1000 inclusive
+relationship: has_order: MS:1002108 ! higher score better
+relationship: has_domain: MS:1002753 ! value between 0 and 1000 inclusive
 
 [Term]
 id: MS:1002755
@@ -18214,7 +18417,7 @@ is_a: MS:1000353 ! adduct ion
 id: MS:1002809
 name: adduct ion attribute
 def: "Nonphysical characteristic attributed to an adduct ion." [PSI:MS]
-relationship: part_of MS:1000353 ! adduct ion
+relationship: part_of: MS:1000353 ! adduct ion
 
 [Term]
 id: MS:1002810
@@ -18222,6 +18425,7 @@ name: adduct ion X m/z
 def: "Theoretical m/z of the X component in the adduct M+X or M-X. This term was formerly called 'adduct ion mass', but it is not really a mass. It corresponds to the column mislabelled as 'mass' at https://fiehnlab.ucdavis.edu/staff/kind/Metabolomics/MS-Adduct-Calculator." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1003056 ! adduct ion property
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002811
@@ -18229,6 +18433,7 @@ name: adduct ion isotope
 def: "Isotope of the matrix molecule M of an adduct formation." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1003056 ! adduct ion property
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002812
@@ -18242,13 +18447,13 @@ name: adduct ion formula
 def: "Adduct formation formula of the form M+X or M-X, as constrained by the provided regular expression." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002809 ! adduct ion attribute
-relationship: has_regexp MS:1002812 ! (\[[:digit:]{0,1}M([+][:digit:]{0,1}(H|K|(Na)|(Li)|(Cl)|(Br)|(NH3)|(NH4)|(CH3OH)|(IsoProp)|(DMSO)|(FA)|(Hac)|(TFA)|(NaCOOH)|(HCOOH)|(CF3COOH)|(ACN))){0,}([-][:digit:]{0,1}(H|(H2O)|(CH2)|(CH4)|(NH3)|(CO)|(CO2)|(COCH2)|(HCOOH)|(C2H4)|(C4H8)|(C3H2O3)|(C5H8O4)|(C6H10O4)|(C6H10O5)|(C6H8O6))){0,}\][:digit:]{0,1}[+-])
+relationship: has_regexp: MS:1002812 ! (\[[:digit:]{0,1}M([+][:digit:]{0,1}(H|K|(Na)|(Li)|(Cl)|(Br)|(NH3)|(NH4)|(CH3OH)|(IsoProp)|(DMSO)|(FA)|(Hac)|(TFA)|(NaCOOH)|(HCOOH)|(CF3COOH)|(ACN))){0,}([-][:digit:]{0,1}(H|(H2O)|(CH2)|(CH4)|(NH3)|(CO)|(CO2)|(COCH2)|(HCOOH)|(C2H4)|(C4H8)|(C3H2O3)|(C5H8O4)|(C6H10O4)|(C6H10O5)|(C6H8O6))){0,}\][:digit:]{0,1}[+-])
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002814
 name: volt-second per square centimeter
 def: "An electrical mobility unit that equals the speed [cm/s] an ion reaches when pulled through a gas by a Voltage[V] over a certain distance [cm]." [PSI:PI]
-synonym: "Vs/cm^2" EXACT []
 is_a: UO:0000000 ! unit
 
 [Term]
@@ -18258,7 +18463,8 @@ def: "Ion mobility measurement for an ion or spectrum of ions as measured in an 
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000455 ! ion selection attribute
 is_a: MS:1002892 ! ion mobility attribute
-relationship: has_units MS:1002814 ! volt-second per square centimeter
+relationship: has_units: MS:1002814 ! volt-second per square centimeter
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002816
@@ -18266,8 +18472,9 @@ name: mean ion mobility array
 def: "Array of population mean ion mobility values (K or K0) based on ion separation in gaseous phase due to different ion mobilities under an electric field based on ion size, m/z and shape, corresponding to a spectrum of individual peaks encoded with an m/z array." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002893 ! ion mobility array
-relationship: has_units UO:0000028 ! millisecond
-relationship: has_units UO:0000010 ! second
+relationship: has_units: UO:0000028 ! millisecond
+relationship: has_units: UO:0000010 ! second
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002817
@@ -18287,20 +18494,21 @@ name: Bruker TDF nativeID format, combined spectra
 def: "Bruker TDF comma separated list of spectra that have been combined prior to searching or interpretation." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002646 ! native spectrum identifier format, combined spectra
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002820
 name: M+H ion
 def: "Adduct formed by protonation of a matrix molecule M, i.e. the addition of a matrix molecule M plus a proton." [PSI:MS]
-property_value: ionMass: "M + 1.007276" xsd:string
 is_a: MS:1002807 ! positive mode adduct ion
+property_value: ionMass: "M + 1.007276" xsd:string
 
 [Term]
 id: MS:1002821
 name: M-H ion
 def: "Adduct formed by deprotonation of a matrix molecule M, i.e. the removal of a proton from a matrix molecule M." [PSI:MS]
-property_value: ionMass: "M - 1.007276" xsd:string
 is_a: MS:1002808 ! negative mode adduct ion
+property_value: ionMass: "M - 1.007276" xsd:string
 
 [Term]
 id: MS:1002822
@@ -18338,7 +18546,8 @@ name: MetaMorpheus:score
 def: "MetaMorpheus score for PSMs." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_order MS:1002108 ! higher score better
+relationship: has_order: MS:1002108 ! higher score better
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002828
@@ -18346,7 +18555,8 @@ name: MetaMorpheus:protein score
 def: "MetaMorpheus score for protein groups." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002368 ! search engine specific score for protein groups
-relationship: has_order MS:1002108 ! higher score better
+relationship: has_order: MS:1002108 ! higher score better
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002829
@@ -18354,6 +18564,7 @@ name: XCMS:into
 def: "Feature intensity produced by XCMS findPeaks() from integrated peak intensity." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002735 ! feature-level quantification datatype
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002830
@@ -18361,6 +18572,7 @@ name: XCMS:intf
 def: "Feature intensity produced by XCMS findPeaks() from baseline corrected integrated peak intensity." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002735 ! feature-level quantification datatype
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002831
@@ -18368,6 +18580,7 @@ name: XCMS:maxo
 def: "Feature intensity produced by XCMS findPeaks() from maximum peak intensity." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002735 ! feature-level quantification datatype
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002832
@@ -18375,6 +18588,7 @@ name: XCMS:area
 def: "Feature intensity produced by XCMS findPeaks() from feature area that is not normalized by the scan rate." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002735 ! feature-level quantification datatype
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002833
@@ -18388,6 +18602,7 @@ name: ProteomeDiscoverer:Delta Score
 def: "The Delta Score reported by Proteome Discoverer version 2." [PSI:PI]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002835
@@ -18401,6 +18616,7 @@ name: iProX dataset identifier
 def: "Dataset identifier issued by the iProX repository. A dataset can refer to either a single sample as part of a study, or all samples that are part of the study corresponding to a publication." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002837
@@ -18408,6 +18624,7 @@ name: iProX dataset URI
 def: "URI that allows the access to one dataset in the iProX repository. A dataset can refer to either a single sample as part of a study, or all samples that are part of the study corresponding to a publication." [PSI:PI]
 xref: value-type:xsd\:anyURI "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
+relationship: has_value_type: xsd\:anyURI ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002838
@@ -18425,7 +18642,7 @@ is_a: MS:1000530 ! file format conversion
 id: MS:1002840
 name: external reference data
 def: "Data belonging to an external reference." [PSI:MS]
-relationship: part_of MS:0000000 ! Proteomics Standards Initiative Mass Spectrometry Vocabularies
+relationship: part_of: MS:0000000 ! Proteomics Standards Initiative Mass Spectrometry Vocabularies
 
 [Term]
 id: MS:1002841
@@ -18433,22 +18650,25 @@ name: external HDF5 dataset
 def: "The HDF5 dataset location containing the binary data, relative to the dataset containing the mzML. Also indicates that there is no data in the <binary> section of the BinaryDataArray." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002840 ! external reference data
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002842
 name: external offset
 def: "The position in the external data where the array begins." [PSI:PI]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
-relationship: has_units UO:0000189 ! Count
 is_a: MS:1002840 ! external reference data
+relationship: has_units: UO:0000189 ! Count
+relationship: has_value_type: xsd\:nonNegativeInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002843
 name: external array length
 def: "Describes how many fields an array contains." [PSI:PI]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
-relationship: has_units UO:0000189 ! Count
 is_a: MS:1002840 ! external reference data
+relationship: has_units: UO:0000189 ! Count
+relationship: has_value_type: xsd\:nonNegativeInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002844
@@ -18462,6 +18682,7 @@ name: Associated file URI
 def: "URI of one external file associated to the PRIDE experiment (maybe through a PX submission)." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002844 ! Experiment additional parameter
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002846
@@ -18469,6 +18690,7 @@ name: Associated raw file URI
 def: "URI of one raw data file associated to the PRIDE experiment (maybe through a PX submission)." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002845 ! Associated file URI
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002847
@@ -18476,6 +18698,7 @@ name: ProteomeCentral dataset URI
 def: "URI associated to one PX submission in ProteomeCentral." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002844 ! Experiment additional parameter
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002848
@@ -18483,6 +18706,7 @@ name: Result file URI
 def: "URI of one file labeled as 'Result', associated to one PX submission." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002845 ! Associated file URI
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002849
@@ -18490,6 +18714,7 @@ name: Search engine output file URI
 def: "URI of one search engine output file associated to one PX submission." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002845 ! Associated file URI
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002850
@@ -18497,6 +18722,7 @@ name: Peak list file URI
 def: "URI of one of one search engine output file associated to one PX submission." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002845 ! Associated file URI
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002851
@@ -18504,6 +18730,7 @@ name: Other type file URI
 def: "URI of one file labeled as 'Other', associated to one PX submission." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002845 ! Associated file URI
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002852
@@ -18511,6 +18738,7 @@ name: Dataset FTP location
 def: "FTP location of one entire PX data set." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002844 ! Experiment additional parameter
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002853
@@ -18554,6 +18782,7 @@ name: Additional associated raw file URI
 def: "Additional URI of one raw data file associated to the PRIDE experiment (maybe through a PX submission). The URI is provided via an additional resource to PRIDE." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002845 ! Associated file URI
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002860
@@ -18561,6 +18790,7 @@ name: Gel image file URI
 def: "URI of one gel image file associated to one PX submission." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002845 ! Associated file URI
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002861
@@ -18568,6 +18798,7 @@ name: Reprocessed complete dataset
 def: "All the raw files included in the original dataset (or group of original datasets) have been reanalysed." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002844 ! Experiment additional parameter
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002862
@@ -18575,6 +18806,7 @@ name: Reprocessed subset dataset
 def: "A subset of the raw files included in the original dataset (or group of original datasets) has been reanalysed." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002844 ! Experiment additional parameter
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002863
@@ -18600,6 +18832,7 @@ name: Reference
 def: "Literature reference associated with one dataset (including the authors, title, year and journal details). The value field can be used for the PubMedID, or to specify if one manuscript is just submitted or accepted, but it does not have a PubMedID yet." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002844 ! Experiment additional parameter
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002867
@@ -18640,6 +18873,7 @@ name: Panorama Public dataset identifier
 def: "Dataset identifier issued by the Panorama Public repository. A dataset can refer to either a single sample as part of a study, or all samples that are part of the study corresponding to a publication." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002873
@@ -18647,6 +18881,7 @@ name: Panorama Public dataset URI
 def: "URI that allows the access to one dataset in the Panorama Public repository. A dataset can refer to either a single sample as part of a study, or all samples that are part of the study corresponding to a publication." [PSI:PI]
 xref: value-type:xsd\:anyURI "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
+relationship: has_value_type: xsd\:anyURI ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002874
@@ -18732,6 +18967,7 @@ name: Progenesis QI normalised abundance
 def: "The normalised abundance produced by Progenesis QI LC-MS." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002886 ! small molecule quantification datatype
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002888
@@ -18745,6 +18981,7 @@ name: Progenesis MetaScope score
 def: "The confidence score produced by Progenesis QI." [PSI:PI]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002888 ! small molecule confidence measure
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002890
@@ -18752,6 +18989,7 @@ name: fragmentation score
 def: "The fragmentation confidence score." [PSI:PI]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002888 ! small molecule confidence measure
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002891
@@ -18759,6 +18997,7 @@ name: isotopic fit score
 def: "The isotopic fit confidence score." [PSI:PI]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002888 ! small molecule confidence measure
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002892
@@ -18779,6 +19018,7 @@ name: InChIKey
 def: "Unique chemical structure identifier for chemical compounds." [PMID:273343401]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001405 ! spectrum identification result details
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002895
@@ -18792,15 +19032,15 @@ name: compound identification confidence level
 def: "Confidence level for annotation of identified compounds as defined by the Metabolomics Standards Initiative (MSI). The value slot can have the values 'Level 0' until 'Level 4'." [PMID:29748461]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002895 ! small molecule identification attribute
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002897
 name: isotopomer peak
 def: "OBSOLETE Identifies a peak when no de-isotoping has been performed. The value slot reports the isotopomer peak, e.g. '2H', '13C', '15N', '18O', '31P'." [PSI:PI]
-comment: This term was obsoleted because it was replaced by the more exact terms MS:1002956 'isotopic ion MS peak', MS:1002957 'isotopomer MS peak' and MS:1002958 'isotopologue MS peak' instead.
 xref: value-type:xsd:string "The allowed value-type for this CV term."
 is_a: MS:1000231 ! peak
-is_obsolete: true
+relationship: has_value_type: xsd:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002898
@@ -18862,7 +19102,8 @@ name: proteoform-level global FDR
 def: "Estimation of the global false discovery rate of proteoforms." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002905 ! proteoform-level identification statistic
-relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_domain: MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002908
@@ -18870,7 +19111,8 @@ name: proteoform-level local FDR
 def: "Estimation of the local false discovery rate of proteoforms." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002905 ! proteoform-level identification statistic
-relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_domain: MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002909
@@ -18884,6 +19126,7 @@ name: proteoform-level global FDR threshold
 def: "Threshold for the global false discovery rate of proteoforms." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002909 ! proteoform-level statistical threshold
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002911
@@ -18891,6 +19134,7 @@ name: proteoform-level local FDR threshold
 def: "Threshold for the local false discovery rate of proteoforms." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002909 ! proteoform-level statistical threshold
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002912
@@ -18916,6 +19160,7 @@ name: TopPIC:error tolerance
 def: "Error tolerance for precursor and fragment masses in PPM." [PSI:PI]
 xref: value-type:xsd\:integer "The allowed value-type for this CV term."
 is_a: MS:1002912 ! TopPIC input parameter
+relationship: has_value_type: xsd\:integer ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002916
@@ -18923,6 +19168,7 @@ name: TopPIC:max shift
 def: "Maximum value of the mass shift (in Dalton) of an unexpected modification." [PSI:PI]
 xref: value-type:xsd\:integer "The allowed value-type for this CV term."
 is_a: MS:1002912 ! TopPIC input parameter
+relationship: has_value_type: xsd\:integer ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002917
@@ -18930,6 +19176,7 @@ name: TopPIC:min shift
 def: "Minimum value of the mass shift (in Dalton) of an unexpected modification." [PSI:PI]
 xref: value-type:xsd\:integer "The allowed value-type for this CV term."
 is_a: MS:1002912 ! TopPIC input parameter
+relationship: has_value_type: xsd\:integer ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002918
@@ -18937,6 +19184,7 @@ name: TopPIC:shift num
 def: "Maximum number of unexpected modifications in a proteoform spectrum match." [PSI:PI]
 xref: value-type:xsd\:integer "The allowed value-type for this CV term."
 is_a: MS:1002912 ! TopPIC input parameter
+relationship: has_value_type: xsd\:integer ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002919
@@ -18944,6 +19192,7 @@ name: TopPIC:spectral cutoff type
 def: "Spectrum-level cutoff type for filtering identified proteoform spectrum matches." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002912 ! TopPIC input parameter
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002920
@@ -18951,6 +19200,7 @@ name: TopPIC:spectral cutoff value
 def: "Spectrum-level cutoff value for filtering identified proteoform spectrum matches." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002912 ! TopPIC input parameter
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002921
@@ -18958,6 +19208,7 @@ name: TopPIC:proteoform-level cutoff type
 def: "Proteoform-level cutoff type for filtering identified proteoform spectrum matches." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002912 ! TopPIC input parameter
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002922
@@ -18965,6 +19216,7 @@ name: TopPIC:proteoform-level cutoff value
 def: "Proteoform-level cutoff value for filtering identified proteoform spectrum matches." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002912 ! TopPIC input parameter
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002923
@@ -18972,6 +19224,7 @@ name: TopPIC:generating function
 def: "P-value and E-value estimation using generating function." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002912 ! TopPIC input parameter
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002924
@@ -18979,6 +19232,7 @@ name: TopPIC:combined spectrum number
 def: "Number of combined spectra." [PSI:PI]
 xref: value-type:xsd\:integer "The allowed value-type for this CV term."
 is_a: MS:1002912 ! TopPIC input parameter
+relationship: has_value_type: xsd\:integer ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002925
@@ -18992,6 +19246,7 @@ name: TopPIC:thread number
 def: "Number of threads used in TopPIC." [PSI:PI]
 xref: value-type:xsd\:integer "The allowed value-type for this CV term."
 is_a: MS:1002912 ! TopPIC input parameter
+relationship: has_value_type: xsd\:integer ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002927
@@ -18999,6 +19254,7 @@ name: TopPIC:use TopFD feature
 def: "Proteoform identification using TopFD feature file." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002912 ! TopPIC input parameter
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002928
@@ -19007,7 +19263,8 @@ def: "TopPIC spectrum-level E-value." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1002353 ! PSM-level e-value
-relationship: has_order MS:1002109 ! lower score better
+relationship: has_order: MS:1002109 ! lower score better
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002929
@@ -19016,6 +19273,7 @@ def: "TopPIC spectrum-level FDR." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1002351 ! PSM-level local FDR
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002930
@@ -19024,6 +19282,7 @@ def: "TopPIC proteoform-level FDR." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002908 ! proteoform-level local FDR
 is_a: MS:1002906 ! search engine specific score for proteoforms
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002931
@@ -19032,6 +19291,7 @@ def: "TopPIC spectrum-level p-value." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1002352 ! PSM-level p-value
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002932
@@ -19039,6 +19299,7 @@ name: TopPIC:MIScore
 def: "Modification identification score." [PMID:27291504]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001968 ! PTM localization PSM-level statistic
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002933
@@ -19046,6 +19307,7 @@ name: TopPIC:MIScore threshold
 def: "TopPIC:MIScore threshold." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002555 ! PTM localization score threshold
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002934
@@ -19071,6 +19333,7 @@ name: TopMG:error tolerance
 def: "Error tolerance for precursor and fragment masses in PPM." [PSI:PI]
 xref: value-type:xsd\:integer "The allowed value-type for this CV term."
 is_a: MS:1002934 ! TopMG input parameter
+relationship: has_value_type: xsd\:integer ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002938
@@ -19078,6 +19341,7 @@ name: TopMG:max shift
 def: "Maximum value of the mass shift (in Dalton)." [PSI:PI]
 xref: value-type:xsd\:integer "The allowed value-type for this CV term."
 is_a: MS:1002934 ! TopMG input parameter
+relationship: has_value_type: xsd\:integer ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002939
@@ -19085,6 +19349,7 @@ name: TopMG:spectral cutoff type
 def: "Spectrum-level cutoff type for filtering identified proteoform spectrum matches." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002934 ! TopMG input parameter
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002940
@@ -19092,6 +19357,7 @@ name: TopMG:spectral cutoff value
 def: "Spectrum-level cutoff value for filtering identified proteoform spectrum matches." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002934 ! TopMG input parameter
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002941
@@ -19099,6 +19365,7 @@ name: TopMG:proteoform-level cutoff type
 def: "Proteoform-level cutoff type for filtering identified proteoform spectrum matches." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002934 ! TopMG input parameter
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002942
@@ -19106,6 +19373,7 @@ name: TopMG:proteoform-level cutoff value
 def: "Proteoform-level cutoff value for filtering identified proteoform spectrum matches." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002934 ! TopMG input parameter
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002943
@@ -19119,6 +19387,7 @@ name: TopMG:thread number
 def: "Number of threads used in TopMG." [PSI:PI]
 xref: value-type:xsd\:integer "The allowed value-type for this CV term."
 is_a: MS:1002934 ! TopMG input parameter
+relationship: has_value_type: xsd\:integer ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002945
@@ -19126,6 +19395,7 @@ name: TopMG:use TopFD feature
 def: "Proteoform identification using TopFD feature file." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002934 ! TopMG input parameter
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002946
@@ -19133,6 +19403,7 @@ name: TopMG:proteoform graph gap size
 def: "Gap size in constructing proteoform graph." [PSI:PI]
 xref: value-type:xsd\:integer "The allowed value-type for this CV term."
 is_a: MS:1002934 ! TopMG input parameter
+relationship: has_value_type: xsd\:integer ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002947
@@ -19140,6 +19411,7 @@ name: TopMG:variable PTM number
 def: "Maximum number of variable PTMs." [PSI:PI]
 xref: value-type:xsd\:integer "The allowed value-type for this CV term."
 is_a: MS:1002934 ! TopMG input parameter
+relationship: has_value_type: xsd\:integer ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002948
@@ -19147,6 +19419,7 @@ name: TopMG:variable PTM number in proteoform graph gap
 def: "Maximum number of variable PTMs in a proteoform graph gap." [PSI:PI]
 xref: value-type:xsd\:integer "The allowed value-type for this CV term."
 is_a: MS:1002934 ! TopMG input parameter
+relationship: has_value_type: xsd\:integer ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002949
@@ -19154,6 +19427,7 @@ name: TopMG:use ASF-DIAGONAL
 def: "Protein filtering using ASF-DIAGONAL method." [PMID:29327814]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002934 ! TopMG input parameter
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002950
@@ -19162,7 +19436,8 @@ def: "TopMG spectrum-level E-value." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002353 ! PSM-level e-value
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_order MS:1002109 ! lower score better
+relationship: has_order: MS:1002109 ! lower score better
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002951
@@ -19171,6 +19446,7 @@ def: "TopMG spectrum-level FDR." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002351 ! PSM-level local FDR
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002952
@@ -19179,6 +19455,7 @@ def: "TopMG proteoform-level FDR." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002908 ! proteoform-level local FDR
 is_a: MS:1002906 ! search engine specific score for proteoforms
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002953
@@ -19187,6 +19464,7 @@ def: "TopMG spectrum-level p-value." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002352 ! PSM-level p-value
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002954
@@ -19194,7 +19472,8 @@ name: collisional cross sectional area
 def: "Structural molecular descriptor for the effective interaction area between the ion and neutral gas measured in ion mobility mass spectrometry." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1000861 ! molecular entity property
-relationship: has_units UO:0000324 ! square angstrom
+relationship: has_units: UO:0000324 ! square angstrom
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002955
@@ -19202,6 +19481,7 @@ name: hr-ms compound identification confidence level
 def: "Refined High Resolution mass spectrometry confidence level for annotation of identified compounds as proposed by Schymanski et al. The value slot can have the values 'Level 1', 'Level 2', 'Level 2a', 'Level 2b', 'Level 3', 'Level 4', and 'Level 5'." [PMID:24476540]
 xref: value-type:xsd:string "The allowed value-type for this CV term."
 is_a: MS:1002895 ! small molecule identification attribute
+relationship: has_value_type: xsd:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002956
@@ -19209,6 +19489,7 @@ name: isotopic ion MS peak
 def: "A mass spectrometry peak that represents one or more isotopic ions. The value slot contains a description of the represented isotope set, e.g. 'M+1 peak'." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000231 ! peak
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002957
@@ -19216,6 +19497,7 @@ name: isotopomer MS peak
 def: "The described isotopomer mass spectrometric signal. The value slot contains a description of the represented isotopomer, e.g. '13C peak', '15N peak', '2H peak', '18O peak' or '31P peak'." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002956 ! isotopic ion MS peak
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002958
@@ -19223,6 +19505,7 @@ name: isotopologue MS peak
 def: "The described isotopologue mass spectrometric signal. The value slot contains a description of the represented isotopologue, e.g. '13C1 peak' or '15N1 peak'." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002956 ! isotopic ion MS peak
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002959
@@ -19230,6 +19513,7 @@ name: isomer
 def: "One of several species (or molecular entities) that have the same atomic composition (molecular formula) but different line formulae or different stereochemical formulae." [https://goldbook.iupac.org/html/I/I03289.html]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000859 ! molecule
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002960
@@ -19237,6 +19521,7 @@ name: isotopomer
 def: "An isomer that differs from another only in the spatial distribution of the constitutive isotopic atoms." [https://goldbook.iupac.org/html/I/I03352.html]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002959 ! isomer
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002961
@@ -19244,6 +19529,7 @@ name: isotopologue
 def: "A molecular entity that differs only in isotopic composition (number of isotopic substitutions)." [https://goldbook.iupac.org/html/I/I03351.html]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002959 ! isomer
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002962
@@ -19422,7 +19708,8 @@ name: IdentiPy:RHNS
 def: "The IdentiPy result 'RHNS'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001153 ! search engine specific score
-relationship: has_order MS:1002108 ! higher score better
+relationship: has_order: MS:1002108 ! higher score better
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002989
@@ -19430,7 +19717,8 @@ name: IdentiPy:hyperscore
 def: "The IdentiPy result 'hyperscore'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001153 ! search engine specific score
-relationship: has_order MS:1002108 ! higher score better
+relationship: has_order: MS:1002108 ! higher score better
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002990
@@ -19450,8 +19738,9 @@ name: Andromeda:PEP
 def: "Posterior error probability of the best identified peptide of the Andromeda search engine." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
-relationship: has_order MS:1002108 ! higher score better
+relationship: has_domain: MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_order: MS:1002108 ! higher score better
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002996
@@ -19465,6 +19754,7 @@ name: ProteomeXchange dataset identifier reanalysis number
 def: "Index number of a reanalysis within a ProteomeXchange reprocessed dataset identifier container (RPXD)." [PSI:PI]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
+relationship: has_value_type: xsd\:nonNegativeInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1002998
@@ -19520,7 +19810,8 @@ name: mean inverse reduced ion mobility array
 def: "Array of population mean ion mobility values based on ion separation in gaseous phase due to different ion mobilities under an electric field based on ion size, m/z and shape, normalized for the local conditions and reported in volt-second per square centimeter, corresponding to a spectrum of individual peaks encoded with an m/z array." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002893 ! ion mobility array
-relationship: has_units MS:1002814 ! volt-second per square centimeter
+relationship: has_units: MS:1002814 ! volt-second per square centimeter
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003007
@@ -19528,8 +19819,9 @@ name: raw ion mobility array
 def: "Array of raw ion mobility values (K or K0) based on ion separation in gaseous phase due to different ion mobilities under an electric field based on ion size, m/z and shape, corresponding to a spectrum of individual peaks encoded with an m/z array." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002893 ! ion mobility array
-relationship: has_units UO:0000028 ! millisecond
-relationship: has_units UO:0000010 ! second
+relationship: has_units: UO:0000028 ! millisecond
+relationship: has_units: UO:0000010 ! second
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003008
@@ -19537,7 +19829,8 @@ name: raw inverse reduced ion mobility array
 def: "Array of raw ion mobility values based on ion separation in gaseous phase due to different ion mobilities under an electric field based on ion size, m/z and shape, normalized for the local conditions and reported in volt-second per square centimeter, corresponding to a spectrum of individual peaks encoded with an m/z array." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002893 ! ion mobility array
-relationship: has_units MS:1002814 ! volt-second per square centimeter
+relationship: has_units: MS:1002814 ! volt-second per square centimeter
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003009
@@ -19563,7 +19856,7 @@ id: MS:1003012
 name: KSDP score
 def: "Kernel mass spectral dot product scoring function." [PMID:15044235]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_order MS:1002108 ! higher score better
+relationship: has_order: MS:1002108 ! higher score better
 
 [Term]
 id: MS:1003013
@@ -19590,8 +19883,9 @@ def: "Fraction of peptide evidence attributable to a protein or a set of indisti
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002490 ! peptide-level scoring
 is_a: MS:1001153 ! search engine specific score
-relationship: has_order MS:1002108 ! higher score better
-relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_order: MS:1002108 ! higher score better
+relationship: has_domain: MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003017
@@ -19600,8 +19894,9 @@ def: "Fraction of peptide evidence attributable to a group of proteins." [PSI:PI
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002490 ! peptide-level scoring
 is_a: MS:1001153 ! search engine specific score
-relationship: has_order MS:1002108 ! higher score better
-relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_order: MS:1002108 ! higher score better
+relationship: has_domain: MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003018
@@ -19648,13 +19943,14 @@ def: "The OpenPepXL score for a cross-link spectrum match." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1001153 ! search engine specific score
-relationship: has_order MS:1002108 ! higher score better
+relationship: has_order: MS:1002108 ! higher score better
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003025
 name: named element
 def: "A named element that is an attribute in a proteomics standards file." [PSI:PI]
-relationship: part_of MS:0000000 ! Proteomics Standards Initiative Mass Spectrometry Vocabularies
+relationship: part_of: MS:0000000 ! Proteomics Standards Initiative Mass Spectrometry Vocabularies
 
 [Term]
 id: MS:1003026
@@ -19686,6 +19982,7 @@ name: Mascot:MinNumSigUniqueSeqs
 def: "Minimum number of significant unique sequences required in a protein hit. The setting is only relevant if the protein grouping strategy is 'family clustering'." [PSI:PI]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1002095 ! Mascot input parameter
+relationship: has_value_type: xsd\:nonNegativeInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003031
@@ -19693,6 +19990,7 @@ name: CPTAC accession number
 def: "Main identifier of a CPTAC dataset." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003032
@@ -19700,12 +19998,13 @@ name: compound identification confidence code in MS-DIAL
 def: "The confidence code to describe the confidence of annotated compounds as defined by the MS-DIAL program." [PMID:25938372, http://prime.psc.riken.jp/Metabolomics_Software/MS-DIAL]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002895 ! small molecule identification attribute
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003033
 name: molecular entity attribute
 def: "Non-inherent characteristic attributed to a molecular entity." [PSI:PI]
-relationship: part_of MS:1000881 ! molecular entity
+relationship: part_of: MS:1000881 ! molecular entity
 
 [Term]
 id: MS:1003034
@@ -19807,22 +20106,19 @@ is_a: MS:1000860 ! peptide
 id: MS:1003050
 name: peptidoform attribute
 def: "Non-inherent characteristic attributed to a peptidoform." [PSI:PI]
-relationship: part_of MS:1003049 ! peptidoform
+relationship: part_of: MS:1003049 ! peptidoform
 
 [Term]
 id: MS:1003051
 name: peptidoform ion
 def: "Peptidoform that has formed an adduct with an ion, thereby rendering it potentially detectable with a mass spectrometer. Commonly called a 'precursor' or 'precursor ion' or 'parent ion'." [PSI:PI]
 is_a: MS:1003049 ! peptidoform
-synonym: "precursor" RELATED []
-synonym: "precursor ion" RELATED []
-synonym: "parent ion" RELATED []
 
 [Term]
 id: MS:1003052
 name: peptidoform ion property
 def: "Inherent or measurable characteristic of a peptidoform ion." [PSI:PI]
-relationship: part_of MS:1003051 ! peptidoform ion
+relationship: part_of: MS:1003051 ! peptidoform ion
 
 [Term]
 id: MS:1003053
@@ -19846,7 +20142,7 @@ is_a: MS:1000859 ! molecule
 id: MS:1003056
 name: adduct ion property
 def: "Physical measurable characteristic of an adduct ion." [PSI:PI]
-relationship: part_of MS:1000353 ! adduct ion
+relationship: part_of: MS:1000353 ! adduct ion
 
 [Term]
 id: MS:1003057
@@ -19858,7 +20154,7 @@ is_a: MS:1000503 ! scan attribute
 id: MS:1003058
 name: spectrum property
 def: "Inherent or measurable characteristic of a spectrum." [PSI:PI]
-relationship: part_of MS:1000442 ! spectrum
+relationship: part_of: MS:1000442 ! spectrum
 
 [Term]
 id: MS:1003059
@@ -19978,7 +20274,7 @@ is_a: MS:1000442 ! spectrum
 id: MS:1003078
 name: interpreted spectrum attribute
 def: "Non-inherent characteristic attributed to an interpreted spectrum." [PSI:PI]
-relationship: part_of MS:1003077 ! interpreted spectrum
+relationship: part_of: MS:1003077 ! interpreted spectrum
 
 [Term]
 id: MS:1003079
@@ -19996,9 +20292,10 @@ is_a: MS:1003078 ! interpreted spectrum attribute
 id: MS:1003081
 name: unidentified modification monoisotopic mass delta
 def: "Monoisotopic mass delta in Daltons of an amino acid residue modification whose atomic composition or molecular identity has not been determined. This term should not be used for modifications of known molecular identity such as those available in Unimod, RESID or PSI-MOD. This term MUST NOT be used inside the <Modification> element in mzIdentML." [PSI:PI]
-is_a: MS:1001471 ! peptide modification details
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-relationship: has_units UO:0000221 ! dalton
+is_a: MS:1001471 ! peptide modification details
+relationship: has_units: UO:0000221 ! dalton
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003082
@@ -20019,6 +20316,7 @@ name: processed data file
 def: "File that contains data that has been substantially processed or transformed from what was originally acquired by an instrument." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000577 ! source data file
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003085
@@ -20027,6 +20325,7 @@ def: "Intensity of the precursor ion in the previous MSn-1 scan (prior in time t
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001141 ! intensity of precursor ion
 is_a: MS:1000499 ! spectrum attribute
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003086
@@ -20035,6 +20334,7 @@ def: "Intensity of the precursor ion current as measured by its apex point over 
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001141 ! intensity of precursor ion
 is_a: MS:1000499 ! spectrum attribute
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003087
@@ -20064,8 +20364,8 @@ is_a: MS:1000572 ! binary data compression type
 id: MS:1003091
 name: binary data compression parameter
 def: "Settable parameter for a binary data compression event." [PSI:MS]
-relationship: part_of MS:1000442 ! spectrum
-relationship: part_of MS:1000625 ! chromatogram
+relationship: part_of: MS:1000442 ! spectrum
+relationship: part_of: MS:1000625 ! chromatogram
 
 [Term]
 id: MS:1003092
@@ -20073,13 +20373,14 @@ name: number of mantissa bits truncated
 def: "Number of extraneous mantissa bits truncated to improve subsequent compression." [PSI:MS]
 xref: value-type:xsd\:positiveInteger "Number of mantissa bits truncated."
 is_a: MS:1003091 ! binary data compression parameter
+relationship: has_value_type: xsd\:positiveInteger ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003093
 name: Lys-N
 def: "Metalloendopeptidase found in the mushroom Grifola frondosa that cleaves proteins on the amino side of lysine residues." [https://en.wikipedia.org/wiki/Lys-N]
 is_a: MS:1001045 ! cleavage agent name
-relationship: has_regexp MS:1001335 ! (?=K)
+relationship: has_regexp: MS:1001335 ! (?=K)
 
 [Term]
 id: MS:1003094
@@ -20105,6 +20406,7 @@ name: MaxQuant protein group-level score
 def: "The probability based MaxQuant protein group score." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002368 ! search engine specific score for protein groups
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003098
@@ -20112,6 +20414,7 @@ name: Andromeda peptide PEP
 def: "Peptide probability from Andromeda." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002358 ! search engine specific peptide sequence-level identification statistic
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003099
@@ -20119,6 +20422,7 @@ name: MaxQuant-DIA peptide PEP
 def: "Peptide probability from MaxQuant-DIA algorithm." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002358 ! search engine specific peptide sequence-level identification statistic
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003100
@@ -20126,6 +20430,7 @@ name: MaxQuant-DIA score
 def: "PSM evidence score from MaxQuant-DIA algorithm." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003101
@@ -20133,6 +20438,7 @@ name: MaxQuant-DIA PEP
 def: "PSM evidence PEP probability from MaxQuant-DIA algorithm." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003102
@@ -20140,6 +20446,7 @@ name: NIST msp comment
 def: "Term for a comment field withing the NIST msp file format" [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000499 ! spectrum attribute
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003103
@@ -20190,7 +20497,8 @@ name: SIM-XL score
 def: "SIM-XL identification search engine score" [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_order MS:1002108 ! higher score better
+relationship: has_order: MS:1002108 ! higher score better
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003111
@@ -20210,6 +20518,7 @@ name: OpenMS:ConsensusID PEP
 def: "The OpenMS ConsesusID tool posterior error probability" [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003114
@@ -20217,6 +20526,7 @@ name: OpenMS:Best PSM Score
 def: "The score of the best PSM selected by the underlying identification tool" [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002358 ! search engine specific peptide sequence-level identification statistic
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003115
@@ -20224,6 +20534,7 @@ name: OpenMS:Target-decoy PSM q-value
 def: "The OpenMS Target-decoy q-values at PSM level" [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003116
@@ -20231,6 +20542,7 @@ name: OpenMS:Target-decoy peptide q-value
 def: "The OpenMS Target-decoy q-values at peptide sequence level" [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002358 ! search engine specific peptide sequence-level identification statistic
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003117
@@ -20238,6 +20550,7 @@ name: OpenMS:Target-decoy protein q-value
 def: "The OpenMS Target-decoy q-values at protein level" [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003118
@@ -20252,6 +20565,7 @@ name: EPIFANY:Protein posterior probability
 def: "Protein Posterior probability calculated by EPIFANY protein inference algorithm" [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003120
@@ -20259,6 +20573,7 @@ name: OpenMS:LFQ intensity
 def: "The data type LFQ intensity produced by OpenMS." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003121
@@ -20266,6 +20581,7 @@ name: OpenMS:LFQ spectral count
 def: "The data type LFQ spectral count produced by OpenMS." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003122
@@ -20292,7 +20608,8 @@ def: "ProSight spectrum-level Q-value." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002354 ! PSM-level q-value
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_order MS:1002109 ! lower score better
+relationship: has_order: MS:1002109 ! lower score better
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003126
@@ -20300,7 +20617,8 @@ name: ProSight:spectral P-score
 def: "ProSight spectrum-level P-score." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_order MS:1002109 ! lower score better
+relationship: has_order: MS:1002109 ! lower score better
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003127
@@ -20309,7 +20627,8 @@ def: "ProSight spectrum-level E-value." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002353 ! PSM-level e-value
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_order MS:1002109 ! lower score better
+relationship: has_order: MS:1002109 ! lower score better
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003128
@@ -20317,7 +20636,8 @@ name: ProSight:spectral C-score
 def: "ProSight spectrum-level C-score." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_order MS:1002108 ! higher score better
+relationship: has_order: MS:1002108 ! higher score better
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003129
@@ -20325,8 +20645,9 @@ name: proteoform-level Q-value
 def: "Estimation of the Q-value for proteoforms." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002905 ! proteoform-level identification statistic
-relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
-relationship: has_order MS:1002109 ! lower score better
+relationship: has_domain: MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_order: MS:1002109 ! lower score better
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003130
@@ -20334,7 +20655,8 @@ name: ProSight:proteoform Q-value
 def: "ProSight proteoform-level Q-value." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1003129 ! proteoform-level Q-value
-relationship: has_order MS:1002109 ! lower score better
+relationship: has_order: MS:1002109 ! lower score better
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003131
@@ -20354,7 +20676,8 @@ name: isoform-level Q-value
 def: "Estimation of the Q-value for isoforms." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1003132 ! isoform-level identification statistic
-relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_domain: MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003134
@@ -20362,7 +20685,8 @@ name: ProSight:isoform Q-value
 def: "ProSight isoform-level Q-value." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1003133 ! isoform-level Q-value
-relationship: has_order MS:1002109 ! lower score better
+relationship: has_order: MS:1002109 ! lower score better
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003135
@@ -20370,7 +20694,8 @@ name: ProSight:protein Q-value
 def: "ProSight protein-level Q-value." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001869 ! protein-level q-value
-relationship: has_order MS:1002109 ! lower score better
+relationship: has_order: MS:1002109 ! lower score better
+relationship: has_value_type: xsd\:double ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003136
@@ -20391,6 +20716,7 @@ def: "If true, runs delta m mode in ProSight." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1003136 ! ProSight input parameter
 is_a: MS:1003137 ! TDPortal input parameter
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003139
@@ -20399,6 +20725,7 @@ def: "If true, runs Subsequence Search mode in ProSight." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1003136 ! ProSight input parameter
 is_a: MS:1003137 ! TDPortal input parameter
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003140
@@ -20407,6 +20734,7 @@ def: "If true, runs Annotated Proteoform Search mode in ProSight." [PSI:MS]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1003136 ! ProSight input parameter
 is_a: MS:1003137 ! TDPortal input parameter
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003141
@@ -20427,7 +20755,7 @@ def: "A data array of mass values." [PSI:MS]
 xref: binary-data-type:MS\:1000521 "32-bit float"
 xref: binary-data-type:MS\:1000523 "64-bit float"
 is_a: MS:1000513 ! binary data array
-relationship: has_units UO:0000221 ! dalton
+relationship: has_units: UO:0000221 ! dalton
 
 [Term]
 id: MS:1003144
@@ -20452,28 +20780,28 @@ id: MS:1003147
 name: PTMProphet probability
 def: "Probability that one mass modification has been correctly localized to a specific residue as computed by PTMProphet." [DOI:10.1021/acs.jproteome.9b00205, PMID:31290668]
 is_a: MS:1001968 ! PTM localization PSM-level statistic
-relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
+relationship: has_regexp: MS:1002505 ! regular expression for modification localization scoring
 
 [Term]
 id: MS:1003148
 name: PTMProphet mean best probability
 def: "PSM-specific average of the m best site probabilities over all potential sites where m is the number of modifications of a specific type, as computed by PTMProphet." [DOI:10.1021/acs.jproteome.9b00205, PMID:31290668]
 is_a: MS:1001968 ! PTM localization PSM-level statistic
-relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
+relationship: has_regexp: MS:1002505 ! regular expression for modification localization scoring
 
 [Term]
 id: MS:1003149
 name: PTMProphet normalized information content
-def: " PTMProphet-computed PSM-specific normalized (0.0 – 1.0) measure of information content across all modifications of a specific type." [DOI:10.1021/acs.jproteome.9b00205, PMID:31290668]
+def: " PTMProphet-computed PSM-specific normalized (0.0 � 1.0) measure of information content across all modifications of a specific type." [DOI:10.1021/acs.jproteome.9b00205, PMID:31290668]
 is_a: MS:1001968 ! PTM localization PSM-level statistic
-relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
+relationship: has_regexp: MS:1002505 ! regular expression for modification localization scoring
 
 [Term]
 id: MS:1003150
 name: PTMProphet information content
 def: " PTMProphet-computed PSM-specific measure of information content per modification type ranging from 0 to m, where m is the number of modifications of a specific type." [DOI:10.1021/acs.jproteome.9b00205, PMID:31290668]
 is_a: MS:1001968 ! PTM localization PSM-level statistic
-relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
+relationship: has_regexp: MS:1002505 ! regular expression for modification localization scoring
 
 [Term]
 id: MS:1003151
@@ -20481,6 +20809,7 @@ name: SHA-256
 def: "SHA-256 (member of Secure Hash Algorithm-2 family) is a cryptographic hash function designed by the National Security Agency (NSA) and published by the NIST as a U. S. government standard. It is also used to verify file integrity." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000561 ! data file checksum type
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003152
@@ -20494,8 +20823,9 @@ name: raw ion mobility drift time array
 def: "Array of raw ion mobility values from a drift time device, reported in seconds (or milliseconds), corresponding to a spectrum of individual peaks encoded with an m/z array." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002893 ! ion mobility array
-relationship: has_units UO:0000028 ! millisecond
-relationship: has_units UO:0000010 ! second
+relationship: has_units: UO:0000028 ! millisecond
+relationship: has_units: UO:0000010 ! second
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003154
@@ -20503,8 +20833,9 @@ name: deconvoluted ion mobility array
 def: "Array of ion mobility values (K or K0) based on ion separation in gaseous phase due to different ion mobilities under an electric field based on ion size, m/z and shape, as an average property of an analyte post peak-detection, weighted charge state reduction, and/or adduct aggregation, corresponding to a spectrum of individual peaks encoded with an m/z array." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002893 ! ion mobility array
-relationship: has_units UO:0000028 ! millisecond
-relationship: has_units UO:0000010 ! second
+relationship: has_units: UO:0000028 ! millisecond
+relationship: has_units: UO:0000010 ! second
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003155
@@ -20512,7 +20843,8 @@ name: deconvoluted inverse reduced ion mobility array
 def: "Array of ion mobility values based on ion separation in gaseous phase due to different ion mobilities under an electric field based on ion size, m/z and shape, normalized for the local conditions and reported in volt-second per square centimeter, as an average property of an analyte post peak-detection, weighted charge state reduction, and/or adduct aggregation, corresponding to a spectrum of individual peaks encoded with an m/z array." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002893 ! ion mobility array
-relationship: has_units MS:1002814 ! volt-second per square centimeter
+relationship: has_units: MS:1002814 ! volt-second per square centimeter
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003156
@@ -20520,8 +20852,9 @@ name: deconvoluted ion mobility drift time array
 def: "Array of mean ion mobility values from a drift time device, reported in seconds (or milliseconds), as an average property of an analyte post peak-detection, weighted charge state reduction, and/or adduct aggregation, corresponding to a spectrum of individual peaks encoded with an m/z array." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002893 ! ion mobility array
-relationship: has_units UO:0000028 ! millisecond
-relationship: has_units UO:0000010 ! second
+relationship: has_units: UO:0000028 ! millisecond
+relationship: has_units: UO:0000010 ! second
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003157
@@ -20529,7 +20862,8 @@ name: scanning quadrupole position lower bound m/z array
 def: "Array of m/z values representing the lower bound m/z of the quadrupole position at each point in the spectrum." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000513 ! binary data array
-relationship: has_units MS:1000040 ! m/z
+relationship: has_units: MS:1000040 ! m/z
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003158
@@ -20537,7 +20871,8 @@ name: scanning quadrupole position upper bound m/z array
 def: "Array of m/z values representing the upper bound m/z of the quadrupole position at each point in the spectrum." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000513 ! binary data array
-relationship: has_units MS:1000040 ! m/z
+relationship: has_units: MS:1000040 ! m/z
+relationship: has_value_type: xsd\:float ! The allowed value-type for this CV term.
 
 [Term]
 id: MS:1003159
@@ -20561,7 +20896,7 @@ is_a: MS:1001459 ! file format
 id: PEFF:0000001
 name: PEFF CV term
 def: "PSI Extended FASTA Format controlled vocabulary term." [PSI:PEFF]
-relationship: part_of MS:0000000 ! Proteomics Standards Initiative Mass Spectrometry Vocabularies
+relationship: part_of: MS:0000000 ! Proteomics Standards Initiative Mass Spectrometry Vocabularies
 
 [Term]
 id: PEFF:0000002
@@ -20579,355 +20914,396 @@ is_a: PEFF:0000001 ! PEFF CV term
 id: PEFF:0000008
 name: DbName
 def: "PEFF keyword for the sequence database name." [PSI:PEFF]
-is_a: PEFF:0000002 ! PEFF file header section term
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
+is_a: PEFF:0000002 ! PEFF file header section term
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0000009
 name: Prefix
 def: "PEFF keyword for the sequence database prefix." [PSI:PEFF]
-is_a: PEFF:0000002 ! PEFF file header section term
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
+is_a: PEFF:0000002 ! PEFF file header section term
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0000010
 name: DbDescription
 def: "PEFF keyword for the sequence database short description." [PSI:PEFF]
-is_a: PEFF:0000002 ! PEFF file header section term
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
+is_a: PEFF:0000002 ! PEFF file header section term
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0000011
 name: Decoy
 def: "PEFF keyword for the specifying whether the sequence database is a decoy database." [PSI:PEFF]
-is_a: PEFF:0000002 ! PEFF file header section term
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
+is_a: PEFF:0000002 ! PEFF file header section term
+relationship: has_value_type: xsd\:boolean ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0000012
 name: DbSource
 def: "PEFF keyword for the source of the database file." [PSI:PEFF]
-is_a: PEFF:0000002 ! PEFF file header section term
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
+is_a: PEFF:0000002 ! PEFF file header section term
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0000013
 name: DbVersion
 def: "PEFF keyword for the database version (release date) according to database provider." [PSI:PEFF]
-is_a: PEFF:0000002 ! PEFF file header section term
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
+is_a: PEFF:0000002 ! PEFF file header section term
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0000014
 name: DbDate
 def: "OBSOLETE PEFF keyword for the database date (release or file date of the source) according to database provider." [PSI:PEFF]
-comment: This term was obsoleted.
 is_a: PEFF:0000002 ! PEFF file header section term
-is_obsolete: true
 
 [Term]
 id: PEFF:0000015
 name: NumberOfEntries
 def: "PEFF keyword for the sumber of sequence entries in the database." [PSI:PEFF]
-is_a: PEFF:0000002 ! PEFF file header section term
 xref: value-type:xsd\:integer "The allowed value-type for this CV term."
+is_a: PEFF:0000002 ! PEFF file header section term
+relationship: has_value_type: xsd\:integer ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0000016
 name: Conversion
 def: "PEFF keyword for the description of the conversion from original format to this current one." [PSI:PEFF]
-is_a: PEFF:0000002 ! PEFF file header section term
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
+is_a: PEFF:0000002 ! PEFF file header section term
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0000017
 name: SequenceType
 def: "PEFF keyword for the molecular type of the sequences." [PSI:PEFF]
-is_a: PEFF:0000002 ! PEFF file header section term
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
-relationship: has_regexp PEFF:1002002 ! regular expression for PEFF molecular sequence type
+is_a: PEFF:0000002 ! PEFF file header section term
+relationship: has_regexp: PEFF:1002002 ! regular expression for PEFF molecular sequence type
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0000018
 name: SpecificKey
 def: "PEFF keyword for database specific keywords not included in the current controlled vocabulary." [PSI:PEFF]
-is_a: PEFF:0000002 ! PEFF file header section term
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
+is_a: PEFF:0000002 ! PEFF file header section term
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0000019
 name: SpecificValue
 def: "PEFF keyword for the specific values for a custom key." [PSI:PEFF]
-is_a: PEFF:0000002 ! PEFF file header section term
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
+is_a: PEFF:0000002 ! PEFF file header section term
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0000020
 name: DatabaseDescription
 def: "PEFF keyword for the short description of the PEFF file." [PSI:PEFF]
-is_a: PEFF:0000002 ! PEFF file header section term
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
+is_a: PEFF:0000002 ! PEFF file header section term
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0000021
 name: GeneralComment
 def: "PEFF keyword for a general comment." [PSI:PEFF]
-is_a: PEFF:0000002 ! PEFF file header section term
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
+is_a: PEFF:0000002 ! PEFF file header section term
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0000022
 name: ProteoformDb
 def: "PEFF keyword that when set to 'true' indicates that the database contains complete proteoforms." [PSI:PEFF]
-is_a: PEFF:0000002 ! PEFF file header section term
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
+is_a: PEFF:0000002 ! PEFF file header section term
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0000023
 name: OptionalTagDef
 def: "PEFF keyword for the short tag (abbreviation) and longer definition used to annotate a sequence annotation (such as variant or modification) in the OptionalTag location." [PSI:PEFF]
-is_a: PEFF:0000002 ! PEFF file header section term
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
+is_a: PEFF:0000002 ! PEFF file header section term
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0000024
 name: HasAnnotationIdentifiers
 def: "PEFF keyword that when set to 'true' indicates that entries in the database have identifiers for each annotation." [PSI:PEFF]
-is_a: PEFF:0000002 ! PEFF file header section term
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
+is_a: PEFF:0000002 ! PEFF file header section term
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0001001
 name: DbUniqueId
 def: "OBSOLETE Sequence database unique identifier." [PSI:PEFF]
-comment: This term was made obsolete because decided in Heidelberg 2018-04 that this is redundant.
-is_a: PEFF:0000003 ! PEFF file sequence entry term
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
-is_obsolete: true
+is_a: PEFF:0000003 ! PEFF file sequence entry term
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0001002
 name: PName
 def: "PEFF keyword for the protein full name." [PSI:PEFF]
-is_a: PEFF:0000003 ! PEFF file sequence entry term
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
+is_a: PEFF:0000003 ! PEFF file sequence entry term
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0001003
 name: NcbiTaxId
 def: "PEFF keyword for the NCBI taxonomy identifier." [PSI:PEFF]
-is_a: PEFF:0000003 ! PEFF file sequence entry term
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
+is_a: PEFF:0000003 ! PEFF file sequence entry term
+relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0001004
 name: TaxName
 def: "PEFF keyword for the taxonomy name (latin or common name)." [PSI:PEFF]
-is_a: PEFF:0000003 ! PEFF file sequence entry term
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
+is_a: PEFF:0000003 ! PEFF file sequence entry term
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0001005
 name: GName
 def: "PEFF keyword for the gene name." [PSI:PEFF]
-is_a: PEFF:0000003 ! PEFF file sequence entry term
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
+is_a: PEFF:0000003 ! PEFF file sequence entry term
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0001006
 name: Length
 def: "PEFF keyword for the sequence length." [PSI:PEFF]
-is_a: PEFF:0000003 ! PEFF file sequence entry term
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
+is_a: PEFF:0000003 ! PEFF file sequence entry term
+relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0001007
 name: SV
 def: "PEFF keyword for the sequence version." [PSI:PEFF]
-is_a: PEFF:0000003 ! PEFF file sequence entry term
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
+is_a: PEFF:0000003 ! PEFF file sequence entry term
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0001008
 name: EV
 def: "PEFF keyword for the entry version." [PSI:PEFF]
-is_a: PEFF:0000003 ! PEFF file sequence entry term
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
+is_a: PEFF:0000003 ! PEFF file sequence entry term
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0001009
 name: PE
 def: "PEFF keyword for the Protein Evidence; A UniProtKB code 1-5." [PSI:PEFF]
-is_a: PEFF:0000003 ! PEFF file sequence entry term
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
+is_a: PEFF:0000003 ! PEFF file sequence entry term
+relationship: has_value_type: xsd\:int ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0001010
 name: Processed
 def: "PEFF keyword for information on how the full length original protein sequence can be processed into shorter components such as signal peptides and chains." [PSI:PEFF]
-is_a: PEFF:0000003 ! PEFF file sequence entry term
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
-relationship: has_regexp PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
+is_a: PEFF:0000003 ! PEFF file sequence entry term
+relationship: has_regexp: PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0001011
 name: Variant
 def: "OBSOLETE Sequence variation (substitution, insertion, deletion)." [PSI:PEFF]
-comment: This term was made obsolete in favor of VariantSimple and VariantComplex.
-is_a: PEFF:0000003 ! PEFF file sequence entry term
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
-relationship: has_regexp PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
-is_obsolete: true
+is_a: PEFF:0000003 ! PEFF file sequence entry term
+relationship: has_regexp: PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0001012
 name: ModResPsi
 def: "PEFF keyword for the modified residue with PSI-MOD identifier." [PSI:PEFF]
-is_a: PEFF:0000003 ! PEFF file sequence entry term
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
-relationship: has_regexp PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
+is_a: PEFF:0000003 ! PEFF file sequence entry term
+relationship: has_regexp: PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0001013
 name: ModRes
 def: "PEFF keyword for the modified residue without aPSI-MOD or UniMod identifier." [PSI:PEFF]
-is_a: PEFF:0000003 ! PEFF file sequence entry term
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
-relationship: has_regexp PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
+is_a: PEFF:0000003 ! PEFF file sequence entry term
+relationship: has_regexp: PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0001014
 name: AltAC
 def: "PEFF keyword for the Alternative Accession Code." [PSI:PEFF]
-is_a: PEFF:0000003 ! PEFF file sequence entry term
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
+is_a: PEFF:0000003 ! PEFF file sequence entry term
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0001015
 name: SeqStatus
 def: "PEFF keyword for the sequence status. Complete or Fragment." [PSI:PEFF]
-is_a: PEFF:0000003 ! PEFF file sequence entry term
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
-relationship: has_regexp PEFF:1002003 ! regular expression for PEFF sequence status
+is_a: PEFF:0000003 ! PEFF file sequence entry term
+relationship: has_regexp: PEFF:1002003 ! regular expression for PEFF sequence status
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0001016
 name: CC
 def: "PEFF keyword for the entry associated comment." [PSI:PEFF]
-is_a: PEFF:0000003 ! PEFF file sequence entry term
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
+is_a: PEFF:0000003 ! PEFF file sequence entry term
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0001017
 name: KW
 def: "PEFF keyword for the entry associated keyword(s)." [PSI:PEFF]
-is_a: PEFF:0000003 ! PEFF file sequence entry term
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
+is_a: PEFF:0000003 ! PEFF file sequence entry term
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0001018
 name: GO
 def: "PEFF keyword for the Gene Ontology code." [PSI:PEFF]
-is_a: PEFF:0000003 ! PEFF file sequence entry term
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
+is_a: PEFF:0000003 ! PEFF file sequence entry term
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0001019
 name: XRef
 def: "PEFF keyword for the cross-reference to an external resource." [PSI:PEFF]
-is_a: PEFF:0000003 ! PEFF file sequence entry term
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
+is_a: PEFF:0000003 ! PEFF file sequence entry term
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0001020
 name: mature protein
 def: "Portion of a newly synthesized protein that contributes to a final structure after other components such as signal peptides are removed." [PSI:PEFF]
-is_a: PEFF:0001032 ! PEFF molecule processing keyword
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
-relationship: has_regexp PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
+is_a: PEFF:0001032 ! PEFF molecule processing keyword
+relationship: has_regexp: PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0001021
 name: signal peptide
 def: "Short peptide present at the N-terminus of a newly synthesized protein that is cleaved off and is not part of the final mature protein." [PSI:PEFF]
-is_a: PEFF:0001032 ! PEFF molecule processing keyword
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
-relationship: has_regexp PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
+is_a: PEFF:0001032 ! PEFF molecule processing keyword
+relationship: has_regexp: PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0001022
 name: transit peptide
 def: "Short peptide present at the N-terminus of a newly synthesized protein that helps the protein through the membrane of its destination organelle." [PSI:PEFF]
-is_a: PEFF:0001032 ! PEFF molecule processing keyword
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
-relationship: has_regexp PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
+is_a: PEFF:0001032 ! PEFF molecule processing keyword
+relationship: has_regexp: PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0001023
 name: Conflict
 def: "PEFF keyword for the sequence conflict; a UniProtKB term." [PSI:PEFF]
-is_a: PEFF:0000003 ! PEFF file sequence entry term
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
-relationship: has_regexp PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
+is_a: PEFF:0000003 ! PEFF file sequence entry term
+relationship: has_regexp: PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0001024
 name: Crc64
 def: "PEFF keyword for the Sequence checksum in crc64." [PSI:PEFF]
-is_a: PEFF:0000003 ! PEFF file sequence entry term
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
+is_a: PEFF:0000003 ! PEFF file sequence entry term
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0001025
 name: Domain
 def: "PEFF keyword for the sequence range of a domain." [PSI:PEFF]
-is_a: PEFF:0000003 ! PEFF file sequence entry term
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
+is_a: PEFF:0000003 ! PEFF file sequence entry term
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0001026
 name: ID
 def: "PEFF keyword for the UniProtKB specific Protein identifier ID; a UniProtKB term." [PSI:PEFF]
-is_a: PEFF:0000003 ! PEFF file sequence entry term
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
+is_a: PEFF:0000003 ! PEFF file sequence entry term
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0001027
 name: ModResUnimod
 def: "PEFF keyword for the modified residue with UniMod identifier." [PSI:PEFF]
-is_a: PEFF:0000003 ! PEFF file sequence entry term
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
-relationship: has_regexp PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
+is_a: PEFF:0000003 ! PEFF file sequence entry term
+relationship: has_regexp: PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0001028
 name: VariantSimple
 def: "PEFF keyword for the simple sequence variation of a single amino acid change. A change to a stop codon is permitted with a * symbol. More complex variations must be encoded with the VariantComplex term." [PSI:PEFF]
-is_a: PEFF:0000003 ! PEFF file sequence entry term
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
-relationship: has_regexp PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
+is_a: PEFF:0000003 ! PEFF file sequence entry term
+relationship: has_regexp: PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0001029
 name: VariantComplex
 def: "PEFF keyword for a sequence variation that is more complex than a single amino acid change or change to a stop codon." [PSI:PEFF]
-is_a: PEFF:0000003 ! PEFF file sequence entry term
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
-relationship: has_regexp PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
+is_a: PEFF:0000003 ! PEFF file sequence entry term
+relationship: has_regexp: PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0001030
 name: Proteoform
 def: "PEFF keyword for the proteoforms of this protein, constructed as a set of annotation identifiers." [PSI:PEFF]
-is_a: PEFF:0000003 ! PEFF file sequence entry term
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
+is_a: PEFF:0000003 ! PEFF file sequence entry term
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0001031
 name: DisulfideBond
 def: "PEFF keyword for the disulfide bonds in this protein, constructed as a sets of annotation identifiers of two half-cystine modifications." [PSI:PEFF]
-is_a: PEFF:0000003 ! PEFF file sequence entry term
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
+is_a: PEFF:0000003 ! PEFF file sequence entry term
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0001032
@@ -20939,24 +21315,27 @@ is_a: PEFF:0000003 ! PEFF file sequence entry term
 id: PEFF:0001033
 name: Comment
 def: "PEFF keyword for the individual protein entry comment. It is discouraged to put parsable information here. This is only for free-text commentary." [PSI:PEFF]
-is_a: PEFF:0000003 ! PEFF file sequence entry term
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
+is_a: PEFF:0000003 ! PEFF file sequence entry term
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0001034
 name: propeptide
 def: "Short peptide that is cleaved off a newly synthesized protein and generally immediately degraded in the process of protein maturation, and is not a signal peptide or transit peptide." [PSI:PEFF]
-is_a: PEFF:0001032 ! PEFF molecule processing keyword
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
-relationship: has_regexp PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
+is_a: PEFF:0001032 ! PEFF molecule processing keyword
+relationship: has_regexp: PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:0001035
 name: initiator methionine
 def: "N-terminal methionine residue of a protein that can be co-translationally cleaved." [PSI:PEFF]
-is_a: PEFF:0001032 ! PEFF molecule processing keyword
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
-relationship: has_regexp PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
+is_a: PEFF:0001032 ! PEFF molecule processing keyword
+relationship: has_regexp: PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
+relationship: has_value_type: xsd\:string ! The allowed value-type for this CV term.
 
 [Term]
 id: PEFF:1002001
@@ -20975,3 +21354,4 @@ id: PEFF:1002003
 name: regular expression for PEFF sequence status
 def: "(Complete|Fragment|[a-z0-9A-Z]+)." [PSI:PEFF]
 is_a: MS:1002479 ! regular expression
+

--- a/scripts/add_type_relationship.py
+++ b/scripts/add_type_relationship.py
@@ -1,0 +1,37 @@
+'''Copy all `xref: value-type:` lines as `relationship: has_value_type`
+lines.
+'''
+
+import sys
+
+inpath = sys.argv[1]
+outpath = sys.argv[2]
+
+with open(inpath, 'rt') as infh, open(outpath, 'wt') as outfh:
+    in_term = False
+    has_types = []
+    existing_types = []
+    term_id = None
+    for line in infh:
+        if line.startswith("[Term]"):
+            in_term = True
+            has_types = []
+            existing_types = []
+        elif line.startswith("id:"):
+            term_id = line
+        elif line.startswith("relationship: has_value_type"):
+            existing_types.append(line.strip())
+        elif line.startswith("xref: value-type"):
+            has_types.append(line)
+        if not line.strip() and in_term:
+            in_term = False
+            if has_types:
+                for val_type in has_types:
+                    new = (
+                        "relationship: has_value_type %s ! The allowed value-type for this CV term\n" %\
+                             val_type.split("value-type:")[1].split(" \"")[0])
+                    if new.strip() not in existing_types:
+                        outfh.write(new)
+
+            term_id = None
+        outfh.write(line)


### PR DESCRIPTION
Implements the same concept as #50 formally across the entire controlled vocabulary.

I also added three formal data type terms:

```
[Term]
id: MS:1002709
name: compound data type
def: "A data type representing more than a single value." []

[Term]
id: MS:1002710
name: list of type
def: "A data type defining a list of values of a single type." []
is_a: MS:1002709 ! compound data type

[Term]
id: MS:1002711
name: list of strings
def: "A list of xsd:string." []
is_a: MS:1002710 ! list of type
relationship: has_value_type: xsd\:string

[Term]
id: MS:1002712
name: list of integers
def: "A list of xsd:integer." []
is_a: MS:1002710 ! list of type
relationship: has_value_type: xsd\:integer

[Term]
id: MS:1002713
name: list of floats
def: "A list of xsd:float." []
is_a: MS:1002710 ! list of type
relationship: has_value_type: xsd\:float
```
and an implementation for mzSpecLib:
```
[Term]
id: MS:1003162
name: analyte mixture members
def: "The set of analyte identifiers that compose an interpretation of a spectrum." [PSI:PI]
is_a: MS:1003078 ! interpreted spectrum attribute
relationship: has_value_type MS:1002711 ! list of strings
```