### PR TITLE
Switch to PURL for OBO imports

### DIFF
--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -1,10 +1,10 @@
 format-version: 1.2
-data-version: 4.1.65
+data-version: 4.1.66
 date: 04:12:2021 00:00
 saved-by: Eric Deutsch
 auto-generated-by: OBO-Edit 2.3.1
-import: http://ontologies.berkeleybop.org/pato.obo
-import: http://ontologies.berkeleybop.org/uo.obo
+import: http://purl.obolibrary.org/obo/pato.obo
+import: http://purl.obolibrary.org/obo/uo.obo
 default-namespace: MS
 namespace-id-rule: * MS:$sequence(7,0,9999999)$
 namespace-id-rule: * PEFF:$sequence(7,0,9999999)$


### PR DESCRIPTION
@edeutsch is right that the robot convert step is already changing the OBO imports to OWL.