### PR TITLE
adding QC terms for PCA

### DIFF
--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -22921,6 +22921,166 @@ relationship: has_optional_column MS:1001843 ! MS1 feature maximum intensity
 relationship: has_optional_column MS:1003085 ! previous MSn-1 scan precursor intensity
 
 [Term]
+id: MS:4000080
+name: QC non-metric term
+def: "QC terms associated but not directly metrics themselves." [PSI:MS]
+relationship: part_of MS:4000000 ! PSI-MS CV Quality Control Vocabulary
+
+[Term]
+id: MS:4000081
+name: 1st PC 
+def: Data from the first principal component of a PCA. [] 
+relationship: has_value_concept NCIT:C60694 ! Principal Component 
+is_a: MS:4000080 ! QC non-metric term
+
+[Term]
+id: MS:4000082
+name: 2nd PC 
+def: Data from the second principal component of a PCA. [] 
+relationship: has_value_concept NCIT:C60694 ! Principal Component 
+is_a: MS:4000080 ! QC non-metric term
+
+[Term]
+id: MS:4000083
+name: 3rd PC 
+def: Data from the third principal component of a PCA. [] 
+relationship: has_value_concept NCIT:C60694 ! Principal Component 
+is_a: MS:4000080 ! QC non-metric term
+
+[Term]
+id: MS:4000084
+name: 4th PC 
+def: Data from the fourth principal component of a PCA. [] 
+relationship: has_value_concept NCIT:C60694 ! Principal Component 
+is_a: MS:4000080 ! QC non-metric term
+
+[Term]
+id: MS:4000085
+name: 5th PC 
+def: Data from the fifth principal component of a PCA. [] 
+relationship: has_value_concept NCIT:C60694 ! Principal Component 
+is_a: MS:4000080 ! QC non-metric term
+
+[Term]
+id: MS:4000086
+name: mzQC input reference 
+def: Used to refer to data elements of input sections in mzQC, either inputFile names or metadata labels. [] 
+is_a: MS:4000080 ! QC non-metric term
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+
+[Term]
+id: MS:4000087
+name: mzQC plot label 
+def: Used to supply alternative labels for plotting figures. [] 
+is_a: MS:4000080 ! QC non-metric term
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+
+[Term]
+id: MS:4000088
+name: batch label
+def: Used to supply batch label information with any string value. []
+is_a: MS:4000080 ! QC non-metric term
+relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+	
+[Term]
+id: MS:4000089
+name: injection sequence label
+def: Used to supply injection sequence information with consecutive whole numbers. []
+is_a: MS:4000080 ! QC non-metric term
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
+
+[Term]
+id: MS:4000090
+name: PCA of MaxQuant's protein group raw intensities
+def: A table with the PCA results of MaxQuant's protein group raw intensities. []
+is_a: MS:4000005 ! table
+relationship: has_metric_category MS:4000008 ! ID based metric
+relationship: has_metric_category MS:4000021 ! MS1 metric
+relationship: has_metric_category MS:4000013 ! multiple runs based metric
+relationship: has_column MS:4000081 ! 1st PC
+relationship: has_column MS:4000086 ! mzQC input reference 
+relationship: has_optional_column MS:4000082 ! 2nd PC 
+relationship: has_optional_column MS:4000083 ! 3rd PC 
+relationship: has_optional_column MS:4000084 ! 4th PC 
+relationship: has_optional_column MS:4000085 ! 5th PC 
+relationship: has_optional_column MS:4000087 ! mzQC plot label 
+relationship: has_optional_column MS:4000088 ! batch label 
+relationship: has_optional_column MS:4000089 ! injection sequence label
+
+[Term]
+id: MS:4000091
+name: PCA of MaxQuant's protein group lfq intensities
+def: A table with the PCA results of MaxQuant's protein group lfq intensities. []
+is_a: MS:4000005 ! table
+relationship: has_metric_category MS:4000008 ! ID based metric
+relationship: has_metric_category MS:4000021 ! MS1 metric
+relationship: has_metric_category MS:4000013 ! multiple runs based metric
+relationship: has_column MS:4000081 ! 1st PC
+relationship: has_column MS:4000086 ! mzQC input reference 
+relationship: has_optional_column MS:4000082 ! 2nd PC 
+relationship: has_optional_column MS:4000083 ! 3rd PC 
+relationship: has_optional_column MS:4000084 ! 4th PC 
+relationship: has_optional_column MS:4000085 ! 5th PC 
+relationship: has_optional_column MS:40000xx ! mzQC input reference 
+relationship: has_optional_column MS:4000087 ! mzQC plot label 
+relationship: has_optional_column MS:4000088 ! batch label 
+relationship: has_optional_column MS:4000089 ! injection sequence label
+
+[Term]
+id: MS:4000092
+name: identified MS1 feature area PCA result
+def: A table with the PCA results of identified MS1 feature areas. []
+is_a: MS:4000005 ! table
+relationship: has_metric_category MS:4000008 ! ID based metric
+relationship: has_metric_category MS:4000021 ! MS1 metric
+relationship: has_metric_category MS:4000013 ! multiple runs based metric
+relationship: has_column MS:4000081 ! 1st PC
+relationship: has_column MS:4000086 ! mzQC input reference 
+relationship: has_optional_column MS:4000082 ! 2nd PC 
+relationship: has_optional_column MS:4000083 ! 3rd PC 
+relationship: has_optional_column MS:4000084 ! 4th PC 
+relationship: has_optional_column MS:4000085 ! 5th PC 
+relationship: has_optional_column MS:4000087 ! mzQC plot label 
+relationship: has_optional_column MS:4000088 ! batch label 
+relationship: has_optional_column MS:4000089 ! injection sequence label
+
+[Term]
+id: MS:4000093
+name: unidentified MS1 feature area PCA result
+def: A table with the PCA results of unidentified but multiple-run-matched MS1 feature areas. []
+is_a: MS:4000005 ! table
+relationship: has_metric_category MS:4000008 ! ID based metric
+relationship: has_metric_category MS:4000021 ! MS1 metric
+relationship: has_metric_category MS:4000013 ! multiple runs based metric
+relationship: has_column MS:4000081 ! 1st PC
+relationship: has_column MS:4000086 ! mzQC input reference 
+relationship: has_optional_column MS:4000082 ! 2nd PC 
+relationship: has_optional_column MS:4000083 ! 3rd PC 
+relationship: has_optional_column MS:4000084 ! 4th PC 
+relationship: has_optional_column MS:4000085 ! 5th PC 
+relationship: has_optional_column MS:4000087 ! mzQC plot label 
+relationship: has_optional_column MS:4000088 ! batch label 
+relationship: has_optional_column MS:4000089 ! injection sequence label
+
+[Term]
+id: MS:4000094
+name: batch-corrected identified MS1 feature area PCA result
+def: A table with the PCA results of identified MS1 feature areas after batch-correction. []
+is_a: MS:4000005 ! table
+relationship: has_metric_category MS:4000008 ! ID based metric
+relationship: has_metric_category MS:4000021 ! MS1 metric
+relationship: has_metric_category MS:4000013 ! multiple runs based metric
+relationship: has_column MS:4000081 ! 1st PC
+relationship: has_column MS:4000086 ! mzQC input reference 
+relationship: has_optional_column MS:4000082 ! 2nd PC 
+relationship: has_optional_column MS:4000083 ! 3rd PC 
+relationship: has_optional_column MS:4000084 ! 4th PC 
+relationship: has_optional_column MS:4000085 ! 5th PC 
+relationship: has_optional_column MS:4000087 ! mzQC plot label 
+relationship: has_optional_column MS:4000088 ! batch label 
+relationship: has_optional_column MS:4000089 ! injection sequence label
+
+[Term]
 id: PEFF:0000001
 name: PEFF CV term
 def: "PSI Extended FASTA Format controlled vocabulary term." [PSI:PEFF]

--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -23031,7 +23031,7 @@ synonym: "PCA of MQ protein group raw intensities" EXACT [http://coxdocs.org/dok
 [Term]
 id: MS:4000091
 name: principal component analysis of MaxQuant's protein group lfq intensities
-def: A table with the PCA results of MaxQuant's protein group lfq intensities. []
+def: "A table with the PCA results of MaxQuant's protein group lfq intensities." [PSI:MS]
 is_a: MS:4000005 ! table
 relationship: has_metric_category MS:4000008 ! ID based metric
 relationship: has_metric_category MS:4000021 ! MS1 metric
@@ -23047,7 +23047,7 @@ synonym: "PCA of MQ protein group lfq intensities" EXACT [http://coxdocs.org/dok
 [Term]
 id: MS:4000092
 name: identified MS1 feature area principal component analysis result
-def: A table with the PCA results of identified MS1 feature areas. []
+def: "A table with the PCA results of identified MS1 feature areas." [PSI:MS]
 is_a: MS:4000005 ! table
 relationship: has_metric_category MS:4000008 ! ID based metric
 relationship: has_metric_category MS:4000021 ! MS1 metric
@@ -23065,7 +23065,7 @@ relationship: has_optional_column MS:4000089 ! injection sequence label
 [Term]
 id: MS:4000093
 name: unidentified MS1 feature area principal component analysis result
-def: A table with the PCA results of unidentified but multiple-run-matched MS1 feature areas. []
+def: "A table with the PCA results of unidentified but multiple-run-matched MS1 feature areas." [PSI:MS]
 is_a: MS:4000005 ! table
 relationship: has_metric_category MS:4000008 ! ID based metric
 relationship: has_metric_category MS:4000021 ! MS1 metric
@@ -23083,7 +23083,7 @@ relationship: has_optional_column MS:4000089 ! injection sequence label
 [Term]
 id: MS:4000094
 name: batch-corrected identified MS1 feature area principal component analysis result
-def: A table with the PCA results of identified MS1 feature areas after batch-correction. []
+def: "A table with the PCA results of identified MS1 feature areas after batch-correction." [PSI:MS]
 is_a: MS:4000005 ! table
 relationship: has_metric_category MS:4000008 ! ID based metric
 relationship: has_metric_category MS:4000021 ! MS1 metric

--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -168,6 +168,24 @@ def: "An organizational header for concepts representing mostly abstract entitie
 synonym: "Conceptual Entity" EXACT [] {http://purl.obolibrary.org/obo/NCIT_P383="PT", http://purl.obolibrary.org/obo/NCIT_P384="NCI"}
 
 [Term]
+id: NCIT:C16847
+name: Technique
+def: "A practiced and regimented skill or series of actions." [] {http://purl.obolibrary.org/obo/NCIT_C16847="NCI"}
+is_a: NCIT:C43431 ! Activity
+	
+[Term]
+id: NCIT:C19044
+name: Statistical Technique
+def: "A method of analyzing or representing statistical data; a procedure for calculating a statistic." [] {http://purl.obolibrary.org/obo/NCIT_C19044="NCI"}
+is_a: NCIT:C16847 ! Technique
+
+[Term]
+id: NCIT:C60694
+name: Principal Component 
+def: "One of the axes representing the projection of varience resulting from principal component analysis." [] {http://purl.obolibrary.org/obo/NCIT_C60694="NCI"}
+is_a: NCIT:C19044 ! Statistical Technique
+
+[Term]
 id: MS:0000000
 name: Proteomics Standards Initiative Mass Spectrometry Vocabularies
 def: "Proteomics Standards Initiative Mass Spectrometry Vocabularies." [PSI:MS]

--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -1,7 +1,7 @@
 format-version: 1.2
-data-version: 4.1.83
-date: 12:04:2022 12:51
-saved-by: Eric Deutsch
+data-version: 4.1.87
+date: 02:05:2022 11:44
+saved-by: Mathias Walzer
 auto-generated-by: OBO-Edit 2.3.1
 import: http://purl.obolibrary.org/obo/pato.obo
 import: http://purl.obolibrary.org/obo/uo.obo
@@ -23015,7 +23015,7 @@ relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 [Term]
 id: MS:4000090
 name: principal component analysis of MaxQuant's protein group raw intensities
-def: "A table with the PCA results of MaxQuant's protein group raw intensities." [PSI:MS]
+def: "A table with the PCA results of MaxQuant's protein group raw intensities." [PSI:MS] {http://coxdocs.org/doku.php?id=maxquant:table:directory&s[]=output}
 is_a: MS:4000005 ! table
 relationship: has_metric_category MS:4000008 ! ID based metric
 relationship: has_metric_category MS:4000021 ! MS1 metric
@@ -23026,12 +23026,11 @@ relationship: has_optional_column MS:4000082 ! second principal component
 relationship: has_optional_column MS:4000083 ! third principal component 
 relationship: has_optional_column MS:4000084 ! fourth principal component 
 relationship: has_optional_column MS:4000085 ! fifth principal component 
-synonym: "PCA of MQ protein group raw intensities" EXACT [] {'http://coxdocs.org/doku.php?id=maxquant:table:directory&s[]=output'}
 
 [Term]
 id: MS:4000091
 name: principal component analysis of MaxQuant's protein group lfq intensities
-def: "A table with the PCA results of MaxQuant's protein group lfq intensities." [PSI:MS]
+def: "A table with the PCA results of MaxQuant's protein group lfq intensities." [PSI:MS] {http://coxdocs.org/doku.php?id=maxquant:table:directory&s[]=output}
 is_a: MS:4000005 ! table
 relationship: has_metric_category MS:4000008 ! ID based metric
 relationship: has_metric_category MS:4000021 ! MS1 metric
@@ -23042,7 +23041,6 @@ relationship: has_optional_column MS:4000082 ! second principal component
 relationship: has_optional_column MS:4000083 ! third principal component 
 relationship: has_optional_column MS:4000084 ! fourth principal component 
 relationship: has_optional_column MS:4000085 ! fifth principal component 
-synonym: "PCA of MQ protein group lfq intensities" EXACT [] {'http://coxdocs.org/doku.php?id=maxquant:table:directory&s[]=output'}
 
 [Term]
 id: MS:4000092

--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -23026,7 +23026,7 @@ relationship: has_optional_column MS:4000082 ! second principal component
 relationship: has_optional_column MS:4000083 ! third principal component 
 relationship: has_optional_column MS:4000084 ! fourth principal component 
 relationship: has_optional_column MS:4000085 ! fifth principal component 
-synonym: "PCA of MQ protein group raw intensities" EXACT [http://coxdocs.org/doku.php?id=maxquant:table:directory&s[]=output]
+synonym: "PCA of MQ protein group raw intensities" EXACT [] {http://coxdocs.org/doku.php?id=maxquant:table:directory&s[]=output}
 
 [Term]
 id: MS:4000091
@@ -23042,7 +23042,7 @@ relationship: has_optional_column MS:4000082 ! second principal component
 relationship: has_optional_column MS:4000083 ! third principal component 
 relationship: has_optional_column MS:4000084 ! fourth principal component 
 relationship: has_optional_column MS:4000085 ! fifth principal component 
-synonym: "PCA of MQ protein group lfq intensities" EXACT [http://coxdocs.org/doku.php?id=maxquant:table:directory&s[]=output]
+synonym: "PCA of MQ protein group lfq intensities" EXACT [] {http://coxdocs.org/doku.php?id=maxquant:table:directory&s[]=output}
 
 [Term]
 id: MS:4000092

--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -22946,154 +22946,154 @@ relationship: part_of MS:4000000 ! PSI-MS CV Quality Control Vocabulary
 
 [Term]
 id: MS:4000081
-name: 1st PC 
-def: Data from the first principal component of a PCA. [] 
+name: first principal component 
+def: "Data from the first principal component of a PCA." [PSI:MS] 
 relationship: has_value_concept NCIT:C60694 ! Principal Component 
 is_a: MS:4000080 ! QC non-metric term
+synonym: "1st PC" EXACT [] 
 
 [Term]
 id: MS:4000082
-name: 2nd PC 
-def: Data from the second principal component of a PCA. [] 
+name: second principal component 
+def: "Data from the second principal component of a PCA." [PSI:MS] 
 relationship: has_value_concept NCIT:C60694 ! Principal Component 
 is_a: MS:4000080 ! QC non-metric term
+synonym: "2nd PC" EXACT [] 
 
 [Term]
 id: MS:4000083
-name: 3rd PC 
-def: Data from the third principal component of a PCA. [] 
+name: third principal component 
+def: "Data from the third principal component of a PCA." [PSI:MS] 
 relationship: has_value_concept NCIT:C60694 ! Principal Component 
 is_a: MS:4000080 ! QC non-metric term
+synonym: "3rd PC" EXACT [] 
 
 [Term]
 id: MS:4000084
-name: 4th PC 
-def: Data from the fourth principal component of a PCA. [] 
+name: fourth principal component 
+def: "Data from the fourth principal component of a PCA." [PSI:MS] 
 relationship: has_value_concept NCIT:C60694 ! Principal Component 
 is_a: MS:4000080 ! QC non-metric term
+synonym: "4th PC" EXACT [] 
 
 [Term]
 id: MS:4000085
-name: 5th PC 
-def: Data from the fifth principal component of a PCA. [] 
+name: fifth principal component 
+def: "Data from the fifth principal component of a PCA." [PSI:MS] 
 relationship: has_value_concept NCIT:C60694 ! Principal Component 
 is_a: MS:4000080 ! QC non-metric term
+synonym: "5th PC" EXACT [] 
 
 [Term]
 id: MS:4000086
 name: mzQC input reference 
-def: Used to refer to data elements of input sections in mzQC, either inputFile names or metadata labels. [] 
+def: "Used to refer to data elements of input sections in mzQC, either inputFile names or metadata labels." [PSI:MS] 
 is_a: MS:4000080 ! QC non-metric term
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:4000087
 name: mzQC plot label 
-def: Used to supply alternative labels for plotting figures. [] 
+def: "Used to supply alternative labels for plotting figures." [PSI:MS] 
 is_a: MS:4000080 ! QC non-metric term
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:4000088
 name: batch label
-def: Used to supply batch label information with any string value. []
+def: "Used to supply batch label information with any string value." [PSI:MS]
 is_a: MS:4000080 ! QC non-metric term
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 	
 [Term]
 id: MS:4000089
 name: injection sequence label
-def: Used to supply injection sequence information with consecutive whole numbers. []
+def: "Used to supply injection sequence information with consecutive whole numbers." [PSI:MS]
 is_a: MS:4000080 ! QC non-metric term
 relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:4000090
-name: PCA of MaxQuant's protein group raw intensities
-def: A table with the PCA results of MaxQuant's protein group raw intensities. []
+name: principal component analysis of MaxQuant's protein group raw intensities
+def: "A table with the PCA results of MaxQuant's protein group raw intensities." [PSI:MS]
 is_a: MS:4000005 ! table
 relationship: has_metric_category MS:4000008 ! ID based metric
 relationship: has_metric_category MS:4000021 ! MS1 metric
 relationship: has_metric_category MS:4000013 ! multiple runs based metric
-relationship: has_column MS:4000081 ! 1st PC
+relationship: has_column MS:4000081 ! first principal component
 relationship: has_column MS:4000086 ! mzQC input reference 
-relationship: has_optional_column MS:4000082 ! 2nd PC 
-relationship: has_optional_column MS:4000083 ! 3rd PC 
-relationship: has_optional_column MS:4000084 ! 4th PC 
-relationship: has_optional_column MS:4000085 ! 5th PC 
-relationship: has_optional_column MS:4000087 ! mzQC plot label 
-relationship: has_optional_column MS:4000088 ! batch label 
-relationship: has_optional_column MS:4000089 ! injection sequence label
+relationship: has_optional_column MS:4000082 ! second principal component 
+relationship: has_optional_column MS:4000083 ! third principal component 
+relationship: has_optional_column MS:4000084 ! fourth principal component 
+relationship: has_optional_column MS:4000085 ! fifth principal component 
+synonym: "PCA of MQ protein group raw intensities" EXACT [http://coxdocs.org/doku.php?id=maxquant:table:directory&s[]=output]
 
 [Term]
 id: MS:4000091
-name: PCA of MaxQuant's protein group lfq intensities
+name: principal component analysis of MaxQuant's protein group lfq intensities
 def: A table with the PCA results of MaxQuant's protein group lfq intensities. []
 is_a: MS:4000005 ! table
 relationship: has_metric_category MS:4000008 ! ID based metric
 relationship: has_metric_category MS:4000021 ! MS1 metric
 relationship: has_metric_category MS:4000013 ! multiple runs based metric
-relationship: has_column MS:4000081 ! 1st PC
+relationship: has_column MS:4000081 ! first principal component
 relationship: has_column MS:4000086 ! mzQC input reference 
-relationship: has_optional_column MS:4000082 ! 2nd PC 
-relationship: has_optional_column MS:4000083 ! 3rd PC 
-relationship: has_optional_column MS:4000084 ! 4th PC 
-relationship: has_optional_column MS:4000085 ! 5th PC 
-relationship: has_optional_column MS:4000086 ! mzQC input reference 
-relationship: has_optional_column MS:4000087 ! mzQC plot label 
-relationship: has_optional_column MS:4000088 ! batch label 
-relationship: has_optional_column MS:4000089 ! injection sequence label
+relationship: has_optional_column MS:4000082 ! second principal component 
+relationship: has_optional_column MS:4000083 ! third principal component 
+relationship: has_optional_column MS:4000084 ! fourth principal component 
+relationship: has_optional_column MS:4000085 ! fifth principal component 
+synonym: "PCA of MQ protein group lfq intensities" EXACT [http://coxdocs.org/doku.php?id=maxquant:table:directory&s[]=output]
 
 [Term]
 id: MS:4000092
-name: identified MS1 feature area PCA result
+name: identified MS1 feature area principal component analysis result
 def: A table with the PCA results of identified MS1 feature areas. []
 is_a: MS:4000005 ! table
 relationship: has_metric_category MS:4000008 ! ID based metric
 relationship: has_metric_category MS:4000021 ! MS1 metric
 relationship: has_metric_category MS:4000013 ! multiple runs based metric
-relationship: has_column MS:4000081 ! 1st PC
+relationship: has_column MS:4000081 ! first principal component
 relationship: has_column MS:4000086 ! mzQC input reference 
-relationship: has_optional_column MS:4000082 ! 2nd PC 
-relationship: has_optional_column MS:4000083 ! 3rd PC 
-relationship: has_optional_column MS:4000084 ! 4th PC 
-relationship: has_optional_column MS:4000085 ! 5th PC 
+relationship: has_optional_column MS:4000082 ! second principal component 
+relationship: has_optional_column MS:4000083 ! third principal component 
+relationship: has_optional_column MS:4000084 ! fourth principal component 
+relationship: has_optional_column MS:4000085 ! fifth principal component 
 relationship: has_optional_column MS:4000087 ! mzQC plot label 
 relationship: has_optional_column MS:4000088 ! batch label 
 relationship: has_optional_column MS:4000089 ! injection sequence label
 
 [Term]
 id: MS:4000093
-name: unidentified MS1 feature area PCA result
+name: unidentified MS1 feature area principal component analysis result
 def: A table with the PCA results of unidentified but multiple-run-matched MS1 feature areas. []
 is_a: MS:4000005 ! table
 relationship: has_metric_category MS:4000008 ! ID based metric
 relationship: has_metric_category MS:4000021 ! MS1 metric
 relationship: has_metric_category MS:4000013 ! multiple runs based metric
-relationship: has_column MS:4000081 ! 1st PC
+relationship: has_column MS:4000081 ! first principal component
 relationship: has_column MS:4000086 ! mzQC input reference 
-relationship: has_optional_column MS:4000082 ! 2nd PC 
-relationship: has_optional_column MS:4000083 ! 3rd PC 
-relationship: has_optional_column MS:4000084 ! 4th PC 
-relationship: has_optional_column MS:4000085 ! 5th PC 
+relationship: has_optional_column MS:4000082 ! second principal component 
+relationship: has_optional_column MS:4000083 ! third principal component 
+relationship: has_optional_column MS:4000084 ! fourth principal component 
+relationship: has_optional_column MS:4000085 ! fifth principal component 
 relationship: has_optional_column MS:4000087 ! mzQC plot label 
 relationship: has_optional_column MS:4000088 ! batch label 
 relationship: has_optional_column MS:4000089 ! injection sequence label
 
 [Term]
 id: MS:4000094
-name: batch-corrected identified MS1 feature area PCA result
+name: batch-corrected identified MS1 feature area principal component analysis result
 def: A table with the PCA results of identified MS1 feature areas after batch-correction. []
 is_a: MS:4000005 ! table
 relationship: has_metric_category MS:4000008 ! ID based metric
 relationship: has_metric_category MS:4000021 ! MS1 metric
 relationship: has_metric_category MS:4000013 ! multiple runs based metric
-relationship: has_column MS:4000081 ! 1st PC
+relationship: has_column MS:4000081 ! first principal component
 relationship: has_column MS:4000086 ! mzQC input reference 
-relationship: has_optional_column MS:4000082 ! 2nd PC 
-relationship: has_optional_column MS:4000083 ! 3rd PC 
-relationship: has_optional_column MS:4000084 ! 4th PC 
-relationship: has_optional_column MS:4000085 ! 5th PC 
+relationship: has_optional_column MS:4000082 ! second principal component 
+relationship: has_optional_column MS:4000083 ! third principal component 
+relationship: has_optional_column MS:4000084 ! fourth principal component 
+relationship: has_optional_column MS:4000085 ! fifth principal component 
 relationship: has_optional_column MS:4000087 ! mzQC plot label 
 relationship: has_optional_column MS:4000088 ! batch label 
 relationship: has_optional_column MS:4000089 ! injection sequence label

--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -23150,7 +23150,7 @@ relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 [Term]
 id: MS:4000090
 name: principal component analysis of MaxQuant's protein group raw intensities
-def: "A table with the PCA results of MaxQuant's protein group raw intensities." [PSI:MS] {http://coxdocs.org/doku.php?id=maxquant:table:directory&s[]=output}
+def: "A table with the PCA results of MaxQuant's protein group raw intensities." [PSI:MS] {http://coxdocs.org/doku.php?id="maxquant:table:directory&s[]=output"}
 is_a: MS:4000005 ! table
 relationship: has_metric_category MS:4000008 ! ID based metric
 relationship: has_metric_category MS:4000021 ! MS1 metric
@@ -23165,7 +23165,7 @@ relationship: has_optional_column MS:4000085 ! fifth principal component
 [Term]
 id: MS:4000091
 name: principal component analysis of MaxQuant's protein group lfq intensities
-def: "A table with the PCA results of MaxQuant's protein group lfq intensities." [PSI:MS] {http://coxdocs.org/doku.php?id=maxquant:table:directory&s[]=output}
+def: "A table with the PCA results of MaxQuant's protein group lfq intensities." [PSI:MS] {http://coxdocs.org/doku.php?id="maxquant:table:directory&s[]=output"}
 is_a: MS:4000005 ! table
 relationship: has_metric_category MS:4000008 ! ID based metric
 relationship: has_metric_category MS:4000021 ! MS1 metric

--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -23026,7 +23026,7 @@ relationship: has_optional_column MS:4000082 ! second principal component
 relationship: has_optional_column MS:4000083 ! third principal component 
 relationship: has_optional_column MS:4000084 ! fourth principal component 
 relationship: has_optional_column MS:4000085 ! fifth principal component 
-synonym: "PCA of MQ protein group raw intensities" EXACT [] {http://coxdocs.org/doku.php?id=maxquant:table:directory&s[]=output}
+synonym: "PCA of MQ protein group raw intensities" EXACT [] {'http://coxdocs.org/doku.php?id=maxquant:table:directory&s[]=output'}
 
 [Term]
 id: MS:4000091
@@ -23042,7 +23042,7 @@ relationship: has_optional_column MS:4000082 ! second principal component
 relationship: has_optional_column MS:4000083 ! third principal component 
 relationship: has_optional_column MS:4000084 ! fourth principal component 
 relationship: has_optional_column MS:4000085 ! fifth principal component 
-synonym: "PCA of MQ protein group lfq intensities" EXACT [] {http://coxdocs.org/doku.php?id=maxquant:table:directory&s[]=output}
+synonym: "PCA of MQ protein group lfq intensities" EXACT [] {'http://coxdocs.org/doku.php?id=maxquant:table:directory&s[]=output'}
 
 [Term]
 id: MS:4000092

--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -23021,7 +23021,7 @@ relationship: has_optional_column MS:4000082 ! 2nd PC
 relationship: has_optional_column MS:4000083 ! 3rd PC 
 relationship: has_optional_column MS:4000084 ! 4th PC 
 relationship: has_optional_column MS:4000085 ! 5th PC 
-relationship: has_optional_column MS:40000xx ! mzQC input reference 
+relationship: has_optional_column MS:4000086 ! mzQC input reference 
 relationship: has_optional_column MS:4000087 ! mzQC plot label 
 relationship: has_optional_column MS:4000088 ! batch label 
 relationship: has_optional_column MS:4000089 ! injection sequence label


### PR DESCRIPTION
This PR adds QC metrics for 'set-use' (involving more than one MS run), with PCA of XIC/MS1-features/precursor-intensities and/or MaxQuant analysis results 