### PR TITLE
Remove xref: value-type lines

### DIFF
--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -1,5 +1,5 @@
 format-version: 1.2
-data-version: 4.1.90
+data-version: 4.1.91
 date: 02:05:2022 11:44
 saved-by: Joshua Klein
 auto-generated-by: OBO-Edit 2.3.1
@@ -194,7 +194,6 @@ def: "Proteomics Standards Initiative Mass Spectrometry Vocabularies." [PSI:MS]
 id: MS:1000001
 name: sample number
 def: "A reference number relevant to the sample under study." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000548 ! sample attribute
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -202,7 +201,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1000002
 name: sample name
 def: "A reference string relevant to the sample under study." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000548 ! sample attribute
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -216,7 +214,6 @@ is_a: MS:1000548 ! sample attribute
 id: MS:1000004
 name: sample mass
 def: "Total mass of sample used." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000548 ! sample attribute
 relationship: has_units UO:0000021 ! gram
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
@@ -225,7 +222,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1000005
 name: sample volume
 def: "Total volume of solution used." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000548 ! sample attribute
 relationship: has_units UO:0000098 ! milliliter
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
@@ -234,7 +230,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1000006
 name: sample concentration
 def: "Concentration of sample in picomol/ul, femtomol/ul or attomol/ul solution used." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000548 ! sample attribute
 relationship: has_units UO:0000175 ! gram per liter
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
@@ -269,7 +264,6 @@ is_obsolete: true
 id: MS:1000011
 name: mass resolution
 def: "Smallest mass difference between two equal magnitude peaks so that the valley between them is a specified fraction of the peak height." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000503 ! scan attribute
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -290,7 +284,6 @@ is_obsolete: true
 id: MS:1000014
 name: accuracy
 def: "Accuracy is the degree of conformity of a measured mass to its actual value." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000480 ! mass analyzer attribute
 relationship: has_units MS:1000040 ! m/z
 relationship: has_units UO:0000169 ! parts per million
@@ -300,7 +293,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1000015
 name: scan rate
 def: "Rate in Th/sec for scanning analyzers." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000503 ! scan attribute
 relationship: has_units MS:1000807 ! Th/s
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
@@ -309,7 +301,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1000016
 name: scan start time
 def: "The time that an analyzer started a scan, relative to the start of the MS run." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000503 ! scan attribute
 is_a: MS:1002345 ! PSM-level attribute
 relationship: has_units UO:0000010 ! second
@@ -353,7 +344,6 @@ is_a: MS:1000480 ! mass analyzer attribute
 id: MS:1000022
 name: TOF Total Path Length
 def: "The length of the field free drift space in a time of flight mass spectrometer." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000480 ! mass analyzer attribute
 relationship: has_units UO:0000008 ! meter
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
@@ -363,7 +353,6 @@ id: MS:1000023
 name: isolation width
 def: "OBSOLETE The total width (i.e. not half for plus-or-minus) of the gate applied around a selected precursor ion." [PSI:MS]
 comment: This former purgatory term was made obsolete.
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 relationship: has_units MS:1000040 ! m/z
 is_obsolete: true
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
@@ -372,7 +361,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1000024
 name: final MS exponent
 def: "Final MS level achieved when performing PFF with the ion trap (e.g. MS E10)." [PSI:MS]
-xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1000480 ! mass analyzer attribute
 relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
@@ -382,7 +370,6 @@ name: magnetic field strength
 def: "A property of space that produces a force on a charged particle equal to qv x B where q is the particle charge and v its velocity." [PSI:MS]
 synonym: "B" EXACT []
 synonym: "Magnetic Field" RELATED []
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000480 ! mass analyzer attribute
 relationship: has_units UO:0000228 ! tesla
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
@@ -403,7 +390,6 @@ relationship: part_of MS:1000453 ! detector
 id: MS:1000028
 name: detector resolution
 def: "The resolving power of the detector to detect the smallest difference between two ions so that the valley between them is a specified fraction of the peak height." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000481 ! detector attribute
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
@@ -412,7 +398,6 @@ id: MS:1000029
 name: sampling frequency
 def: "The rate of signal sampling (measurement) with respect to time." [PSI:MS]
 synonym: "ADC Sampling Frequency" NARROW []
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000481 ! detector attribute
 relationship: has_units UO:0000106 ! hertz
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
@@ -434,7 +419,6 @@ relationship: part_of MS:1000463 ! instrument
 id: MS:1000032
 name: customization
 def: "Free text description of a single customization made to the instrument; for several modifications, use several entries." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000496 ! instrument attribute
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -498,7 +482,6 @@ id: MS:1000041
 name: charge state
 def: "Number of net charges, positive or negative, on an ion." [PSI:MS]
 synonym: "z" EXACT []
-xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1000455 ! ion selection attribute
 is_a: MS:1000507 ! ion property
 relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
@@ -507,7 +490,6 @@ relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 id: MS:1000042
 name: peak intensity
 def: "Intensity of ions as measured by the height or area of a peak in a mass spectrum." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000455 ! ion selection attribute
 relationship: has_units MS:1000131 ! number of detector counts
 relationship: has_units MS:1000132 ! percent of base peak
@@ -534,7 +516,6 @@ relationship: part_of MS:1000456 ! precursor activation
 id: MS:1000045
 name: collision energy
 def: "Energy for an ion experiencing collision with a stationary gas particle resulting in dissociation of the ion." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000510 ! precursor activation attribute
 relationship: has_units UO:0000266 ! electronvolt
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
@@ -587,7 +568,6 @@ is_a: MS:1000003 ! sample state
 id: MS:1000053
 name: sample batch
 def: "Sample batch lot identifier." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000548 ! sample attribute
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -1109,7 +1089,6 @@ is_a: MS:1000043 ! intensity unit
 id: MS:1000132
 name: percent of base peak
 def: "The magnitude of a peak or measurement element expressed in terms of the percentage of the magnitude of the base peak intensity." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000043 ! intensity unit
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
@@ -1154,7 +1133,6 @@ is_obsolete: true
 id: MS:1000138
 name: normalized collision energy
 def: "Instrument setting, expressed in percent, for adjusting collisional energies of ions in an effort to provide equivalent excitation of all ions." [PSI:PI]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000510 ! precursor activation attribute
 relationship: has_units UO:0000187 ! percent
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
@@ -1580,7 +1558,6 @@ is_a: MS:1003213 ! mass spectrometry acquisition method
 id: MS:1000207
 name: accurate mass
 def: "OBSOLETE An experimentally determined mass that is can be to determine a unique elemental formula. For ions less than 200 u, a measurement with 5 ppm accuracy is sufficient to determine the elemental composition." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 comment: This child of the former purgatory term ion attribute was made obsolete.
 relationship: has_units UO:0000002 ! mass unit
 is_obsolete: true
@@ -1590,7 +1567,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1000208
 name: average mass
 def: "OBSOLETE The mass of an ion or molecule calculated using the average mass of each element weighted for its natural isotopic abundance." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 comment: This child of the former purgatory term ion attribute was made obsolete.
 relationship: has_units UO:0000002 ! mass unit
 is_obsolete: true
@@ -1601,7 +1577,6 @@ id: MS:1000209
 name: appearance energy
 def: "OBSOLETE The minimum energy that must be imparted to an atom or molecule to produce a specified ion. The term appearance potential is not recommended." [PSI:MS]
 synonym: "AE" EXACT []
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 comment: This child of the former purgatory term ion attribute was made obsolete.
 relationship: has_units UO:0000266 ! electronvolt
 is_obsolete: true
@@ -1618,7 +1593,6 @@ is_a: MS:1000231 ! peak
 id: MS:1000211
 name: OBSOLETE charge number
 def: "OBSOLETE The total charge on an ion divided by the electron charge e. OBSOLETED 2009-10-27 since this was viewed as a duplication of 00041 charge state." [PSI:MS]
-xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_obsolete: true
 relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
@@ -1635,7 +1609,6 @@ name: electron affinity
 def: "OBSOLETE The electron affinity of M is the minimum energy required for the process M- ? M + e where M- and M are in their ground rotational, vibrational and electronic states and the electron has zero kinetic energy." [PSI:MS]
 comment: This child of the former purgatory term ion attribute was made obsolete.
 synonym: "EA" EXACT []
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_obsolete: true
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
@@ -1650,7 +1623,6 @@ is_obsolete: true
 id: MS:1000215
 name: exact mass
 def: "OBSOLETE The calculated mass of an ion or molecule containing a single isotope of each atom." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 comment: This child of the former purgatory term ion attribute was made obsolete.
 relationship: has_units UO:0000002 ! mass unit
 is_obsolete: true
@@ -1675,7 +1647,6 @@ id: MS:1000218
 name: ionization efficiency
 def: "OBSOLETE The ratio of the number of ions formed to the number of electrons, molecules or photons used." [PSI:MS]
 comment: This term was made obsolete because it was replaced by ionization efficiency (MS:1000392).
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_obsolete: true
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
@@ -1685,7 +1656,6 @@ name: ionization energy
 def: "OBSOLETE The minimum energy required to remove an electron from an atom or molecule to produce a positive ion." [PSI:MS]
 synonym: "IE" EXACT []
 comment: This child of the former purgatory term ion attribute was made obsolete.
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 relationship: has_units UO:0000266 ! electronvolt
 is_obsolete: true
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
@@ -1708,7 +1678,6 @@ is_a: MS:1000597 ! ion optics type
 id: MS:1000222
 name: mass defect
 def: "OBSOLETE The difference between the monoisotopic and nominal mass of a molecule or atom." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 comment: This child of the former purgatory term ion attribute was made obsolete.
 relationship: has_units UO:0000002 ! mass unit
 is_obsolete: true
@@ -1718,7 +1687,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1000223
 name: mass number
 def: "OBSOLETE The sum of the protons and neutrons in an atom, molecule or ion." [PSI:MS]
-xref: value-type:xsd\:int "The allowed value-type for this CV term."
 comment: This child of the former purgatory term ion attribute was made obsolete.
 is_obsolete: true
 relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
@@ -1727,7 +1695,6 @@ relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 id: MS:1000224
 name: molecular mass
 def: "Mass of a molecule measured in unified atomic mass units (u or Da)." [https://en.wikipedia.org/wiki/Molecular_mass]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000861 ! molecular entity property
 relationship: has_units UO:0000002 ! mass unit
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
@@ -1736,7 +1703,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1000225
 name: monoisotopic mass
 def: "OBSOLETE The mass of an ion or molecule calculated using the mass of the most abundant isotope of each element." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 comment: This child of the former purgatory term ion attribute was made obsolete.
 relationship: has_units UO:0000002 ! mass unit
 is_obsolete: true
@@ -1768,7 +1734,6 @@ is_obsolete: true
 id: MS:1000229
 name: nominal mass
 def: "OBSOLETE The mass of an ion or molecule calculated using the mass of the most abundant isotope of each element rounded to the nearest integer value." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 comment: This child of the former purgatory term ion attribute was made obsolete.
 relationship: has_units UO:0000002 ! mass unit
 is_obsolete: true
@@ -1800,7 +1765,6 @@ name: proton affinity
 def: "OBSOLETE The proton affinity of a species M is defined as the negative of the enthalpy change for the reaction M + H+ ->[M+H]+, where all species are in their ground rotational, vibrational and electronic states." [PSI:MS]
 synonym: "PA" EXACT [PSI:MS]
 comment: This child of the former purgatory term ion attribute was made obsolete.
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_obsolete: true
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
@@ -1809,7 +1773,6 @@ id: MS:1000234
 name: mass resolving power
 def: "OBSOLETE In a mass spectrum, the observed mass divided by the difference between two masses that can be separated. The method by which delta m was obtained and the mass at which the measurement was made should be reported." [PSI:MS]
 comment: This term was made obsolete because it was replaced by mass resolving power (MS:1000800).
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_obsolete: true
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
@@ -1824,7 +1787,6 @@ is_a: MS:1000810 ! ion current chromatogram
 id: MS:1000236
 name: transmission
 def: "The ratio of the number of ions leaving a region of a mass spectrometer to the number entering that region." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000496 ! instrument attribute
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
@@ -2191,7 +2153,6 @@ id: MS:1000285
 name: total ion current
 def: "The sum of all the separate ion currents carried by the ions of different m/z contributing to a complete mass spectrum or in a specified m/z range of a mass spectrum." [PSI:MS]
 synonym: "TIC" EXACT []
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1003058 ! spectrum property
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
@@ -2324,7 +2285,6 @@ is_obsolete: true
 id: MS:1000304
 name: accelerating voltage
 def: "The electrical potential used to impart kinetic energy to ions in a mass spectrometer." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000487 ! ion optics attribute
 relationship: has_units UO:0000218 ! volt
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
@@ -2353,7 +2313,6 @@ is_a: MS:1000597 ! ion optics type
 id: MS:1000308
 name: electric field strength
 def: "The magnitude of the force per unit charge at a given point in space." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000487 ! ion optics attribute
 relationship: has_units UO:0000268 ! volt per meter
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
@@ -2547,7 +2506,6 @@ is_obsolete: true
 id: MS:1000336
 name: neutral loss
 def: "The loss of an uncharged species during a rearrangement process. The value slot holds the molecular formula in Hill notation of the neutral loss molecule, see PMID: 21182243. This term must be used in conjunction with a child of the term MS:1002307 (fragmentation ion type)." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001055 ! modification parameters
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -2926,7 +2884,6 @@ is_obsolete: true
 id: MS:1000392
 name: ionization efficiency
 def: "The ratio of the number of ions formed to the number of electrons, molecules or photons used." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000482 ! source attribute
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
@@ -3047,7 +3004,6 @@ is_obsolete: true
 id: MS:1000412
 name: buffer gas
 def: "An inert gas used for collisional deactivation of internally excited ions." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000510 ! precursor activation attribute
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -3097,7 +3053,6 @@ is_obsolete: true
 id: MS:1000419
 name: collision gas
 def: "An inert gas used for collisional excitation. The term target gas is not recommended." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000510 ! precursor activation attribute
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -3542,7 +3497,6 @@ is_a: MS:1000057 ! electrospray inlet
 id: MS:1000486
 name: source potential
 def: "Potential difference at the MS source in volts." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000482 ! source attribute
 relationship: has_units UO:0000218 ! volt
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
@@ -3634,7 +3588,6 @@ id: MS:1000500
 name: scan window upper limit
 def: "The lower m/z bound of a mass spectrometer scan window." [PSI:MS]
 synonym: "mzRangeStop" RELATED []
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000549 ! selection window attribute
 relationship: has_units MS:1000040 ! m/z
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
@@ -3644,7 +3597,6 @@ id: MS:1000501
 name: scan window lower limit
 def: "The upper m/z bound of a mass spectrometer scan window." [PSI:MS]
 synonym: "mzRangeStart" RELATED []
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000549 ! selection window attribute
 relationship: has_units MS:1000040 ! m/z
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
@@ -3654,7 +3606,6 @@ id: MS:1000502
 name: dwell time
 def: "The time spent gathering data across a peak." [PSI:MS]
 synonym: "Scan Duration" RELATED []
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000503 ! scan attribute
 relationship: has_units UO:0000010 ! second
 relationship: has_units UO:0000031 ! minute
@@ -3671,7 +3622,6 @@ relationship: part_of MS:1000441 ! scan
 id: MS:1000504
 name: base peak m/z
 def: "M/z value of the signal of highest intensity in the mass spectrum." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1003058 ! spectrum property
 relationship: has_units MS:1000040 ! m/z
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
@@ -3680,7 +3630,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1000505
 name: base peak intensity
 def: "The intensity of the greatest peak in the mass spectrum." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1003058 ! spectrum property
 relationship: has_units MS:1000131 ! number of detector counts
 relationship: has_units MS:1000132 ! percent of base peak
@@ -3713,7 +3662,6 @@ is_obsolete: true
 id: MS:1000509
 name: activation energy
 def: "Activation Energy." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000510 ! precursor activation attribute
 relationship: has_units UO:0000266 ! electronvolt
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
@@ -3728,7 +3676,6 @@ relationship: part_of MS:1000456 ! precursor activation
 id: MS:1000511
 name: ms level
 def: "Stage number achieved in a multi stage mass spectrometry acquisition." [PSI:MS]
-xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1000499 ! spectrum attribute
 relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
@@ -3736,7 +3683,6 @@ relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 id: MS:1000512
 name: filter string
 def: "A string unique to Thermo instrument describing instrument settings for the scan." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000503 ! scan attribute
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -3844,7 +3790,6 @@ is_a: MS:1000560 ! mass spectrometer file format
 id: MS:1000527
 name: highest observed m/z
 def: "Highest m/z value observed in the m/z array." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000808 ! chromatogram attribute
 is_a: MS:1003058 ! spectrum property
 relationship: has_units MS:1000040 ! m/z
@@ -3854,7 +3799,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1000528
 name: lowest observed m/z
 def: "Lowest m/z value observed in the m/z array." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000808 ! chromatogram attribute
 is_a: MS:1003058 ! spectrum property
 relationship: has_units MS:1000040 ! m/z
@@ -3864,7 +3808,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1000529
 name: instrument serial number
 def: "Serial Number of the instrument." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000496 ! instrument attribute
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -4129,7 +4072,6 @@ is_a: MS:1000560 ! mass spectrometer file format
 id: MS:1000568
 name: MD5
 def: "MD5 (Message-Digest algorithm 5) is a (now deprecated) cryptographic hash function with a 128-bit hash value used to check the integrity of files." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000561 ! data file checksum type
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -4137,7 +4079,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1000569
 name: SHA-1
 def: "SHA-1 (Secure Hash Algorithm-1) is a cryptographic hash function designed by the National Security Agency (NSA). It is also used to verify file integrity. Since 2011 it has been deprecated by the NIST as a U. S. government standard." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000561 ! data file checksum type
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -4258,7 +4199,6 @@ relationship: part_of MS:0000000 ! Proteomics Standards Initiative Mass Spectrom
 id: MS:1000586
 name: contact name
 def: "Name of the contact person or organization." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000585 ! contact attribute
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -4266,7 +4206,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1000587
 name: contact address
 def: "Postal address of the contact person or organization." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000585 ! contact attribute
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -4274,7 +4213,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1000588
 name: contact URL
 def: "Uniform Resource Locator related to the contact person or organization." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000585 ! contact attribute
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -4282,7 +4220,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1000589
 name: contact email
 def: "Email address of the contact person or organization." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000585 ! contact attribute
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -4290,7 +4227,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1000590
 name: contact affiliation
 def: "Home institution of the contact person." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000585 ! contact attribute
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -4460,7 +4396,6 @@ is_a: MS:1001457 ! data processing software
 id: MS:1000616
 name: preset scan configuration
 def: "A user-defined scan configuration that specifies the instrumental settings in which a spectrum is acquired. An instrument may cycle through a list of preset scan configurations to acquire data. This is a more generic term for the Thermo \"scan event\", which is defined in the Thermo Xcalibur glossary as: a mass spectrometer scan that is defined by choosing the necessary scan parameter settings. Multiple scan events can be defined for each segment of time." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000503 ! scan attribute
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -4477,7 +4412,6 @@ relationship: has_units UO:0000018 ! nanometer
 id: MS:1000618
 name: highest observed wavelength
 def: "Highest wavelength observed in an EMR spectrum." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1003058 ! spectrum property
 is_a: MS:1000808 ! chromatogram attribute
 relationship: has_units UO:0000018 ! nanometer
@@ -4487,7 +4421,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1000619
 name: lowest observed wavelength
 def: "Lowest wavelength observed in an EMR spectrum." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1003058 ! spectrum property
 is_a: MS:1000808 ! chromatogram attribute
 relationship: has_units UO:0000018 ! nanometer
@@ -4557,7 +4490,6 @@ is_a: MS:1000810 ! ion current chromatogram
 id: MS:1000629
 name: low intensity threshold
 def: "Threshold below which some action is taken." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000630 ! data processing parameter
 relationship: has_units MS:1000131 ! number of detector counts
 relationship: has_units MS:1000132 ! percent of base peak
@@ -4576,7 +4508,6 @@ relationship: part_of MS:1001458 ! spectrum generation information
 id: MS:1000631
 name: high intensity threshold
 def: "Threshold above which some action is taken." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000630 ! data processing parameter
 relationship: has_units MS:1000131 ! number of detector counts
 relationship: has_units MS:1000132 ! percent of base peak
@@ -4595,7 +4526,6 @@ is_a: MS:1000126 ! Waters instrument model
 id: MS:1000633
 name: possible charge state
 def: "A possible charge state of the ion in a situation where the charge of an ion is known to be one of several possible values rather than a completely unknown value or determined to be a specific charge with reasonable certainty." [PSI:MS]
-xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1000455 ! ion selection attribute
 relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
@@ -5342,7 +5272,6 @@ is_a: MS:1000494 ! Thermo Scientific instrument model
 id: MS:1000744
 name: selected ion m/z
 def: "Mass-to-charge ratio of an selected ion." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000455 ! ion selection attribute
 relationship: has_units MS:1000040 ! m/z
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
@@ -5363,7 +5292,6 @@ is_a: MS:1001486 ! data filtering
 id: MS:1000747
 name: completion time
 def: "The time that a data processing action was finished." [PSI:MS]
-xref: value-type:xsd\:dateTime "The allowed value-type for this CV term."
 is_a: MS:1000630 ! data processing parameter
 relationship: has_value_type xsd\:dateTime ! The allowed value-type for this CV term
 
@@ -5624,7 +5552,6 @@ xref: binary-data-type:MS\:1000521 "32-bit float"
 xref: binary-data-type:MS\:1000522 "64-bit integer"
 xref: binary-data-type:MS\:1000523 "64-bit float"
 xref: binary-data-type:MS\:1001479 "null-terminated ASCII string"
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000513 ! binary data array
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -5632,7 +5559,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1000787
 name: inclusive low intensity threshold
 def: "Threshold at or below which some action is taken." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000630 ! data processing parameter
 relationship: has_units MS:1000131 ! number of detector counts
 relationship: has_units MS:1000132 ! percent of base peak
@@ -5645,7 +5571,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1000788
 name: inclusive high intensity threshold
 def: "Threshold at or above which some action is taken." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000630 ! data processing parameter
 relationship: has_units MS:1000131 ! number of detector counts
 relationship: has_units MS:1000132 ! percent of base peak
@@ -5685,7 +5610,6 @@ id: MS:1000793
 name: isolation window upper limit
 def: "OBSOLETE The highest m/z being isolated in an isolation window." [PSI:MS]
 comment: This term was obsoleted in favour of using a target, lower, upper offset scheme. See terms 1000827-1000829.
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000792 ! isolation window attribute
 relationship: has_units MS:1000040 ! m/z
 is_obsolete: true
@@ -5696,7 +5620,6 @@ id: MS:1000794
 name: isolation window lower limit
 def: "OBSOLETE The lowest m/z being isolated in an isolation window." [PSI:MS]
 comment: This term was obsoleted in favour of using a target, lower, upper offset scheme. See terms 1000827-1000829.
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000792 ! isolation window attribute
 relationship: has_units MS:1000040 ! m/z
 is_obsolete: true
@@ -5713,7 +5636,6 @@ id: MS:1000796
 name: spectrum title
 def: "Free-form text title describing a spectrum, usually a series of key value pairs as used in an MGF file." [PSI:MS]
 comment: This is the preferred storage place for the spectrum TITLE from an MGF peak list.
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001405 ! spectrum identification result details
 is_a: MS:1000499 ! spectrum attribute
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
@@ -5723,7 +5645,6 @@ id: MS:1000797
 name: peak list scans
 def: "A list of scan numbers and or scan ranges associated with a peak list. If possible the list of scans should be converted to native spectrum identifiers instead of using this term." [PSI:MS]
 comment: This is the preferred storage place for the spectrum SCANS attribute from an MGF peak list.
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001405 ! spectrum identification result details
 is_a: MS:1003058 ! spectrum property
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
@@ -5733,7 +5654,6 @@ id: MS:1000798
 name: peak list raw scans
 def: "A list of raw scans and or scan ranges used to generate a peak list. If possible the list of scans should be converted to native spectrum identifiers instead of using this term." [PSI:MS]
 comment: This is the preferred storage place for the spectrum RAWSCANS attribute from an MGF peak list.
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001405 ! spectrum identification result details
 is_a: MS:1003058 ! spectrum property
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
@@ -5742,7 +5662,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1000799
 name: custom unreleased software tool
 def: "A software tool that has not yet been released. The value should describe the software. Please do not use this term for publicly available software - contact the PSI-MS working group in order to have another CV term added." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000531 ! software
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -5750,7 +5669,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1000800
 name: mass resolving power
 def: "The observed mass divided by the difference between two masses that can be separated: m/dm. The procedure by which dm was obtained and the mass at which the measurement was made should be reported." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000503 ! scan attribute
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -5772,7 +5690,6 @@ is_a: MS:1000035 ! peak picking
 id: MS:1000803
 name: analyzer scan offset
 def: "Offset between two analyzers in a constant neutral loss or neutral gain scan. The value corresponds to the neutral loss or neutral gain value." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000503 ! scan attribute
 relationship: has_units MS:1000040 ! m/z
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
@@ -5817,7 +5734,6 @@ id: MS:1000809
 name: chromatogram title
 def: "A free-form text title describing a chromatogram." [PSI:MS]
 comment: This is the preferred storage place for the spectrum title.
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000808 ! chromatogram attribute
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -5935,7 +5851,6 @@ is_a: MS:1000560 ! mass spectrometer file format
 id: MS:1000826
 name: elution time
 def: "The time of elution from all used chromatographic columns (one or more) in the chromatographic separation step, relative to the start of the chromatography." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000503 ! scan attribute
 relationship: has_units UO:0000010 ! second
 relationship: has_units UO:0000031 ! minute
@@ -5945,7 +5860,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1000827
 name: isolation window target m/z
 def: "The primary or reference m/z about which the isolation window is defined." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000792 ! isolation window attribute
 relationship: has_units MS:1000040 ! m/z
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
@@ -5954,7 +5868,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1000828
 name: isolation window lower offset
 def: "The extent of the isolation window in m/z below the isolation window target m/z. The lower and upper offsets may be asymmetric about the target m/z." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000792 ! isolation window attribute
 relationship: has_units MS:1000040 ! m/z
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
@@ -5963,7 +5876,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1000829
 name: isolation window upper offset
 def: "The extent of the isolation window in m/z above the isolation window target m/z. The lower and upper offsets may be asymmetric about the target m/z." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000792 ! isolation window attribute
 relationship: has_units MS:1000040 ! m/z
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
@@ -5991,7 +5903,6 @@ relationship: part_of MS:1000832 ! MALDI matrix application
 id: MS:1000834
 name: matrix solution
 def: "Describes the chemical solution used as matrix." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000832 ! MALDI matrix application
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -5999,7 +5910,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1000835
 name: matrix solution concentration
 def: "Concentration of the chemical solution used as matrix." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000832 ! MALDI matrix application
 relationship: has_units UO:0000175 ! gram per liter
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
@@ -6052,7 +5962,6 @@ id: MS:1000843
 name: wavelength
 def: "OBSOLETE The distance between two peaks of the emitted laser beam." [PSI:MS]
 comment: This term was made obsolete because it was redundant with the Pato Ontology term wavelength (UO:0001242).
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000841 ! laser attribute
 relationship: has_units UO:0000018 ! nanometer
 is_obsolete: true
@@ -6062,7 +5971,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1000844
 name: focus diameter x
 def: "Describes the diameter of the laser beam in x direction." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000841 ! laser attribute
 relationship: has_units UO:0000017 ! micrometer
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
@@ -6071,7 +5979,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1000845
 name: focus diameter y
 def: "Describes the diameter of the laser beam in y direction." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000841 ! laser attribute
 relationship: has_units UO:0000017 ! micrometer
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
@@ -6080,7 +5987,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1000846
 name: pulse energy
 def: "Describes output energy of the laser system. May be attenuated by filters or other means." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000841 ! laser attribute
 relationship: has_units UO:0000112 ! joule
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
@@ -6089,7 +5995,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1000847
 name: pulse duration
 def: "Describes how long the laser beam was emitted from the laser device." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000841 ! laser attribute
 relationship: has_units UO:0000150 ! nanosecond
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
@@ -6098,7 +6003,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1000848
 name: attenuation
 def: "Describes the reduction of the intensity of the laser beam energy." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000841 ! laser attribute
 relationship: has_units UO:0000187 ! percent
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
@@ -6107,7 +6011,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1000849
 name: impact angle
 def: "Describes the angle between the laser beam and the sample target." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000841 ! laser attribute
 relationship: has_units UO:0000185 ! degree
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
@@ -6164,7 +6067,6 @@ is_a: MS:1000547 ! object attribute
 id: MS:1000858
 name: fraction identifier
 def: "Identier string that describes the sample fraction. This identifier should contain the fraction number(s) or similar information." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000857 ! run attribute
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -6191,7 +6093,6 @@ id: MS:1000862
 name: isoelectric point
 def: "The pH of a solution at which a charged molecule does not migrate in an electric field." [PSI:MS]
 synonym: "pI" EXACT []
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000861 ! molecular entity property
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
@@ -6200,7 +6101,6 @@ id: MS:1000863
 name: predicted isoelectric point
 def: "The pH of a solution at which a charged molecule would not migrate in an electric field, as predicted by a software algorithm." [PSI:MS]
 synonym: "predicted pI" EXACT []
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000862 ! isoelectric point
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
@@ -6214,7 +6114,6 @@ is_a: MS:1003033 ! molecular entity attribute
 id: MS:1000865
 name: empirical formula
 def: "A chemical formula which expresses the proportions of the elements present in a substance." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000864 ! chemical formula
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -6222,7 +6121,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1000866
 name: molecular formula
 def: "A chemical compound formula expressing the number of atoms of each element present in a compound, without indicating how they are linked." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000864 ! chemical formula
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -6230,7 +6128,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1000867
 name: structural formula
 def: "A chemical formula showing the number of atoms of each element in a molecule, their spatial arrangement, and their linkage to each other." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000864 ! chemical formula
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -6238,7 +6135,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1000868
 name: SMILES formula
 def: "The simplified molecular input line entry specification or SMILES is a specification for unambiguously describing the structure of a chemical compound using a short ASCII string." [EDAM:2301]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000864 ! chemical formula
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -6246,7 +6142,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1000869
 name: collision gas pressure
 def: "The gas pressure of the collision gas used for collisional excitation." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000510 ! precursor activation attribute
 relationship: has_units UO:0000110 ! pascal
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
@@ -6287,7 +6182,6 @@ is_a: MS:1000873 ! peptide attribute calculation software
 id: MS:1000875
 name: declustering potential
 def: "Potential difference between the orifice and the skimmer in volts." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000482 ! source attribute
 relationship: has_units UO:0000218 ! volt
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
@@ -6296,7 +6190,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1000876
 name: cone voltage
 def: "Potential difference between the sampling cone/orifice in volts." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000482 ! source attribute
 relationship: has_units UO:0000218 ! volt
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
@@ -6305,7 +6198,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1000877
 name: tube lens voltage
 def: "Potential difference setting of the tube lens in volts." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000482 ! source attribute
 relationship: has_units UO:0000218 ! volt
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
@@ -6320,7 +6212,6 @@ is_a: MS:1002840 ! external reference data
 id: MS:1000879
 name: PubMed identifier
 def: "A unique identifier for a publication in the PubMed database (MIR:00000015)." [PSI:MS]
-xref: value-type:xsd\:integer "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
 relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term
 
@@ -6328,7 +6219,6 @@ relationship: has_value_type xsd\:integer ! The allowed value-type for this CV t
 id: MS:1000880
 name: interchannel delay
 def: "The duration of intervals between scanning, during which the instrument configuration is switched." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000503 ! scan attribute
 relationship: has_units UO:0000010 ! second
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
@@ -6349,7 +6239,6 @@ is_a: MS:1000859 ! molecule
 id: MS:1000883
 name: protein short name
 def: "A short name or symbol of a protein (e.g., HSF 1 or HSF1_HUMAN)." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000884 ! protein attribute
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -6364,7 +6253,6 @@ is_a: MS:1001806 ! quantification object attribute
 id: MS:1000885
 name: protein accession
 def: "Identifier for a specific protein in a database." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000884 ! protein attribute
 is_a: MS:1003046 ! peptide-to-protein mapping attribute
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
@@ -6373,7 +6261,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1000886
 name: protein name
 def: "A long name describing the function of the protein." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000884 ! protein attribute
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -6387,7 +6274,6 @@ relationship: part_of MS:1000860 ! peptide
 id: MS:1000888
 name: stripped peptide sequence
 def: "Sequence of letter symbols denoting the order of amino acids that compose the peptide, with any amino acid mass modifications that might be present having been stripped away." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1003050 ! peptidoform attribute
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -6396,7 +6282,6 @@ id: MS:1000889
 name: peptidoform sequence
 def: "Sequence of letter symbols denoting the order of amino acid residues that compose the peptidoform including the encoding of any residue modifications that are present." [PSI:MS]
 comment: Make it more general as there are actually many other ways to display a modified peptide sequence.
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1003050 ! peptidoform attribute
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -6423,7 +6308,6 @@ is_a: MS:1000890 ! peptidoform labeling state
 id: MS:1000893
 name: peptidoform group label
 def: "An arbitrary string label used to mark a set of peptides that belong together in a set, whereby the members are differentiated by different isotopic labels. For example, the heavy and light forms of the same peptide will both be assigned the same peptide group label." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1003050 ! peptidoform attribute
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -6431,7 +6315,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1000894
 name: retention time
 def: "A time interval from the start of chromatography when an analyte exits a chromatographic column." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1003050 ! peptidoform attribute
 relationship: has_units UO:0000010 ! second
 relationship: has_units UO:0000031 ! minute
@@ -6441,7 +6324,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1000895
 name: local retention time
 def: "A time interval from the start of chromatography when an analyte exits an unspecified local chromatographic column and instrumental setup." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000894 ! retention time
 relationship: has_units UO:0000010 ! second
 relationship: has_units UO:0000031 ! minute
@@ -6451,7 +6333,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1000896
 name: normalized retention time
 def: "A time interval from the start of chromatography when an analyte exits a standardized reference chromatographic column and instrumental setup." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000894 ! retention time
 relationship: has_units UO:0000010 ! second
 relationship: has_units UO:0000031 ! minute
@@ -6461,7 +6342,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1000897
 name: predicted retention time
 def: "A time interval from the start of chromatography when an analyte exits a chromatographic column as predicted by a referenced software application." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000894 ! retention time
 relationship: has_units UO:0000010 ! second
 relationship: has_units UO:0000031 ! minute
@@ -6501,7 +6381,6 @@ is_a: MS:1000901 ! retention time normalization standard
 id: MS:1000903
 name: product ion series ordinal
 def: "The ordinal of the fragment within a specified ion series. (e.g. 8 for a y8 ion)." [PSI:PI]
-xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1001221 ! product ion attribute
 relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term
 
@@ -6516,7 +6395,6 @@ relationship: has_units MS:1000040 ! m/z
 id: MS:1000905
 name: percent of base peak times 100
 def: "The magnitude of a peak expressed in terms of the percentage of the magnitude of the base peak intensity multiplied by 100. The base peak is therefore 10000. This unit is common in normalized spectrum libraries." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000043 ! intensity unit
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
@@ -6524,7 +6402,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1000906
 name: peak intensity rank
 def: "Ordinal specifying the rank in intensity of a peak in a spectrum. Base peak is 1. The next most intense peak is 2, etc." [PSI:MS]
-xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1000455 ! ion selection attribute
 relationship: part_of MS:1000231 ! peak
 relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term
@@ -6533,7 +6410,6 @@ relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for t
 id: MS:1000907
 name: peak targeting suitability rank
 def: "Ordinal specifying the rank of a peak in a spectrum in terms of suitability for targeting. The most suitable peak is 1. The next most suitability peak is 2, etc. Suitability is algorithm and context dependant." [PSI:MS]
-xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1000455 ! ion selection attribute
 relationship: part_of MS:1000231 ! peak
 relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term
@@ -6592,7 +6468,6 @@ relationship: part_of MS:1000894 ! retention time
 id: MS:1000916
 name: retention time window lower offset
 def: "The extent of the retention time window in time units below the target retention time. The lower and upper offsets may be asymmetric about the target time." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000915 ! retention time window attribute
 relationship: has_units UO:0000010 ! second
 relationship: has_units UO:0000031 ! minute
@@ -6602,7 +6477,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1000917
 name: retention time window upper offset
 def: "The extent of the retention time window in time units above the target retention time. The lower and upper offsets may be asymmetric about the target time." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000915 ! retention time window attribute
 relationship: has_units UO:0000010 ! second
 relationship: has_units UO:0000031 ! minute
@@ -6663,7 +6537,6 @@ is_a: MS:1000871 ! SRM software
 id: MS:1000926
 name: product interpretation rank
 def: "The integer rank given an interpretation of an observed product ion. For example, if y8 is selected as the most likely interpretation of a peak, then it is assigned a rank of 1." [PSI:MS]
-xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1001221 ! product ion attribute
 relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term
 
@@ -6671,7 +6544,6 @@ relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for t
 id: MS:1000927
 name: ion injection time
 def: "The length of time spent filling an ion trapping device." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000503 ! scan attribute
 relationship: has_units UO:0000028 ! millisecond
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
@@ -6710,7 +6582,6 @@ is_a: MS:1000121 ! SCIEX instrument model
 id: MS:1000933
 name: protein modifications
 def: "Encoding of modifications of the protein sequence from the specified accession, written in PEFF notation." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000884 ! protein attribute
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -6718,7 +6589,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1000934
 name: gene name
 def: "Name of the gene from which the protein is translated." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000884 ! protein attribute
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -6749,7 +6619,6 @@ relationship: part_of MS:0000000 ! Proteomics Standards Initiative Mass Spectrom
 [Term]
 id: MS:1001005
 name: SEQUEST:CleavesAt
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002096 ! SEQUEST input parameter
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -6763,7 +6632,6 @@ is_a: MS:1002096 ! SEQUEST input parameter
 id: MS:1001007
 name: SEQUEST:OutputLines
 def: "Number of peptide results to show." [PSI:MS]
-xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1002096 ! SEQUEST input parameter
 relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term
 
@@ -6771,7 +6639,6 @@ relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type fo
 id: MS:1001009
 name: SEQUEST:DescriptionLines
 def: "Number of full protein descriptions to show for top N peptides." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002096 ! SEQUEST input parameter
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -6791,7 +6658,6 @@ is_a: MS:1001249 ! search input details
 id: MS:1001012
 name: database source
 def: "The organisation, project or laboratory from where the database is obtained (UniProt, NCBI, EBI, other)." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001011 ! search database details
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -6812,7 +6678,6 @@ is_obsolete: true
 id: MS:1001015
 name: database original uri
 def: "URI, from where the search database was originally downloaded." [PSI:PI]
-xref: value-type:xsd\:anyURI "The allowed value-type for this CV term."
 is_a: MS:1001011 ! search database details
 relationship: has_value_type xsd\:anyURI ! The allowed value-type for this CV term
 
@@ -6820,7 +6685,6 @@ relationship: has_value_type xsd\:anyURI ! The allowed value-type for this CV te
 id: MS:1001016
 name: database version
 def: "Version of the search database. In mzIdentML use the attribute instead." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001011 ! search database details
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -6879,14 +6743,12 @@ is_a: MS:1001011 ! search database details
 id: MS:1001025
 name: translation table
 def: "The translation table used to translate the nucleotides to amino acids." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001011 ! search database details
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001026
 name: SEQUEST:NormalizeXCorrValues
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002096 ! SEQUEST input parameter
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -6900,7 +6762,6 @@ is_a: MS:1001511 ! Sequence database filter types
 id: MS:1001028
 name: SEQUEST:SequenceHeaderFilter
 def: "String in the header of a sequence entry for that entry to be searched." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002096 ! SEQUEST input parameter
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -6908,7 +6769,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1001029
 name: number of sequences searched
 def: "The number of sequences (proteins / nucleotides) from the database search after filtering." [PSI:PI]
-xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1001011 ! search database details
 relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term
 
@@ -6916,7 +6776,6 @@ relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for t
 id: MS:1001030
 name: number of peptide seqs compared to each spectrum
 def: "Number of peptide seqs compared to each spectrum." [PSI:PI]
-xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1001011 ! search database details
 is_a: MS:1001405 ! spectrum identification result details
 relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term
@@ -6930,7 +6789,6 @@ is_a: MS:1001080 ! search type
 [Term]
 id: MS:1001032
 name: SEQUEST:SequencePartialFilter
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002096 ! SEQUEST input parameter
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -6945,7 +6803,6 @@ is_obsolete: true
 id: MS:1001036
 name: search time taken
 def: "The time taken to complete the search in seconds." [PSI:PI]
-xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1001184 ! search statistics
 relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term
 
@@ -6953,7 +6810,6 @@ relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for t
 id: MS:1001037
 name: SEQUEST:ShowFragmentIons
 def: "Flag indicating that fragment ions should be shown." [PSI:MS]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002096 ! SEQUEST input parameter
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -6961,7 +6817,6 @@ relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV t
 id: MS:1001038
 name: SEQUEST:Consensus
 def: "Specify depth as value of the CVParam." [PSI:PI]
-xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1001006 ! SEQUEST:ViewCV
 relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term
 
@@ -6981,7 +6836,6 @@ is_a: MS:1001006 ! SEQUEST:ViewCV
 id: MS:1001042
 name: SEQUEST:LimitTo
 def: "Specify \"number of dtas shown\" as value of the CVParam." [PSI:PI]
-xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1002096 ! SEQUEST input parameter
 relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term
 
@@ -7001,7 +6855,6 @@ is_a: MS:1001044 ! cleavage agent details
 id: MS:1001046
 name: SEQUEST:sort by dCn
 def: "Sort order of SEQUEST search results by the delta of the normalized correlation score." [PSI:PI]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001041 ! SEQUEST:sortCV
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -7009,7 +6862,6 @@ relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV t
 id: MS:1001047
 name: SEQUEST:sort by dM
 def: "Sort order of SEQUEST search results by the difference between a theoretically calculated and the corresponding experimentally measured molecular mass M." [PSI:PI]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001041 ! SEQUEST:sortCV
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -7017,7 +6869,6 @@ relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV t
 id: MS:1001048
 name: SEQUEST:sort by Ions
 def: "Sort order of SEQUEST search results given by the ions." [PSI:PI]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001041 ! SEQUEST:sortCV
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -7025,7 +6876,6 @@ relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV t
 id: MS:1001049
 name: SEQUEST:sort by MH+
 def: "Sort order of SEQUEST search results given by the mass of the protonated ion." [PSI:PI]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001041 ! SEQUEST:sortCV
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -7033,7 +6883,6 @@ relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV t
 id: MS:1001050
 name: SEQUEST:sort by P
 def: "Sort order of SEQUEST search results given by the probability." [PSI:PI]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001041 ! SEQUEST:sortCV
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -7041,7 +6890,6 @@ relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV t
 id: MS:1001051
 name: multiple enzyme combination rules
 def: "OBSOLETE: use attribute independent in mzIdentML instead. Description of multiple enzyme digestion protocol, if any." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_obsolete: true
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -7049,7 +6897,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1001052
 name: SEQUEST:sort by PreviousAminoAcid
 def: "Sort order of SEQUEST search results given by the previous amino acid." [PSI:PI]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001041 ! SEQUEST:sortCV
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -7057,7 +6904,6 @@ relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV t
 id: MS:1001053
 name: SEQUEST:sort by Ref
 def: "Sort order of SEQUEST search results given by the reference." [PSI:PI]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001041 ! SEQUEST:sortCV
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -7090,7 +6936,6 @@ is_a: MS:1001060 ! quality estimation method details
 id: MS:1001059
 name: SEQUEST:sort by RSp
 def: "Sort order of SEQUEST search results given by the result 'Sp' of 'Rank/Sp' in the out file (peptide)." [PSI:PI]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001041 ! SEQUEST:sortCV
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -7133,7 +6978,6 @@ is_a: MS:1001249 ! search input details
 id: MS:1001068
 name: SEQUEST:sort by Sp
 def: "Sort order of SEQUEST search results by the Sp score." [PSI:PI]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001041 ! SEQUEST:sortCV
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -7141,7 +6985,6 @@ relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV t
 id: MS:1001069
 name: SEQUEST:sort by TIC
 def: "Sort order of SEQUEST search results given by the total ion current." [PSI:PI]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001041 ! SEQUEST:sortCV
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -7149,7 +6992,6 @@ relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV t
 id: MS:1001070
 name: SEQUEST:sort by Scan
 def: "Sort order of SEQUEST search results given by the scan number." [PSI:PI]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001041 ! SEQUEST:sortCV
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -7157,7 +6999,6 @@ relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV t
 id: MS:1001071
 name: SEQUEST:sort by Sequence
 def: "Sort order of SEQUEST search results given by the sequence." [PSI:PI]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001041 ! SEQUEST:sortCV
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -7165,7 +7006,6 @@ relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV t
 id: MS:1001072
 name: SEQUEST:sort by Sf
 def: "Sort order of SEQUEST search results given by the SEQUEST result 'Sf'." [PSI:PI]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001041 ! SEQUEST:sortCV
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -7221,7 +7061,6 @@ is_a: MS:1002694 ! single identification result attribute
 id: MS:1001086
 name: SEQUEST:sort by XCorr
 def: "Sort order of SEQUEST search results by the correlation score." [PSI:PI]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001041 ! SEQUEST:sortCV
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -7235,7 +7074,6 @@ is_a: MS:1002096 ! SEQUEST input parameter
 id: MS:1001088
 name: protein description
 def: "The protein description line from the sequence entry in the source database FASTA file." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001085 ! protein-level identification attribute
 is_a: MS:1001342 ! database sequence details
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
@@ -7244,7 +7082,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1001089
 name: molecule taxonomy
 def: "The taxonomy of the resultant molecule from the search." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001085 ! protein-level identification attribute
 is_a: MS:1001342 ! database sequence details
 is_a: MS:1001512 ! Sequence database filters
@@ -7278,7 +7115,6 @@ is_a: MS:1001105 ! peptide sequence-level identification attribute
 id: MS:1001093
 name: sequence coverage
 def: "The percent coverage for the protein based upon the matched peptide sequences (can be calculated)." [PSI:PI]
-xref: value-type:xsd\:decimal "The allowed value-type for this CV term."
 is_a: MS:1001085 ! protein-level identification attribute
 relationship: has_value_type xsd\:decimal ! The allowed value-type for this CV term
 
@@ -7286,14 +7122,12 @@ relationship: has_value_type xsd\:decimal ! The allowed value-type for this CV t
 id: MS:1001094
 name: SEQUEST:sort by z
 def: "Sort order of SEQUEST search results given by the charge." [PSI:PI]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001041 ! SEQUEST:sortCV
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001095
 name: SEQUEST:ProcessAll
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001087 ! SEQUEST:ProcessCV
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -7301,7 +7135,6 @@ relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV t
 id: MS:1001096
 name: SEQUEST:TopPercentMostIntense
 def: "Specify \"percentage\" as value of the CVParam." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001087 ! SEQUEST:ProcessCV
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -7309,7 +7142,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001097
 name: distinct peptide sequences
 def: "This counts distinct sequences hitting the protein without regard to a minimal confidence threshold." [PSI:PI]
-xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1001085 ! protein-level identification attribute
 relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term
 
@@ -7317,7 +7149,6 @@ relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type fo
 id: MS:1001098
 name: confident distinct peptide sequences
 def: "This counts the number of distinct peptide sequences. Multiple charge states and multiple modification states do NOT count as multiple sequences. The definition of 'confident' must be qualified elsewhere." [PSI:PI]
-xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1001085 ! protein-level identification attribute
 relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term
 
@@ -7325,7 +7156,6 @@ relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type fo
 id: MS:1001099
 name: confident peptide qualification
 def: "The point of this entry is to define what is meant by confident for the term Confident distinct peptide sequence and/or Confident peptides. Example 1 - metric=Paragon:Confidence value=95 sense=greater than Example 2 - metric=Mascot:Eval value=0.05 sense=less than." [PSI:PI]
-xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1001085 ! protein-level identification attribute
 relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term
 
@@ -7333,7 +7163,6 @@ relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type fo
 id: MS:1001100
 name: confident peptide sequence number
 def: "This counts the number of peptide sequences without regard to whether they are distinct. Multiple charges states and multiple modification states DO count as multiple peptides. The definition of 'confident' must be qualified elsewhere." [PSI:PI]
-xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1001085 ! protein-level identification attribute
 relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term
 
@@ -7346,14 +7175,12 @@ is_a: MS:1001085 ! protein-level identification attribute
 [Term]
 id: MS:1001102
 name: SEQUEST:Chromatogram
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001006 ! SEQUEST:ViewCV
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001103
 name: SEQUEST:InfoAndLog
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001006 ! SEQUEST:ViewCV
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -7373,7 +7200,6 @@ is_a: MS:1002694 ! single identification result attribute
 id: MS:1001106
 name: SEQUEST:TopNumber
 def: "Specify \"number\" as value of the CVParam." [PSI:PI]
-xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1001087 ! SEQUEST:ProcessCV
 relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term
 
@@ -7393,7 +7219,6 @@ is_a: MS:1002473 ! ion series considered in search
 id: MS:1001109
 name: SEQUEST:CullTo
 def: "Specify cull string as value of the CVParam." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001087 ! SEQUEST:ProcessCV
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -7406,7 +7231,6 @@ is_a: MS:1002096 ! SEQUEST input parameter
 [Term]
 id: MS:1001111
 name: SEQUEST:Full
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001110 ! SEQUEST:modeCV
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -7414,7 +7238,6 @@ relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV t
 id: MS:1001112
 name: n-terminal flanking residue
 def: "Residue preceding the first amino acid in the peptide sequence as it occurs in the protein. Use 'N-term' to denote if the peptide starts at the N terminus of the protein." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1003046 ! peptide-to-protein mapping attribute
 is_a: MS:1001105 ! peptide sequence-level identification attribute
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
@@ -7423,7 +7246,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1001113
 name: c-terminal flanking residue
 def: "Residue following the last amino acid in the peptide sequence as it occurs in the protein. Use 'C-term' to denote if the peptide ends at the C terminus of the protein." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1003046 ! peptide-to-protein mapping attribute
 is_a: MS:1001105 ! peptide sequence-level identification attribute
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
@@ -7433,7 +7255,6 @@ id: MS:1001114
 name: retention time(s)
 def: "OBSOLETE Retention time of the spectrum from the source file." [PSI:PI]
 comment: This term was made obsolete because scan start time (MS:1000016) should be used instead.
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001105 ! peptide sequence-level identification attribute
 relationship: has_units UO:0000010 ! second
 relationship: has_units UO:0000031 ! minute
@@ -7457,7 +7278,6 @@ is_a: MS:1001085 ! protein-level identification attribute
 id: MS:1001117
 name: theoretical mass
 def: "The theoretical neutral mass of the molecule (e.g. the peptide sequence and its modifications) not including its charge carrier." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001105 ! peptide sequence-level identification attribute
 relationship: has_units UO:0000221 ! dalton
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
@@ -7477,7 +7297,6 @@ is_a: MS:1002473 ! ion series considered in search
 [Term]
 id: MS:1001120
 name: SEQUEST:FormatAndLinks
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001110 ! SEQUEST:modeCV
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -7485,7 +7304,6 @@ relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV t
 id: MS:1001121
 name: number of matched peaks
 def: "The number of peaks that were matched as qualified by the ion series considered field. If a peak matches multiple ions then only 1 would be added the count." [PSI:PI]
-xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1001105 ! peptide sequence-level identification attribute
 relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term
 
@@ -7499,7 +7317,6 @@ is_a: MS:1001105 ! peptide sequence-level identification attribute
 id: MS:1001123
 name: number of peaks used
 def: "The number of peaks from the original peak list that are used to calculate the scores for a particular search engine. All ions that have the opportunity to match or be counted even if they don't." [PSI:PI]
-xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1001105 ! peptide sequence-level identification attribute
 relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term
 
@@ -7507,7 +7324,6 @@ relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type fo
 id: MS:1001124
 name: number of peaks submitted
 def: "The number of peaks from the original peaks listed that were submitted to the search engine." [PSI:PI]
-xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1001105 ! peptide sequence-level identification attribute
 relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term
 
@@ -7515,7 +7331,6 @@ relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type fo
 id: MS:1001125
 name: manual validation
 def: "Result of quality estimation: decision of a manual validation." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001092 ! peptide sequence-level identification statistic
 is_a: MS:1001116 ! single protein identification statistic
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
@@ -7523,7 +7338,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 [Term]
 id: MS:1001126
 name: SEQUEST:Fast
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001110 ! SEQUEST:modeCV
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -7550,7 +7364,6 @@ id: MS:1001130
 name: peptide raw area
 def: "OBSOLETE Peptide raw area." [PSI:PI]
 comment: This term was made obsolete because it is replaced by 'MS1 feature area' (MS:1001844).
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002737 ! peptide-level quantification datatype
 is_obsolete: true
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
@@ -7559,7 +7372,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001131
 name: error on peptide area
 def: "Error on peptide area." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002737 ! peptide-level quantification datatype
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -7567,7 +7379,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001132
 name: peptide ratio
 def: "Peptide ratio." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002737 ! peptide-level quantification datatype
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -7575,7 +7386,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001133
 name: error on peptide ratio
 def: "Error on peptide ratio." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002737 ! peptide-level quantification datatype
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -7583,7 +7393,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001134
 name: protein ratio
 def: "Protein ratio." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002738 ! protein-level quantification datatype
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -7591,7 +7400,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001135
 name: error on protein ratio
 def: "Error on protein ratio." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002738 ! protein-level quantification datatype
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -7600,7 +7408,6 @@ id: MS:1001136
 name: p-value (protein diff from 1 randomly)
 def: "OBSOLETE P-value (protein diff from 1 randomly)." [PSI:PI]
 comment: This term was made obsolete because it is replaced by 't-test p-value' (MS:1001855).
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002738 ! protein-level quantification datatype
 is_obsolete: true
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
@@ -7609,7 +7416,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001137
 name: absolute quantity
 def: "Absolute quantity in terms of real concentration or molecule copy number in sample." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -7617,7 +7423,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001138
 name: error on absolute quantity
 def: "Error on absolute quantity." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -7640,7 +7445,6 @@ is_obsolete: true
 id: MS:1001141
 name: intensity of precursor ion
 def: "The intensity of the precursor ion." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -7719,7 +7523,6 @@ is_a: MS:1002694 ! single identification result attribute
 id: MS:1001154
 name: SEQUEST:probability
 def: "The SEQUEST result 'Probability'." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -7727,7 +7530,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001155
 name: SEQUEST:xcorr
 def: "The SEQUEST result 'XCorr'." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002108 ! higher score better
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
@@ -7736,7 +7538,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001156
 name: SEQUEST:deltacn
 def: "The SEQUEST result 'DeltaCn'." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -7744,14 +7545,12 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001157
 name: SEQUEST:sp
 def: "The SEQUEST result 'Sp' (protein)." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001158
 name: SEQUEST:Uniq
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -7759,7 +7558,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001159
 name: SEQUEST:expectation value
 def: "The SEQUEST result 'Expectation value'." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001153 ! search engine specific score
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -7767,7 +7565,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001160
 name: SEQUEST:sf
 def: "The SEQUEST result 'Sf'." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -7775,7 +7572,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001161
 name: SEQUEST:matched ions
 def: "The SEQUEST result 'Matched Ions'." [PSI:PI]
-xref: value-type:xsd\:integer "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term
 
@@ -7783,7 +7579,6 @@ relationship: has_value_type xsd\:integer ! The allowed value-type for this CV t
 id: MS:1001162
 name: SEQUEST:total ions
 def: "The SEQUEST result 'Total Ions'." [PSI:PI]
-xref: value-type:xsd\:integer "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term
 
@@ -7791,7 +7586,6 @@ relationship: has_value_type xsd\:integer ! The allowed value-type for this CV t
 id: MS:1001163
 name: SEQUEST:consensus score
 def: "The SEQUEST result 'Consensus Score'." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001153 ! search engine specific score
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -7799,7 +7593,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001164
 name: Paragon:unused protscore
 def: "The Paragon result 'Unused ProtScore'." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
 is_a: MS:1002368 ! search engine specific score for protein groups
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
@@ -7808,7 +7601,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001165
 name: Paragon:total protscore
 def: "The Paragon result 'Total ProtScore'." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
 is_a: MS:1002368 ! search engine specific score for protein groups
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
@@ -7817,7 +7609,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001166
 name: Paragon:score
 def: "The Paragon result 'Score'." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -7825,7 +7616,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001167
 name: Paragon:confidence
 def: "The Paragon result 'Confidence'." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -7833,7 +7623,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001168
 name: Paragon:expression error factor
 def: "The Paragon result 'Expression Error Factor'." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -7841,7 +7630,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001169
 name: Paragon:expression change p-value
 def: "The Paragon result 'Expression change P-value'." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -7849,7 +7637,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001170
 name: Paragon:contrib
 def: "The Paragon result 'Contrib'." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -7857,7 +7644,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001171
 name: Mascot:score
 def: "The Mascot result 'Score'." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -7865,7 +7651,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001172
 name: Mascot:expectation value
 def: "The Mascot result 'expectation value'." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -7873,7 +7658,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001173
 name: Mascot:matched ions
 def: "The Mascot result 'Matched ions'." [PSI:PI]
-xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term
 
@@ -7881,7 +7665,6 @@ relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type fo
 id: MS:1001174
 name: Mascot:total ions
 def: "The Mascot result 'Total ions'." [PSI:PI]
-xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term
 
@@ -7901,7 +7684,6 @@ is_a: MS:1001180 ! Cleavage agent regular expression
 id: MS:1001177
 name: number of molecular hypothesis considered
 def: "Number of Molecular Hypothesis Considered - This is the number of molecules (e.g. peptides for proteomics) considered for a particular search." [PSI:PI]
-xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1001184 ! search statistics
 relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term
 
@@ -7941,7 +7723,6 @@ id: MS:1001191
 name: p-value
 def: "OBSOLETE Quality estimation by p-value." [PSI:PI]
 comment: This term was made obsolete because now is split into peptide and protein terms.
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001092 ! peptide sequence-level identification statistic
 is_a: MS:1001198 ! protein identification confidence metric
 is_obsolete: true
@@ -7951,7 +7732,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001192
 name: Expect value
 def: "Result of quality estimation: Expect value." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001092 ! peptide sequence-level identification statistic
 is_a: MS:1001116 ! single protein identification statistic
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
@@ -7960,7 +7740,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001193
 name: confidence score
 def: "Result of quality estimation: confidence score." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001092 ! peptide sequence-level identification statistic
 is_a: MS:1001116 ! single protein identification statistic
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
@@ -7969,7 +7748,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001194
 name: quality estimation with decoy database
 def: "Quality estimation by decoy database." [PSI:PI]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001060 ! quality estimation method details
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -8013,7 +7791,6 @@ is_a: MS:1001040 ! intermediate analysis format
 id: MS:1001201
 name: DB MW filter maximum
 def: "Maximum value of molecular weight filter." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001512 ! Sequence database filters
 relationship: has_units UO:0000221 ! dalton
 relationship: has_units UO:0000222 ! kilodalton
@@ -8023,7 +7800,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001202
 name: DB MW filter minimum
 def: "Minimum value of molecular weight filter." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001512 ! Sequence database filters
 relationship: has_units UO:0000221 ! dalton
 relationship: has_units UO:0000222 ! kilodalton
@@ -8033,7 +7809,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001203
 name: DB PI filter maximum
 def: "Maximum value of isoelectric point filter." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001512 ! Sequence database filters
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -8041,7 +7816,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001204
 name: DB PI filter minimum
 def: "Minimum value of isoelectric point filter." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001512 ! Sequence database filters
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -8092,7 +7866,6 @@ is_obsolete: true
 id: MS:1001214
 name: protein-level global FDR
 def: "Estimation of the global false discovery rate of proteins." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002705 ! protein-level result list statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
@@ -8101,7 +7874,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001215
 name: SEQUEST:PeptideSp
 def: "The SEQUEST result 'Sp' in out file (peptide)." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -8109,7 +7881,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001217
 name: SEQUEST:PeptideRankSp
 def: "The SEQUEST result 'Sp' of 'Rank/Sp' in out file (peptide). Also called 'rsp'." [PSI:PI]
-xref: value-type:xsd\:integer "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term
 
@@ -8117,7 +7888,6 @@ relationship: has_value_type xsd\:integer ! The allowed value-type for this CV t
 id: MS:1001218
 name: SEQUEST:PeptideNumber
 def: "The SEQUEST result '#' in out file (peptide)." [PSI:PI]
-xref: value-type:xsd\:integer "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term
 
@@ -8125,7 +7895,6 @@ relationship: has_value_type xsd\:integer ! The allowed value-type for this CV t
 id: MS:1001219
 name: SEQUEST:PeptideIdnumber
 def: "The SEQUEST result 'Id#' in out file (peptide)." [PSI:PI]
-xref: value-type:xsd\:integer "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term
 
@@ -8310,7 +8079,6 @@ relationship: part_of MS:1001000 ! spectrum interpretation
 id: MS:1001250
 name: local FDR
 def: "Result of quality estimation: the local FDR at the current position of a sorted list." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001092 ! peptide sequence-level identification statistic
 is_a: MS:1001116 ! single protein identification statistic
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
@@ -8410,7 +8178,6 @@ is_a: MS:1001266 ! role type
 id: MS:1001268
 name: programmer
 def: "Programmer role." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001266 ! role type
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -8418,7 +8185,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1001269
 name: instrument vendor
 def: "Instrument vendor role." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001266 ! role type
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -8426,7 +8192,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1001270
 name: lab personnel
 def: "Lab personnel role." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001266 ! role type
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -8470,7 +8235,6 @@ is_a: MS:1001040 ! intermediate analysis format
 id: MS:1001283
 name: decoy DB accession regexp
 def: "Specify the regular expression for decoy accession numbers." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001450 ! decoy DB details
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -8592,7 +8356,6 @@ is_obsolete: true
 id: MS:1001301
 name: protein rank
 def: "The rank of the protein in a list sorted by the search engine." [PSI:PI]
-xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1001085 ! protein-level identification attribute
 relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
@@ -8700,7 +8463,6 @@ relationship: has_regexp MS:1001341 ! (?<=[EZ])(?!P)
 id: MS:1001316
 name: Mascot:SigThreshold
 def: "Significance threshold below which the p-value of a peptide match must lie to be considered statistically significant (default 0.05)." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002095 ! Mascot input parameter
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -8708,7 +8470,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001317
 name: Mascot:MaxProteinHits
 def: "The number of protein hits to display in the report. If 'Auto', all protein hits that have a protein score exceeding the average peptide identity threshold are reported. Otherwise an integer at least 1." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002095 ! Mascot input parameter
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -8716,7 +8477,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1001318
 name: Mascot:ProteinScoringMethod
 def: "Mascot protein scoring method; either 'Standard' or 'MudPIT'." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002095 ! Mascot input parameter
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -8724,7 +8484,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1001319
 name: Mascot:MinMSMSThreshold
 def: "Mascot peptide match ion score threshold. If between 0 and 1, then peptide matches whose expect value exceeds the thresholds are suppressed; if at least 1, then peptide matches whose ion score is below the threshold are suppressed." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002095 ! Mascot input parameter
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -8732,7 +8491,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001320
 name: Mascot:ShowHomologousProteinsWithSamePeptides
 def: "If true, show (sequence or spectrum) same-set proteins. Otherwise they are suppressed." [PSI:PI]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002095 ! Mascot input parameter
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -8740,7 +8498,6 @@ relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV t
 id: MS:1001321
 name: Mascot:ShowHomologousProteinsWithSubsetOfPeptides
 def: "If true, show (sequence or spectrum) sub-set and subsumable proteins. Otherwise they are suppressed." [PSI:PI]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002095 ! Mascot input parameter
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -8748,7 +8505,6 @@ relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV t
 id: MS:1001322
 name: Mascot:RequireBoldRed
 def: "Only used in Peptide Summary and Select Summary reports. If true, a peptide match must be 'bold red' to be included in the report; bold red means the peptide is a top ranking match in a query and appears for the first time (in linear order) in the list of protein hits." [PSI:PI]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002095 ! Mascot input parameter
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -8756,7 +8512,6 @@ relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV t
 id: MS:1001323
 name: Mascot:UseUnigeneClustering
 def: "If true, then the search results are against a nucleic acid database and Unigene clustering is enabled. Otherwise UniGene clustering is not in use." [PSI:PI]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002095 ! Mascot input parameter
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -8764,7 +8519,6 @@ relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV t
 id: MS:1001324
 name: Mascot:IncludeErrorTolerantMatches
 def: "If true, then the search results are error tolerant and peptide matches from the second pass are included in search results. Otherwise no error tolerant peptide matches are included." [http://www.matrixscience.com/help/error_tolerant_help.html]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002095 ! Mascot input parameter
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -8772,7 +8526,6 @@ relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV t
 id: MS:1001325
 name: Mascot:ShowDecoyMatches
 def: "If true, then the search results are against an automatically generated decoy database and the reported peptide matches and protein hits come from the decoy database. Otherwise peptide matches and protein hits come from the original database." [PSI:PI]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002095 ! Mascot input parameter
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -8787,7 +8540,6 @@ is_obsolete: true
 id: MS:1001328
 name: OMSSA:evalue
 def: "OMSSA E-value." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -8795,7 +8547,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001329
 name: OMSSA:pvalue
 def: "OMSSA p-value." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -8803,7 +8554,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001330
 name: X\!Tandem:expect
 def: "The X!Tandem expectation value." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -8811,7 +8561,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001331
 name: X\!Tandem:hyperscore
 def: "The X!Tandem hyperscore." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -8975,7 +8724,6 @@ is_a: MS:1001356 ! spectrum descriptions
 id: MS:1001358
 name: msmsEval quality
 def: "This term reports the quality of the spectrum assigned by msmsEval." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001357 ! spectrum quality descriptions
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -8989,7 +8737,6 @@ relationship: part_of MS:1001000 ! spectrum interpretation
 id: MS:1001360
 name: alternate single letter codes
 def: "List of standard residue one letter codes which are used to replace a non-standard." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001359 ! ambiguous residues
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -8997,7 +8744,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1001361
 name: alternate mass
 def: "List of masses a non-standard letter code is replaced with." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001359 ! ambiguous residues
 relationship: has_units UO:0000221 ! dalton
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
@@ -9006,7 +8752,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001362
 name: number of unmatched peaks
 def: "The number of unmatched peaks." [PSI:PI]
-xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1002345 ! PSM-level attribute
 relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term
 
@@ -9020,7 +8765,6 @@ is_a: MS:1001127 ! peptide sharing details
 id: MS:1001364
 name: peptide sequence-level global FDR
 def: "Estimation of the global false discovery rate for distinct peptides once redundant identifications of the same peptide have been removed (id est multiple PSMs have been collapsed to one entry)." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002703 ! peptide sequence-level result list statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
@@ -9059,7 +8803,6 @@ is_a: MS:1000560 ! mass spectrometer file format
 id: MS:1001370
 name: Mascot:homology threshold
 def: "The Mascot result 'homology threshold'." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -9067,14 +8810,12 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001371
 name: Mascot:identity threshold
 def: "The Mascot result 'identity threshold'." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001372
 name: SEQUEST:Sequences
-xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
 relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term
 
@@ -9082,14 +8823,12 @@ relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for t
 id: MS:1001373
 name: SEQUEST:TIC
 def: "SEQUEST total ion current." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001374
 name: SEQUEST:Sum
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -9097,7 +8836,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001375
 name: Phenyx:Instrument Type
 def: "The instrument type parameter value in Phenyx." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002097 ! Phenyx input parameter
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -9105,7 +8843,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1001376
 name: Phenyx:Scoring Model
 def: "The selected scoring model in Phenyx." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002097 ! Phenyx input parameter
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -9113,7 +8850,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1001377
 name: Phenyx:Default Parent Charge
 def: "The default parent charge value in Phenyx." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002097 ! Phenyx input parameter
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -9121,7 +8857,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1001378
 name: Phenyx:Trust Parent Charge
 def: "The parameter in Phenyx that specifies if the experimental charge state is to be considered as correct." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002097 ! Phenyx input parameter
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -9129,7 +8864,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1001379
 name: Phenyx:Turbo
 def: "The turbo mode parameter in Phenyx." [PSI:PI]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002097 ! Phenyx input parameter
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -9137,7 +8871,6 @@ relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV t
 id: MS:1001380
 name: Phenyx:Turbo:ErrorTol
 def: "The maximal allowed fragment m/z error filter considered in the turbo mode of Phenyx." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002097 ! Phenyx input parameter
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -9145,7 +8878,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001381
 name: Phenyx:Turbo:Coverage
 def: "The minimal peptide sequence coverage value, expressed in percent, considered in the turbo mode of Phenyx." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002097 ! Phenyx input parameter
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -9153,7 +8885,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001382
 name: Phenyx:Turbo:Series
 def: "The list of ion series considered in the turbo mode of Phenyx." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002097 ! Phenyx input parameter
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -9161,7 +8892,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1001383
 name: Phenyx:MinPepLength
 def: "The minimal number of residues for a peptide to be considered for a valid identification in Phenyx." [PSI:PI]
-xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1002097 ! Phenyx input parameter
 relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term
 
@@ -9169,7 +8899,6 @@ relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for t
 id: MS:1001384
 name: Phenyx:MinPepzscore
 def: "The minimal peptide z-score for a peptide to be considered for a valid identification in Phenyx." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002097 ! Phenyx input parameter
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -9177,7 +8906,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001385
 name: Phenyx:MaxPepPvalue
 def: "The maximal peptide p-value for a peptide to be considered for a valid identification in Phenyx." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002097 ! Phenyx input parameter
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -9185,7 +8913,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001386
 name: Phenyx:AC Score
 def: "The minimal protein score required for a protein database entry to be displayed in the list of identified proteins in Phenyx." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002097 ! Phenyx input parameter
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -9193,7 +8920,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001387
 name: Phenyx:Conflict Resolution
 def: "The parameter in Phenyx that specifies if the conflict resolution algorithm is to be used." [PSI:PI]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002097 ! Phenyx input parameter
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -9201,14 +8927,12 @@ relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV t
 id: MS:1001388
 name: Phenyx:AC
 def: "The primary sequence database identifier of a protein in Phenyx." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001389
 name: Phenyx:ID
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 def: "A secondary sequence database identifier of a protein in Phenyx." [PSI:PI]
 is_a: MS:1002363 ! search engine specific score for proteins
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
@@ -9217,7 +8941,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1001390
 name: Phenyx:Score
 def: "The protein score of a protein match in Phenyx." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -9225,7 +8948,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001391
 name: Phenyx:Peptides1
 def: "First number of phenyx result \"#Peptides\"." [PSI:PI]
-xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
 relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term
 
@@ -9233,7 +8955,6 @@ relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for t
 id: MS:1001392
 name: Phenyx:Peptides2
 def: "Second number of phenyx result \"#Peptides\"." [PSI:PI]
-xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
 relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term
 
@@ -9241,7 +8962,6 @@ relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for t
 id: MS:1001393
 name: Phenyx:Auto
 def: "The value of the automatic peptide acceptance filter in Phenyx." [PSI:PI]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -9249,7 +8969,6 @@ relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV t
 id: MS:1001394
 name: Phenyx:User
 def: "The value of the user-defined peptide acceptance filter in Phenyx." [PSI:PI]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1002363 ! search engine specific score for proteins
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
@@ -9258,7 +8977,6 @@ relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV t
 id: MS:1001395
 name: Phenyx:Pepzscore
 def: "The z-score value of a peptide sequence match in Phenyx." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -9266,7 +8984,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001396
 name: Phenyx:PepPvalue
 def: "The p-value of a peptide sequence match in Phenyx." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1002358 ! search engine specific peptide sequence-level identification statistic
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
@@ -9275,7 +8992,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001397
 name: Phenyx:NumberOfMC
 def: "The number of missed cleavages of a peptide sequence in Phenyx." [PSI:PI]
-xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term
 
@@ -9283,7 +8999,6 @@ relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for t
 id: MS:1001398
 name: Phenyx:Modif
 def: "The expression of the nature and position(s) of modified residue(s) on a matched peptide sequence in Phenyx." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1002363 ! search engine specific score for proteins
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
@@ -9340,7 +9055,6 @@ is_a: MS:1002473 ! ion series considered in search
 id: MS:1001410
 name: translation start codons
 def: "The translation start codons used to translate the nucleotides to amino acids." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001011 ! search database details
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -9353,7 +9067,6 @@ is_a: MS:1001249 ! search input details
 [Term]
 id: MS:1001412
 name: search tolerance plus value
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001411 ! search tolerance specification
 relationship: has_units UO:0000166 ! parts per notation unit
 relationship: has_units UO:0000169 ! parts per million
@@ -9364,7 +9077,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 [Term]
 id: MS:1001413
 name: search tolerance minus value
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001411 ! search tolerance specification
 relationship: has_units UO:0000166 ! parts per notation unit
 relationship: has_units UO:0000169 ! parts per million
@@ -9376,7 +9088,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001414
 name: MGF scans
 def: "OBSOLETE: replaced by MS:1000797 (peak list scans): This term can hold the scans attribute from an MGF input file." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001405 ! spectrum identification result details
 is_obsolete: true
 replaced_by: MS:1000797
@@ -9386,7 +9097,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1001415
 name: MGF raw scans
 def: "OBSOLETE: replaced by MS:1000798 (peak list raw scans): This term can hold the raw scans attribute from an MGF input file." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001405 ! spectrum identification result details
 is_obsolete: true
 replaced_by: MS:1000798
@@ -9396,7 +9106,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1001416
 name: spectrum title
 def: "OBSOLETE: replaced by MS:1000796 (spectrum title): Holds the spectrum title from different input file formats, e.g. MGF TITLE." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001405 ! spectrum identification result details
 is_obsolete: true
 replaced_by: MS:1000796
@@ -9406,7 +9115,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1001417
 name: SpectraST:dot
 def: "SpectraST dot product of two spectra, measuring spectral similarity." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -9414,7 +9122,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001418
 name: SpectraST:dot_bias
 def: "SpectraST measure of how much of the dot product is dominated by a few peaks." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -9422,7 +9129,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001419
 name: SpectraST:discriminant score F
 def: "SpectraST spectrum score." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -9430,7 +9136,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001420
 name: SpectraST:delta
 def: "SpectraST normalised difference between dot product of top hit and runner-up." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -9450,7 +9155,6 @@ is_a: MS:1001040 ! intermediate analysis format
 id: MS:1001423
 name: translation table description
 def: "A URL that describes the translation table used to translate the nucleotides to amino acids." [PSI:PI]
-xref: value-type:xsd\:anyURI "The allowed value-type for this CV term."
 is_a: MS:1001011 ! search database details
 relationship: has_value_type xsd\:anyURI ! The allowed value-type for this CV term
 
@@ -9458,7 +9162,6 @@ relationship: has_value_type xsd\:anyURI ! The allowed value-type for this CV te
 id: MS:1001424
 name: ProteinExtractor:Methodname
 def: "Name of the used method in the ProteinExtractor algorithm." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -9466,7 +9169,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1001425
 name: ProteinExtractor:GenerateNonRedundant
 def: "Flag indicating if a non redundant scoring should be generated." [PSI:PI]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -9474,7 +9176,6 @@ relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV t
 id: MS:1001426
 name: ProteinExtractor:IncludeIdentified
 def: "Flag indicating if identified proteins should be included." [PSI:PI]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -9482,7 +9183,6 @@ relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV t
 id: MS:1001427
 name: ProteinExtractor:MaxNumberOfProteins
 def: "The maximum number of proteins to consider." [PSI:PI]
-xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
 relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term
 
@@ -9490,7 +9190,6 @@ relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for t
 id: MS:1001428
 name: ProteinExtractor:MaxProteinMass
 def: "The maximum considered mass for a protein." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -9498,7 +9197,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001429
 name: ProteinExtractor:MinNumberOfPeptides
 def: "The minimum number of proteins to consider." [PSI:PI]
-xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
 relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term
 
@@ -9506,7 +9204,6 @@ relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for t
 id: MS:1001430
 name: ProteinExtractor:UseMascot
 def: "Flag indicating to include Mascot scoring for calculation of the ProteinExtractor meta score." [PSI:PI]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -9514,7 +9211,6 @@ relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV t
 id: MS:1001431
 name: ProteinExtractor:MascotPeptideScoreThreshold
 def: "Only peptides with scores higher than that threshold are taken into account in Mascot scoring for calculation of the ProteinExtractor meta score." [DOI:10.4172/jpb.1000056]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -9522,14 +9218,12 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001432
 name: ProteinExtractor:MascotUniqueScore
 def: "In the final result each protein must have at least one peptide above this Mascot score threshold in ProteinExtractor meta score calculation." [DOI:10.4172/jpb.1000056]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001433
 name: ProteinExtractor:MascotUseIdentityScore
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -9537,7 +9231,6 @@ relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV t
 id: MS:1001434
 name: ProteinExtractor:MascotWeighting
 def: "Influence of Mascot search engine in the process of merging the search engine specific protein lists into the global protein list of ProteinExtractor." [DOI:10.4172/jpb.1000056]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -9545,7 +9238,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001435
 name: ProteinExtractor:UseSequest
 def: "Flag indicating to include SEQUEST scoring for calculation of the ProteinExtractor meta score." [PSI:PI]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -9553,7 +9245,6 @@ relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV t
 id: MS:1001436
 name: ProteinExtractor:SequestPeptideScoreThreshold
 def: "Only peptides with scores higher than that threshold are taken into account in SEQUEST scoring for calculation of the ProteinExtractor meta score." [DOI:10.4172/jpb.1000056]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -9561,7 +9252,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001437
 name: ProteinExtractor:SequestUniqueScore
 def: "In the final result each protein must have at least one peptide above this SEQUEST score threshold in ProteinExtractor meta score calculation." [DOI:10.4172/jpb.1000056]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -9569,7 +9259,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001438
 name: ProteinExtractor:SequestWeighting
 def: "Influence of SEQUEST search engine in the process of merging the search engine specific protein lists into the global protein list of ProteinExtractor." [DOI:10.4172/jpb.1000056]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -9577,7 +9266,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001439
 name: ProteinExtractor:UseProteinSolver
 def: "Flag indicating to include ProteinSolver scoring for calculation of the ProteinExtractor meta score." [PSI:PI]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -9585,7 +9273,6 @@ relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV t
 id: MS:1001440
 name: ProteinExtractor:ProteinSolverPeptideScoreThreshold
 def: "Only peptides with scores higher than that threshold are taken into account in ProteinSolver scoring for calculation of the ProteinExtractor meta score." [DOI:10.4172/jpb.1000056]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -9593,7 +9280,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001441
 name: ProteinExtractor:ProteinSolverUniqueScore
 def: "In the final result each protein must have at least one peptide above this ProteinSolver score threshold in ProteinExtractor meta score calculation." [DOI:10.4172/jpb.1000056]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -9601,7 +9287,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001442
 name: ProteinExtractor:ProteinSolverWeighting
 def: "Influence of ProteinSolver search engine in the process of merging the search engine specific protein lists into the global protein list of ProteinExtractor." [DOI:10.4172/jpb.1000056]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -9609,7 +9294,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001443
 name: ProteinExtractor:UsePhenyx
 def: "Flag indicating to include Phenyx scoring for calculation of the ProteinExtractor meta score." [PSI:PI]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -9617,7 +9301,6 @@ relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV t
 id: MS:1001444
 name: ProteinExtractor:PhenyxPeptideScoreThreshold
 def: "Only peptides with scores higher than that threshold are taken into account in Phenyx scoring for calculation of the ProteinExtractor meta score." [DOI:10.4172/jpb.1000056]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -9625,7 +9308,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001445
 name: ProteinExtractor:PhenyxUniqueScore
 def: "In the final result each protein must have at least one peptide above this Phenyx score threshold in ProteinExtractor meta score calculation." [DOI:10.4172/jpb.1000056]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -9633,7 +9315,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001446
 name: ProteinExtractor:PhenyxWeighting
 def: "Influence of Phenyx search engine in the process of merging the search engine specific protein lists into the global protein list of ProteinExtractor." [DOI:10.4172/jpb.1000056]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -9641,7 +9322,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001447
 name: prot:FDR threshold
 def: "False-discovery rate threshold for proteins." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002485 ! protein-level statistical threshold
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -9649,7 +9329,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001448
 name: pep:FDR threshold
 def: "False-discovery rate threshold for peptides." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002484 ! peptide-level statistical threshold
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -9657,7 +9336,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001449
 name: OMSSA e-value threshold
 def: "Threshold for OMSSA e-value for quality estimation." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002099 ! OMSSA input parameter
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -9671,7 +9349,6 @@ is_a: MS:1001011 ! search database details
 id: MS:1001451
 name: decoy DB generation algorithm
 def: "Name of algorithm used for decoy generation." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001450 ! decoy DB details
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -9764,7 +9441,6 @@ is_a: MS:1000560 ! mass spectrometer file format
 id: MS:1001467
 name: taxonomy: NCBI TaxID
 def: "This term is used if a NCBI TaxID is specified, e.g. 9606 for Homo sapiens." [PSI:PI]
-xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1001089 ! molecule taxonomy
 relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term
 
@@ -9772,7 +9448,6 @@ relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for t
 id: MS:1001468
 name: taxonomy: common name
 def: "This term is used if a common name is specified, e.g. human. Recommend using MS:1001467 (taxonomy: NCBI TaxID) where possible." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001089 ! molecule taxonomy
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -9780,7 +9455,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1001469
 name: taxonomy: scientific name
 def: "This term is used if a scientific name is specified, e.g. Homo sapiens. Recommend using MS:1001467 (taxonomy: NCBI TaxID) where possible." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001089 ! molecule taxonomy
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -9788,7 +9462,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1001470
 name: taxonomy: Swiss-Prot ID
 def: "This term is used if a swiss prot taxonomy id is specified, e.g. Human. Recommend using MS:1001467 (taxonomy: NCBI TaxID) where possible." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001089 ! molecule taxonomy
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -9927,7 +9600,6 @@ is_a: MS:1001456 ! analysis software
 id: MS:1001491
 name: percolator:Q value
 def: "Percolator:Q value." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -9935,7 +9607,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001492
 name: percolator:score
 def: "Percolator:score." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -9943,7 +9614,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001493
 name: percolator:PEP
 def: "Posterior error probability." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -9957,7 +9627,6 @@ is_a: MS:1002482 ! statistical threshold
 id: MS:1001495
 name: ProteinScape:SearchResultId
 def: "The SearchResultId of this peptide as SearchResult in the ProteinScape database." [PSI:PI]
-xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term
 
@@ -9965,7 +9634,6 @@ relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for t
 id: MS:1001496
 name: ProteinScape:SearchEventId
 def: "The SearchEventId of the SearchEvent in the ProteinScape database." [PSI:PI]
-xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term
 
@@ -9973,7 +9641,6 @@ relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for t
 id: MS:1001497
 name: ProteinScape:ProfoundProbability
 def: "The Profound probability score stored by ProteinScape." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -9981,7 +9648,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001498
 name: Profound:z value
 def: "The Profound z value." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -9989,7 +9655,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001499
 name: Profound:Cluster
 def: "The Profound cluster score." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -9997,7 +9662,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001500
 name: Profound:ClusterRank
 def: "The Profound cluster rank." [PSI:PI]
-xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term
 
@@ -10005,7 +9669,6 @@ relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for t
 id: MS:1001501
 name: MSFit:Mowse score
 def: "The MSFit Mowse score." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -10013,7 +9676,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001502
 name: Sonar:Score
 def: "The Sonar score." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -10021,7 +9683,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001503
 name: ProteinScape:PFFSolverExp
 def: "The ProteinSolver exp value stored by ProteinScape." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -10029,7 +9690,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001504
 name: ProteinScape:PFFSolverScore
 def: "The ProteinSolver score stored by ProteinScape." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -10037,7 +9697,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001505
 name: ProteinScape:IntensityCoverage
 def: "The intensity coverage of the identified peaks in the spectrum calculated by ProteinScape." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -10045,7 +9704,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001506
 name: ProteinScape:SequestMetaScore
 def: "The SEQUEST meta score calculated by ProteinScape from the original SEQUEST scores." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -10053,7 +9711,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001507
 name: ProteinExtractor:Score
 def: "The score calculated by ProteinExtractor." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -10091,7 +9748,6 @@ is_a: MS:1001019 ! database filtering
 id: MS:1001513
 name: DB sequence filter pattern
 def: "DB sequence filter pattern." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001512 ! Sequence database filters
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -10099,7 +9755,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1001514
 name: DB accession filter string
 def: "DB accession filter string." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001512 ! Sequence database filters
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -10161,7 +9816,6 @@ is_a: MS:1002307 ! fragmentation ion type
 id: MS:1001524
 name: fragment neutral loss
 def: "This term can describe a neutral loss m/z value that is lost from an ion." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001471 ! peptide modification details
 relationship: has_units UO:0000221 ! dalton
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
@@ -10170,7 +9824,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001525
 name: precursor neutral loss
 def: "This term can describe a neutral loss m/z value that is lost from an ion." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001471 ! peptide modification details
 relationship: has_units UO:0000221 ! dalton
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
@@ -10430,7 +10083,6 @@ is_a: MS:1001040 ! intermediate analysis format
 id: MS:1001568
 name: Scaffold:Peptide Probability
 def: "Scaffold peptide probability score." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -10438,7 +10090,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001569
 name: IdentityE Score
 def: "Waters IdentityE peptide score." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -10446,7 +10097,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001570
 name: ProteinLynx:Log Likelihood
 def: "ProteinLynx log likelihood score." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -10454,7 +10104,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001571
 name: ProteinLynx:Ladder Score
 def: "Waters ProteinLynx Ladder score." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -10462,7 +10111,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001572
 name: SpectrumMill:Score
 def: "Spectrum mill peptide score." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -10470,7 +10118,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001573
 name: SpectrumMill:SPI
 def: "SpectrumMill SPI score (%)." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -10484,7 +10131,6 @@ is_a: MS:1001060 ! quality estimation method details
 id: MS:1001575
 name: Scaffold: Minimum Peptide Count
 def: "Minimum number of peptides a protein must have to be accepted." [PSI:PI]
-xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1002106 ! Scaffold input parameter
 relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term
 
@@ -10492,7 +10138,6 @@ relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for t
 id: MS:1001576
 name: Scaffold: Minimum Protein Probability
 def: "Minimum protein probability a protein must have to be accepted." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002106 ! Scaffold input parameter
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -10500,7 +10145,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001577
 name: Scaffold: Minimum Peptide Probability
 def: "Minimum probability a peptide must have to be accepted for protein scoring." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002106 ! Scaffold input parameter
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -10508,7 +10152,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001578
 name: minimum number of enzymatic termini
 def: "Minimum number of enzymatic termini a peptide must have to be accepted." [PSI:PI]
-xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1002094 ! common search engine input parameter
 relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term
 
@@ -10516,7 +10159,6 @@ relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type fo
 id: MS:1001579
 name: Scaffold:Protein Probability
 def: "Scaffold protein probability score." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -10524,7 +10166,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001580
 name: SpectrumMill:Discriminant Score
 def: "Discriminant score from Agilent SpectrumMill software." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -10532,7 +10173,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001581
 name: FAIMS compensation voltage
 def: "The DC potential applied to the asymmetric waveform in FAIMS that compensates for the difference between high and low field mobility of an ion." [PSI:MS]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 synonym: "FAIMS CV" EXACT []
 is_a: MS:1002892 ! ion mobility attribute
 relationship: has_units UO:0000218 ! volt
@@ -10602,7 +10242,6 @@ is_a: MS:1001143 ! PSM-level search engine specific statistic
 id: MS:1001591
 name: anchor protein
 def: "A representative protein selected from a set of sequence same-set or spectrum same-set proteins." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001101 ! protein group or subset relationship
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -10610,7 +10249,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1001592
 name: family member protein
 def: "A protein with significant homology to another protein, but some distinguishing peptide matches." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001101 ! protein group or subset relationship
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -10624,7 +10262,6 @@ is_a: MS:1001101 ! protein group or subset relationship
 id: MS:1001594
 name: sequence same-set protein
 def: "A protein which is indistinguishable or equivalent to another protein, having matches to an identical set of peptide sequences." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001101 ! protein group or subset relationship
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -10632,7 +10269,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1001595
 name: spectrum same-set protein
 def: "A protein which is indistinguishable or equivalent to another protein, having matches to a set of peptide sequences that cannot be distinguished using the evidence in the mass spectra." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001101 ! protein group or subset relationship
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -10640,7 +10276,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1001596
 name: sequence sub-set protein
 def: "A protein with a sub-set of the peptide sequence matches for another protein, and no distinguishing peptide matches." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001101 ! protein group or subset relationship
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -10648,7 +10283,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1001597
 name: spectrum sub-set protein
 def: "A protein with a sub-set of the matched spectra for another protein, where the matches cannot be distinguished using the evidence in the mass spectra, and no distinguishing peptide matches." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001101 ! protein group or subset relationship
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -10656,7 +10290,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1001598
 name: sequence subsumable protein
 def: "A sequence same-set or sequence sub-set protein where the matches are distributed across two or more proteins." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001101 ! protein group or subset relationship
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -10664,7 +10297,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1001599
 name: spectrum subsumable protein
 def: "A spectrum same-set or spectrum sub-set protein where the matches are distributed across two or more proteins." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001101 ! protein group or subset relationship
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -10672,7 +10304,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1001600
 name: protein inference confidence category
 def: "Confidence category of inferred protein (conclusive, non conclusive, ambiguous group or indistinguishable)." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001101 ! protein group or subset relationship
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -10681,7 +10312,6 @@ id: MS:1001601
 name: ProteomeDiscoverer:Spectrum Files:Raw File names
 def: "OBSOLETE Name and location of the .raw file or files." [PSI:MS]
 comment: This term was made obsolete because it's recommended to use one of the 'mass spectrometer file format' terms (MS:1000560) instead.
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
@@ -10691,7 +10321,6 @@ id: MS:1001602
 name: ProteomeDiscoverer:SRF File Selector:SRF File Path
 def: "OBSOLETE Path and name of the .srf (SEQUEST Result Format) file." [PSI:MS]
 comment: This term was made obsolete. Use attribute in mzIdentML / mzQuantML instead.
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
@@ -10701,7 +10330,6 @@ id: MS:1001603
 name: ProteomeDiscoverer:Spectrum Selector:Ionization Source
 def: "OBSOLETE Ionization source (electro-, nano-, thermospray, electron impact, APCI, MALDI, FAB etc)." [PSI:MS]
 comment: This term was made obsolete because it's recommended to use one of the 'inlet type' (MS:1000007) or 'ionization type' (MS:1000008) terms instead.
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
@@ -10711,7 +10339,6 @@ id: MS:1001604
 name: ProteomeDiscoverer:Activation Type
 def: "OBSOLETE Fragmentation method used (CID, MPD, ECD, PQD, ETD, HCD, Any)." [PSI:MS]
 comment: This term was made obsolete because it's recommended to use one of the 'ionization type' terms (MS:1000008) instead.
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
@@ -10720,7 +10347,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1001605
 name: ProteomeDiscoverer:Spectrum Selector:Lower RT Limit
 def: "Lower retention-time limit." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
@@ -10729,7 +10355,6 @@ id: MS:1001606
 name: ProteomeDiscoverer:Mass Analyzer
 def: "OBSOLETE Type of mass spectrometer used (ITMS, FTMS, TOFMS, SQMS, TQMS, SectorMS)." [PSI:MS]
 comment: This term was made obsolete because it's recommended to use mass analyzer type (MS:1000443) instead.
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
@@ -10738,7 +10363,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1001607
 name: ProteomeDiscoverer:Max Precursor Mass
 def: "Maximum mass limit of a singly charged precursor ion." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
@@ -10746,7 +10370,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1001608
 name: ProteomeDiscoverer:Min Precursor Mass
 def: "Minimum mass limit of a singly charged precursor ion." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
@@ -10754,7 +10377,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1001609
 name: ProteomeDiscoverer:Spectrum Selector:Minimum Peak Count
 def: "Minimum number of peaks in a tandem mass spectrum that is allowed to pass the filter and to be subjected to further processing in the workflow." [PSI:MS]
-xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
@@ -10763,7 +10385,6 @@ id: MS:1001610
 name: ProteomeDiscoverer:MS Order
 def: "OBSOLETE Level of the mass spectrum (MS2 ... MS10)." [PSI:MS]
 comment: This term was made obsolete because it's recommended to use MS1 spectrum (MS:1000579) or MSn spectrum (MS:1000580) instead.
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
@@ -10773,7 +10394,6 @@ id: MS:1001611
 name: ProteomeDiscoverer:Polarity Mode
 def: "OBSOLETE Polarity mode (positive or negative)." [PSI:MS]
 comment: This term was made obsolete because it's recommended to use scan polarity (MS:1000465) instead.
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
@@ -10782,7 +10402,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1001612
 name: ProteomeDiscoverer:Spectrum Selector:Precursor Selection
 def: "Determines which precursor mass to use for a given MSn scan. This option applies only to higher-order MSn scans (n >= 3)." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -10790,7 +10409,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1001613
 name: ProteomeDiscoverer:SN Threshold
 def: "Signal-to-Noise ratio below which peaks are removed." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
@@ -10799,7 +10417,6 @@ id: MS:1001614
 name: ProteomeDiscoverer:Scan Type
 def: "OBSOLETE Scan type for the precursor ion (full, Single Ion Monitoring (SIM), Single Reaction Monitoring (SRM))." [PSI:MS]
 comment: This term was made obsolete because it's recommended to use MS1 spectrum (MS:1000579), MSn spectrum (MS:1000580), CRM spectrum (MS:1000581), SIM spectrum (MS:1000582) or SRM spectrum (MS:1000583) instead.
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
@@ -10808,7 +10425,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1001615
 name: ProteomeDiscoverer:Spectrum Selector:Total Intensity Threshold
 def: "Used to filter out tandem mass spectra that have a total intensity current(sum of the intensities of all peaks in a spectrum) below the specified value." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
@@ -10816,7 +10432,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1001616
 name: ProteomeDiscoverer:Spectrum Selector:Unrecognized Activation Type Replacements
 def: "Specifies the fragmentation method to use in the search algorithm if it is not included in the scan header." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -10824,7 +10439,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1001617
 name: ProteomeDiscoverer:Spectrum Selector:Unrecognized Charge Replacements
 def: "Specifies the charge state of the precursor ions, if it is not defined in the scan header." [PSI:MS]
-xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
@@ -10832,7 +10446,6 @@ relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 id: MS:1001618
 name: ProteomeDiscoverer:Spectrum Selector:Unrecognized Mass Analyzer Replacements
 def: "Specifies the mass spectrometer to use to produce the spectra, if it is not included in the scan header." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -10840,7 +10453,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1001619
 name: ProteomeDiscoverer:Spectrum Selector:Unrecognized MS Order Replacements
 def: "Specifies the MS scan order used to produce the product spectra, if it is not included in the scan header." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -10848,7 +10460,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1001620
 name: ProteomeDiscoverer:Spectrum Selector:Unrecognized Polarity Replacements
 def: "Specifies the polarity of the ions monitored if it is not included in the scan header." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -10856,7 +10467,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1001621
 name: ProteomeDiscoverer:Spectrum Selector:Upper RT Limit
 def: "Upper retention-time limit." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
@@ -10864,7 +10474,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1001622
 name: ProteomeDiscoverer:Non-Fragment Filter:Mass Window Offset
 def: "Specifies the size of the mass-to-charge ratio (m/z) window in daltons used to remove precursors." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
@@ -10872,7 +10481,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1001623
 name: ProteomeDiscoverer:Non-Fragment Filter:Maximum Neutral Loss Mass
 def: "Maximum allowed mass of a neutral loss." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
@@ -10880,7 +10488,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1001624
 name: ProteomeDiscoverer:Non-Fragment Filter:Remove Charge Reduced Precursor
 def: "Determines whether the charge-reduced precursor peaks found in an ETD or ECD spectrum are removed." [PSI:MS]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -10888,7 +10495,6 @@ relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV t
 id: MS:1001625
 name: ProteomeDiscoverer:Non-Fragment Filter:Remove Neutral Loss Peaks
 def: "Determines whether neutral loss peaks are removed from ETD and ECD spectra." [PSI:MS]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -10896,7 +10502,6 @@ relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV t
 id: MS:1001626
 name: ProteomeDiscoverer:Non-Fragment Filter:Remove Only Known Masses
 def: "Determines whether overtone peaks are removed from LTQ FT or LTQ FT Ultra ECD spectra." [PSI:MS]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -10904,7 +10509,6 @@ relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV t
 id: MS:1001627
 name: ProteomeDiscoverer:Non-Fragment Filter:Remove Precursor Overtones
 def: "Determines whether precursor overtone peaks in the spectrum are removed from the input spectrum." [PSI:MS]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -10912,7 +10516,6 @@ relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV t
 id: MS:1001628
 name: ProteomeDiscoverer:Non-Fragment Filter:Remove Precursor Peak
 def: "Determines whether precursor artifact peaks from the MS2 input spectra are removed." [PSI:MS]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -10920,7 +10523,6 @@ relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV t
 id: MS:1001629
 name: ProteomeDiscoverer:Spectrum Grouper:Allow Mass Analyzer Mismatch
 def: "Determines whether the fragment spectrum for scans with the same precursor mass is grouped, regardless of mass analyzer and activation type." [PSI:MS]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -10928,7 +10530,6 @@ relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV t
 id: MS:1001630
 name: ProteomeDiscoverer:Spectrum Grouper:Allow MS Order Mismatch
 def: "Determines whether spectra from different MS order scans can be grouped together." [PSI:MS]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -10937,7 +10538,6 @@ id: MS:1001631
 name: ProteomeDiscoverer:Spectrum Grouper:Max RT Difference
 def: "OBSOLETE Chromatographic window where precursors to be grouped must reside to be considered the same species." [PSI:MS]
 comment: This term was made obsolete because it's recommended to use retention time window width (MS:1001907) instead.
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
@@ -10946,7 +10546,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1001632
 name: ProteomeDiscoverer:Spectrum Grouper:Precursor Mass Criterion
 def: "Groups spectra measured within the given mass and retention-time tolerances into a single spectrum for analysis." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -10954,7 +10553,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1001633
 name: ProteomeDiscoverer:Xtract:Highest Charge
 def: "Highest charge state that is allowed for the deconvolution of multiply charged data." [PSI:MS]
-xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
@@ -10963,7 +10561,6 @@ id: MS:1001634
 name: ProteomeDiscoverer:Xtract:Highest MZ
 def: "OBSOLETE Highest mass-to-charge (mz) value for spectral peaks in the measured spectrum that are considered for Xtract." [PSI:MS]
 comment: This term was made obsolete because it's recommended to use scan window upper limit (MS:1000500) instead.
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
@@ -10972,7 +10569,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1001635
 name: ProteomeDiscoverer:Xtract:Lowest Charge
 def: "Lowest charge state that is allowed for the deconvolution of multiply charged data." [PSI:MS]
-xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
@@ -10981,7 +10577,6 @@ id: MS:1001636
 name: ProteomeDiscoverer:Xtract:Lowest MZ
 def: "OBSOLETE Lowest mass-to-charge (mz) value for spectral peaks in the measured spectrum that are considered for Xtract." [PSI:MS]
 comment: This term was made obsolete because it's recommended to use scan window lower limit (MS:1000501) instead.
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
@@ -10990,7 +10585,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1001637
 name: ProteomeDiscoverer:Xtract:Monoisotopic Mass Only
 def: "Determines whether the isotopic pattern, i.e. all isotopes of a mass are removed from the spectrum." [PSI:MS]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -10998,7 +10592,6 @@ relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV t
 id: MS:1001638
 name: ProteomeDiscoverer:Xtract:Overlapping Remainder
 def: "Fraction of the more abundant peak that an overlapping multiplet must exceed in order to be processed (deconvoluted)." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
@@ -11006,7 +10599,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1001639
 name: ProteomeDiscoverer:Xtract:Required Fitting Accuracy
 def: "Accuracy required for a pattern fit to be considered valid." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
@@ -11014,7 +10606,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1001640
 name: ProteomeDiscoverer:Xtract:Resolution At 400
 def: "Resolution at mass 400." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
@@ -11022,7 +10613,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1001641
 name: ProteomeDiscoverer:Lowest Charge State
 def: "Minimum charge state below which peptides are filtered out." [PSI:MS]
-xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
@@ -11030,7 +10620,6 @@ relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 id: MS:1001642
 name: ProteomeDiscoverer:Highest Charge State
 def: "Maximum charge above which peptides are filtered out." [PSI:MS]
-xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
@@ -11038,7 +10627,6 @@ relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 id: MS:1001643
 name: ProteomeDiscoverer:Spectrum Score Filter:Let Pass Above Scores
 def: "Determines whether spectra with scores above the threshold score are retained rather than filtered out." [PSI:MS]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -11046,7 +10634,6 @@ relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV t
 id: MS:1001644
 name: ProteomeDiscoverer:Dynamic Modification
 def: "Determine dynamic post-translational modifications (PTMs)." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -11054,7 +10641,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1001645
 name: ProteomeDiscoverer:Static Modification
 def: "Static Modification to all occurrences of a named amino acid." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -11063,7 +10649,6 @@ id: MS:1001646
 name: ProteomeDiscoverer:Mascot:Decoy Search
 def: "OBSOLETE Determines whether the Proteome Discoverer application searches an additional decoy database." [PSI:MS]
 comment: This term was made obsolete because it's recommended to use quality estimation with decoy database (MS:1001194) instead.
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
@@ -11072,7 +10657,6 @@ relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV t
 id: MS:1001647
 name: ProteomeDiscoverer:Mascot:Error tolerant Search
 def: "Determines whether to search error-tolerant." [PSI:MS]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -11080,7 +10664,6 @@ relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV t
 id: MS:1001648
 name: ProteomeDiscoverer:Mascot:Max MGF File Size
 def: "Maximum size of the .mgf (Mascot Generic Format) file in MByte." [PSI:MS]
-xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
@@ -11088,7 +10671,6 @@ relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 id: MS:1001649
 name: ProteomeDiscoverer:Mascot:Mascot Server URL
 def: "URL (Uniform resource Locator) of the Mascot server." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -11096,7 +10678,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1001650
 name: ProteomeDiscoverer:Mascot:Number of attempts to submit the search
 def: "Number of attempts to submit the Mascot search." [PSI:MS]
-xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
@@ -11104,7 +10685,6 @@ relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 id: MS:1001651
 name: ProteomeDiscoverer:Mascot:X Static Modification
 def: "Number of attempts to submit the Mascot search." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -11113,7 +10693,6 @@ id: MS:1001652
 name: ProteomeDiscoverer:Mascot:User Name
 def: "OBSOLETE Name of the user submitting the Mascot search." [PSI:MS]
 comment: This term was made obsolete because it's recommended to use researcher (MS:1001271) instead.
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
@@ -11122,7 +10701,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1001653
 name: ProteomeDiscoverer:Mascot:Time interval between attempts to submit a search
 def: "Time interval between attempts to submit a search in seconds." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -11131,7 +10709,6 @@ id: MS:1001654
 name: ProteomeDiscoverer:Enzyme Name
 def: "OBSOLETE Specifies the enzyme reagent used for protein digestion." [PSI:MS]
 comment: This term was made obsolete because it's recommended to use cleavage agent name (MS:1001045) instead.
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
@@ -11141,7 +10718,6 @@ id: MS:1001655
 name: ProteomeDiscoverer:Fragment Mass Tolerance
 def: "OBSOLETE Mass tolerance used for matching fragment peaks in Da or mmu." [PSI:MS]
 comment: This term was made obsolete because it's recommended to use search tolerance minus value (MS:1001413) or search tolerance plus value (MS:1001412) instead.
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
@@ -11150,7 +10726,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1001656
 name: Mascot:Instrument
 def: "Type of instrument used to acquire the data in the raw file." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002095 ! Mascot input parameter
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -11158,7 +10733,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1001657
 name: ProteomeDiscoverer:Maximum Missed Cleavage Sites
 def: "Maximum number of missed cleavage sites to consider during the digest." [PSI:MS]
-xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
@@ -11166,7 +10740,6 @@ relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 id: MS:1001658
 name: ProteomeDiscoverer:Mascot:Peptide CutOff Score
 def: "Minimum score in the IonScore column that each peptide must exceed in order to be reported." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
@@ -11175,7 +10748,6 @@ id: MS:1001659
 name: ProteomeDiscoverer:Precursor Mass Tolerance
 def: "OBSOLETE Mass window for which precursor ions are considered to be the same species." [PSI:MS]
 comment: This term was made obsolete because it's recommended to use search tolerance minus value (MS:1001413) or search tolerance plus value (MS:1001412) instead.
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
@@ -11184,7 +10756,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1001660
 name: ProteomeDiscoverer:Mascot:Protein CutOff Score
 def: "Minimum protein score in the IonScore column that each protein must exceed in order to be reported." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
@@ -11193,7 +10764,6 @@ id: MS:1001661
 name: ProteomeDiscoverer:Protein Database
 def: "OBSOLETE Database to use in the search (configured on the Mascot server)." [PSI:MS]
 comment: This term was made obsolete because it's recommended to use database name (MS:1001013) instead.
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
@@ -11202,7 +10772,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1001662
 name: ProteomeDiscoverer:Mascot:Protein Relevance Factor
 def: "Specifies a factor that is used in calculating a threshold that determines whether a protein appears in the results report." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
@@ -11210,7 +10779,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1001663
 name: ProteomeDiscoverer:Target FDR Relaxed
 def: "Specifies the relaxed target false discovery rate (FDR, 0.0 - 1.0) for peptide hits with moderate confidence." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
@@ -11218,7 +10786,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1001664
 name: ProteomeDiscoverer:Target FDR Strict
 def: "Specifies the strict target false discovery rate (FDR, 0.0 - 1.0) for peptide hits with high confidence." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
@@ -11227,7 +10794,6 @@ id: MS:1001665
 name: ProteomeDiscoverer:Mascot:Taxonomy
 def: "OBSOLETE Limits searches to entries from a particular species or group of species." [PSI:MS]
 comment: This term was made obsolete because it's recommended to use taxonomy: scientific name (MS:1001469) instead.
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
@@ -11237,7 +10803,6 @@ id: MS:1001666
 name: ProteomeDiscoverer:Use Average Precursor Mass
 def: "OBSOLETE Use average mass for the precursor." [PSI:MS]
 comment: This term was made obsolete because it's recommended to use parent mass type average (MS:1001212) instead.
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
@@ -11247,7 +10812,6 @@ id: MS:1001667
 name: Mascot:use MudPIT scoring
 def: "OBSOLETE Determines whether to use MudPIT or normal scoring." [PSI:MS]
 comment: This term was made obsolete because it's recommended to use Mascot:ProteinScoringMethod (MS:1001318) instead.
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002095 ! Mascot input parameter
 is_obsolete: true
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
@@ -11256,7 +10820,6 @@ relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV t
 id: MS:1001668
 name: ProteomeDiscoverer:Absolute XCorr Threshold
 def: "Minimum cross-correlation threshold that determines whether peptides in an .srf file are imported." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
@@ -11264,7 +10827,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1001669
 name: ProteomeDiscoverer:SEQUEST:Calculate Probability Score
 def: "Determines whether to calculate a probability score for every peptide match." [PSI:MS]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -11272,7 +10834,6 @@ relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV t
 id: MS:1001670
 name: ProteomeDiscoverer:SEQUEST:CTerminal Modification
 def: "Dynamic C-terminal modification that is used during the search." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -11280,7 +10841,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1001671
 name: ProteomeDiscoverer:SEQUEST:Fragment Ion Cutoff Percentage
 def: "Percentage of the theoretical ions that must be found in order for a peptide to be scored and retained." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
@@ -11288,7 +10848,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1001672
 name: ProteomeDiscoverer:SEQUEST:Max Identical Modifications Per Peptide
 def: "Maximum number of identical modifications that a single peptide can have." [PSI:MS]
-xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
@@ -11296,7 +10855,6 @@ relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 id: MS:1001673
 name: ProteomeDiscoverer:Max Modifications Per Peptide
 def: "Maximum number of different modifications that a peptide can have, e.g. because of steric hindrance." [PSI:MS]
-xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
@@ -11304,7 +10862,6 @@ relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 id: MS:1001674
 name: ProteomeDiscoverer:SEQUEST:Maximum Peptides Considered
 def: "Maximum number of peptides that are searched and scored per spectrum." [PSI:MS]
-xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
@@ -11312,7 +10869,6 @@ relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 id: MS:1001675
 name: ProteomeDiscoverer:Maximum Peptides Output
 def: "Maximum number of peptide matches reported per spectrum." [PSI:MS]
-xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
@@ -11320,7 +10876,6 @@ relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 id: MS:1001676
 name: ProteomeDiscoverer:Maximum Protein References Per Peptide
 def: "Maximum number of proteins that a single identified peptide can be associated with during protein assembly." [PSI:MS]
-xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
@@ -11328,7 +10883,6 @@ relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 id: MS:1001677
 name: ProteomeDiscoverer:SEQUEST:NTerminal Modification
 def: "Dynamic N-terminal modification that is used during the search." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -11336,7 +10890,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1001678
 name: ProteomeDiscoverer:Peptide CTerminus
 def: "Static modification for the C terminal of the peptide used during the search." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -11344,7 +10897,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1001679
 name: ProteomeDiscoverer:Peptide NTerminus
 def: "Static modification for the N terminal of the peptide used during the search." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -11352,7 +10904,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1001680
 name: ProteomeDiscoverer:SEQUEST:Peptide Relevance Factor
 def: "Specifies a factor to apply to the protein score." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
@@ -11360,7 +10911,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1001681
 name: ProteomeDiscoverer:Protein Relevance Threshold
 def: "Specifies a peptide threshold that determines whether the protein that it is a part of is scored and retained in the report." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
@@ -11369,7 +10919,6 @@ id: MS:1001682
 name: ProteomeDiscoverer:Search Against Decoy Database
 def: "OBSOLETE Determines whether the Proteome Discoverer application searches against a decoy database." [PSI:MS]
 comment: This term was made obsolete because it's recommended to use quality estimation with decoy database (MS:1001194) instead.
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
@@ -11378,7 +10927,6 @@ relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV t
 id: MS:1001683
 name: ProteomeDiscoverer:SEQUEST:Use Average Fragment Masses
 def: "Use average masses for the fragments." [PSI:MS]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -11386,7 +10934,6 @@ relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV t
 id: MS:1001684
 name: ProteomeDiscoverer:Use Neutral Loss a Ions
 def: "Determines whether a ions with neutral loss are used for spectrum matching." [PSI:MS]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -11394,7 +10941,6 @@ relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV t
 id: MS:1001685
 name: ProteomeDiscoverer:Use Neutral Loss b Ions
 def: "Determines whether b ions with neutral loss are used for spectrum matching." [PSI:MS]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -11402,7 +10948,6 @@ relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV t
 id: MS:1001686
 name: ProteomeDiscoverer:Use Neutral Loss y Ions
 def: "Determines whether y ions with neutral loss are used for spectrum matching." [PSI:MS]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -11410,7 +10955,6 @@ relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV t
 id: MS:1001687
 name: ProteomeDiscoverer:Use Neutral Loss z Ions
 def: "Determines whether z ions with neutral loss are used for spectrum matching." [PSI:MS]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -11418,7 +10962,6 @@ relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV t
 id: MS:1001688
 name: ProteomeDiscoverer:SEQUEST:Weight of a Ions
 def: "Uses a ions for spectrum matching with this relative factor." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
@@ -11426,7 +10969,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1001689
 name: ProteomeDiscoverer:SEQUEST:Weight of b Ions
 def: "Uses b ions for spectrum matching with this relative factor." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
@@ -11434,7 +10976,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1001690
 name: ProteomeDiscoverer:SEQUEST:Weight of c Ions
 def: "Uses c ions for spectrum matching with this relative factor." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
@@ -11442,7 +10983,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1001691
 name: ProteomeDiscoverer:SEQUEST:Weight of d Ions
 def: "Uses c ions for spectrum matching with this relative factor." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
@@ -11450,7 +10990,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1001692
 name: ProteomeDiscoverer:SEQUEST:Weight of v Ions
 def: "Uses c ions for spectrum matching with this relative factor." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
@@ -11458,7 +10997,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1001693
 name: ProteomeDiscoverer:SEQUEST:Weight of w Ions
 def: "Uses c ions for spectrum matching with this relative factor." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
@@ -11466,7 +11004,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1001694
 name: ProteomeDiscoverer:SEQUEST:Weight of x Ions
 def: "Uses x ions for spectrum matching with this relative factor." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
@@ -11474,7 +11011,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1001695
 name: ProteomeDiscoverer:SEQUEST:Weight of y Ions
 def: "Uses y ions for spectrum matching with this relative factor." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
@@ -11482,7 +11018,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1001696
 name: ProteomeDiscoverer:SEQUEST:Weight of z Ions
 def: "Uses z ions for spectrum matching with this relative factor." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
@@ -11490,7 +11025,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1001697
 name: ProteomeDiscoverer:ZCore:Protein Score Cutoff
 def: "Sets a minimum protein score that each protein must exceed in order to be reported." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
@@ -11498,7 +11032,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1001698
 name: ProteomeDiscoverer:Reporter Ions Quantizer:Integration Method
 def: "Specifies which peak to select if more than one peak is found inside the integration window." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -11506,7 +11039,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1001699
 name: ProteomeDiscoverer:Reporter Ions Quantizer:Integration Window Tolerance
 def: "Specifies the mass-to-charge window that enables one to look for the reporter peaks." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
@@ -11514,7 +11046,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1001700
 name: ProteomeDiscoverer:Reporter Ions Quantizer:Quantitation Method
 def: "Quantitation method for isobarically labeled quantitation." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -11523,7 +11054,6 @@ id: MS:1001701
 name: ProteomeDiscoverer:Spectrum Exporter:Export Format
 def: "OBSOLETE Format of the exported spectra (dta, mgf or mzData)." [PSI:MS]
 comment: This term was made obsolete because it's recommended to use one of the 'mass spectrometer file format' terms (MS:1000560) instead.
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
@@ -11532,7 +11062,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1001702
 name: ProteomeDiscoverer:Spectrum Exporter:File name
 def: "Name of the output file that contains the exported data." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -11540,7 +11069,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1001703
 name: ProteomeDiscoverer:Search Modifications Only For Identified Proteins
 def: "Influences the modifications search." [PSI:MS]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -11548,7 +11076,6 @@ relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV t
 id: MS:1001704
 name: ProteomeDiscoverer:SEQUEST:Std High Confidence XCorr Charge1
 def: "Standard high confidence XCorr parameter for charge = 1." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
@@ -11556,7 +11083,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1001705
 name: ProteomeDiscoverer:SEQUEST:Std High Confidence XCorr Charge2
 def: "Standard high confidence XCorr parameter for charge = 2." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
@@ -11564,7 +11090,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1001706
 name: ProteomeDiscoverer:SEQUEST:Std High Confidence XCorr Charge3
 def: "Standard high confidence XCorr parameter for charge = 3." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
@@ -11572,7 +11097,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1001707
 name: ProteomeDiscoverer:SEQUEST:Std High Confidence XCorr Charge4
 def: "Standard high confidence XCorr parameter for charge >= 4." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
@@ -11580,7 +11104,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1001708
 name: ProteomeDiscoverer:SEQUEST:Std Medium Confidence XCorr Charge1
 def: "Standard medium confidence XCorr parameter for charge = 1." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
@@ -11588,7 +11111,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1001709
 name: ProteomeDiscoverer:SEQUEST:Std Medium Confidence XCorr Charge2
 def: "Standard medium confidence XCorr parameter for charge = 2." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
@@ -11596,7 +11118,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1001710
 name: ProteomeDiscoverer:SEQUEST:Std Medium Confidence XCorr Charge3
 def: "Standard medium confidence XCorr parameter for charge = 3." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
@@ -11604,7 +11125,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1001711
 name: ProteomeDiscoverer:SEQUEST:Std Medium Confidence XCorr Charge4
 def: "Standard medium confidence XCorr parameter for charge >= 4." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
@@ -11612,7 +11132,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1001712
 name: ProteomeDiscoverer:SEQUEST:FT High Confidence XCorr Charge1
 def: "FT high confidence XCorr parameter for charge = 1." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
@@ -11620,7 +11139,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1001713
 name: ProteomeDiscoverer:SEQUEST:FT High Confidence XCorr Charge2
 def: "FT high confidence XCorr parameter for charge = 2." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
@@ -11628,7 +11146,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1001714
 name: ProteomeDiscoverer:SEQUEST:FT High Confidence XCorr Charge3
 def: "FT high confidence XCorr parameter for charge = 3." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
@@ -11636,7 +11153,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1001715
 name: ProteomeDiscoverer:SEQUEST:FT High Confidence XCorr Charge4
 def: "FT high confidence XCorr parameter for charge >= 4." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
@@ -11644,7 +11160,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1001716
 name: ProteomeDiscoverer:SEQUEST:FT Medium Confidence XCorr Charge1
 def: "FT medium confidence XCorr parameter for charge = 1." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
@@ -11652,7 +11167,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1001717
 name: ProteomeDiscoverer:SEQUEST:FT Medium Confidence XCorr Charge2
 def: "FT medium confidence XCorr parameter for charge = 2." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
@@ -11660,7 +11174,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1001718
 name: ProteomeDiscoverer:SEQUEST:FT Medium Confidence XCorr Charge3
 def: "FT medium confidence XCorr parameter for charge = 3." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
@@ -11668,7 +11181,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1001719
 name: ProteomeDiscoverer:SEQUEST:FT Medium Confidence XCorr Charge4
 def: "FT medium confidence XCorr parameter for charge >= 4." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
@@ -11677,7 +11189,6 @@ id: MS:1001720
 name: ProteomeDiscoverer:1. Dynamic Modification
 def: "OBSOLETE ProteomeDiscoverer's 1st dynamic post-translational modification (PTM) input parameter." [PSI:PI]
 comment: This term was made obsolete because it's recommended to use ProteomeDiscoverer:Dynamic Modification (MS:1001644) instead.
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
@@ -11687,7 +11198,6 @@ id: MS:1001721
 name: ProteomeDiscoverer:2. Dynamic Modification
 def: "OBSOLETE ProteomeDiscoverer's 2nd dynamic post-translational modification (PTM) input parameter." [PSI:PI]
 comment: This term was made obsolete because it's recommended to use ProteomeDiscoverer:Dynamic Modification (MS:1001644) instead.
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
@@ -11697,7 +11207,6 @@ id: MS:1001722
 name: ProteomeDiscoverer:3. Dynamic Modification
 def: "OBSOLETE ProteomeDiscoverer's 3rd dynamic post-translational modification (PTM) input parameter." [PSI:PI]
 comment: This term was made obsolete because it's recommended to use ProteomeDiscoverer:Dynamic Modification (MS:1001644) instead.
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
@@ -11707,7 +11216,6 @@ id: MS:1001723
 name: ProteomeDiscoverer:4. Dynamic Modification
 def: "OBSOLETE ProteomeDiscoverer's 4th dynamic post-translational modification (PTM) input parameter." [PSI:PI]
 comment: This term was made obsolete because it's recommended to use ProteomeDiscoverer:Dynamic Modification (MS:1001644) instead.
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
@@ -11716,7 +11224,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1001724
 name: ProteomeDiscoverer:Static Modification for X
 def: "Static Modification for X." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -11724,7 +11231,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1001725
 name: ProteomeDiscoverer:Initial minimal peptide probability
 def: "Minimal initial peptide probability to contribute to analysis." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
@@ -11732,7 +11238,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1001726
 name: ProteomeDiscoverer:Minimal peptide probability
 def: "Minimum adjusted peptide probability contributing to protein probability." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
@@ -11740,7 +11245,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1001727
 name: ProteomeDiscoverer:Minimal peptide weight
 def: "Minimum peptide weight contributing to protein probability." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
@@ -11748,7 +11252,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1001728
 name: ProteomeDiscoverer:Number of input1 spectra
 def: "Number of spectra from 1+ precursor ions." [PSI:MS]
-xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
@@ -11756,7 +11259,6 @@ relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 id: MS:1001729
 name: ProteomeDiscoverer:Number of input2 spectra
 def: "Number of spectra from 2+ precursor ions." [PSI:MS]
-xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
@@ -11764,7 +11266,6 @@ relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 id: MS:1001730
 name: ProteomeDiscoverer:Number of input3 spectra
 def: "Number of spectra from 3+ precursor ions." [PSI:MS]
-xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
@@ -11772,7 +11273,6 @@ relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 id: MS:1001731
 name: ProteomeDiscoverer:Number of input4 spectra
 def: "Number of spectra from 4+ precursor ions." [PSI:MS]
-xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
@@ -11780,7 +11280,6 @@ relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 id: MS:1001732
 name: ProteomeDiscoverer:Number of input5 spectra
 def: "Number of spectra from 5+ precursor ions." [PSI:MS]
-xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
@@ -11788,7 +11287,6 @@ relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 id: MS:1001733
 name: ProteomeDiscoverer:Number of predicted correct proteins
 def: "Total number of predicted correct protein ids (sum of probabilities)." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
@@ -11797,7 +11295,6 @@ id: MS:1001734
 name: ProteomeDiscoverer:Organism
 def: "OBSOLETE Sample organism (used for annotation purposes)." [PSI:MS]
 comment: This term was made obsolete because it's recommended to use taxonomy: scientific name (MS:1001469) instead.
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
@@ -11807,7 +11304,6 @@ id: MS:1001735
 name: ProteomeDiscoverer:Reference Database
 def: "OBSOLETE Full path database name." [PSI:MS]
 comment: This term was made obsolete. Use attribute in mzIdentML / mzQuantML instead.
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
@@ -11816,7 +11312,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1001736
 name: ProteomeDiscoverer:Residue substitution list
 def: "Residues considered equivalent when comparing peptides." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -11825,7 +11320,6 @@ id: MS:1001737
 name: ProteomeDiscoverer:Source file extension
 def: "OBSOLETE File type (if not pepXML)." [PSI:MS]
 comment: This term was made obsolete because it's recommended to use mass spectrometer file format (MS:1000560) instead.
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
@@ -11835,7 +11329,6 @@ id: MS:1001738
 name: ProteomeDiscoverer:Source Files
 def: "OBSOLETE Input pepXML files." [PSI:MS]
 comment: This term was made obsolete because it's recommended to use pepXML file (MS:1001421) instead.
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
@@ -11845,7 +11338,6 @@ id: MS:1001739
 name: ProteomeDiscoverer:Source Files old
 def: "OBSOLETE Input pepXML files (old)." [PSI:MS]
 comment: This term was made obsolete because it's recommended to use pepXML file (MS:1001421) instead.
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
@@ -11854,7 +11346,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1001740
 name: ProteomeDiscoverer:WinCyg reference database
 def: "Windows full path for database." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -11862,7 +11353,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1001741
 name: ProteomeDiscoverer:WinCyg source files
 def: "Windows pepXML file names." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -11876,7 +11366,6 @@ is_a: MS:1000494 ! Thermo Scientific instrument model
 id: MS:1001743
 name: ProteomeDiscoverer:Mascot:Weight of A Ions
 def: "Determines if to use A ions for spectrum matching." [PSI:MS]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -11884,7 +11373,6 @@ relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV t
 id: MS:1001744
 name: ProteomeDiscoverer:Mascot:Weight of B Ions
 def: "Determines if to use B ions for spectrum matching." [PSI:MS]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -11892,7 +11380,6 @@ relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV t
 id: MS:1001745
 name: ProteomeDiscoverer:Mascot:Weight of C Ions
 def: "Determines if to use C ions for spectrum matching." [PSI:MS]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -11900,7 +11387,6 @@ relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV t
 id: MS:1001746
 name: ProteomeDiscoverer:Mascot:Weight of D Ions
 def: "Determines if to use D ions for spectrum matching." [PSI:MS]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -11908,7 +11394,6 @@ relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV t
 id: MS:1001747
 name: ProteomeDiscoverer:Mascot:Weight of V Ions
 def: "Determines if to use V ions for spectrum matching." [PSI:MS]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -11916,7 +11401,6 @@ relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV t
 id: MS:1001748
 name: ProteomeDiscoverer:Mascot:Weight of W Ions
 def: "Determines if to use W ions for spectrum matching." [PSI:MS]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -11924,7 +11408,6 @@ relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV t
 id: MS:1001749
 name: ProteomeDiscoverer:Mascot:Weight of X Ions
 def: "Determines if to use X ions for spectrum matching." [PSI:MS]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -11932,7 +11415,6 @@ relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV t
 id: MS:1001750
 name: ProteomeDiscoverer:Mascot:Weight of Y Ions
 def: "Determines if to use Y ions for spectrum matching." [PSI:MS]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -11940,7 +11422,6 @@ relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV t
 id: MS:1001751
 name: ProteomeDiscoverer:Mascot:Weight of Z Ions
 def: "Determines if to use z ions for spectrum matching." [PSI:MS]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -11948,7 +11429,6 @@ relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV t
 id: MS:1001752
 name: ProteomeDiscoverer:Spectrum Selector:Use New Precursor Reevaluation
 def: "Determines if to use precursor reevaluation." [PSI:MS]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -11956,7 +11436,6 @@ relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV t
 id: MS:1001753
 name: ProteomeDiscoverer:Spectrum Selector:SN Threshold FTonly
 def: "Signal-to-Noise ratio below which peaks are removed (in FT mode only)." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
@@ -11964,7 +11443,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1001754
 name: ProteomeDiscoverer:Mascot:Please Do not Touch this
 def: "Unknown Mascot parameter which ProteomeDiscoverer uses for mascot searches." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -11972,7 +11450,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1001755
 name: contact phone number
 def: "Phone number of the contact person or organization." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000585 ! contact attribute
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -11980,7 +11457,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1001756
 name: contact fax number
 def: "Fax number for the contact person or organization." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000585 ! contact attribute
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -11988,7 +11464,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1001757
 name: contact toll-free phone number
 def: "Toll-free phone number of the contact person or organization." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000585 ! contact attribute
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -11996,7 +11471,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1001758
 name: Mascot:SigThresholdType
 def: "Significance threshold type used in Mascot reporting (either 'identity' or 'homology')." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002095 ! Mascot input parameter
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -12004,7 +11478,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1001759
 name: Mascot:ProteinGrouping
 def: "Strategy used by Mascot to group proteins with same peptide matches (one of 'none', 'Occam's razor' or 'family clustering')." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002095 ! Mascot input parameter
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -12012,7 +11485,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1001760
 name: Percolator:features
 def: "List of Percolator features that were used in processing the peptide matches. Typical Percolator features are 'retentionTime', 'dM', 'mScore', 'lgDScore', 'mrCalc', 'charge' and 'dMppm'." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002107 ! Percolator input parameter
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -12212,7 +11684,6 @@ is_a: MS:1000126 ! Waters instrument model
 id: MS:1001793
 name: Mascot:PreferredTaxonomy
 def: "NCBI TaxID taxonomy ID to prefer when two or more proteins match the same set of peptides or when protein entry in database represents multiple sequences." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002095 ! Mascot input parameter
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -12307,7 +11778,6 @@ is_a: MS:1001806 ! quantification object attribute
 id: MS:1001808
 name: technical replicate
 def: "The study variable is 'technical replicate'. The string value denotes the category of technical replicate, e.g. 'run generated from same sample'." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001807 ! study variable attribute
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -12345,7 +11815,6 @@ is_a: MS:1001807 ! study variable attribute
 id: MS:1001814
 name: generic experimental condition
 def: "The experimental condition is given in the value of this term." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001807 ! study variable attribute
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -12353,7 +11822,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1001815
 name: time series, time point X
 def: "The experimental design followed a time series design. The time point of this run is given in the value of this term." [PSI:MS]
-xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1001807 ! study variable attribute
 relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
@@ -12361,7 +11829,6 @@ relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 id: MS:1001816
 name: dilution series, concentration X
 def: "The experimental design followed a dilution series design. The concentration of this run is given in the value of this term." [PSI:MS]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001807 ! study variable attribute
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -12441,7 +11908,6 @@ is_a: MS:1001806 ! quantification object attribute
 id: MS:1001829
 name: SRM transition ID
 def: "Identifier for an SRM transition in an external document describing additional information about the transition." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001828 ! feature attribute
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -12462,7 +11928,6 @@ is_a: MS:1000752 ! TOPP software
 id: MS:1001832
 name: quantitation software comment or customizations
 def: "Quantitation software comment or any customizations to the default setup of the software." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001129 ! quantification information
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -12512,7 +11977,6 @@ is_a: MS:1001833 ! quantitation analysis summary
 id: MS:1001840
 name: LC-MS feature intensity
 def: "Maximum peak intensity of the LC-MS feature." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002735 ! feature-level quantification datatype
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -12520,7 +11984,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001841
 name: LC-MS feature volume
 def: "Real (intensity times area) volume of the LC-MS feature." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002735 ! feature-level quantification datatype
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -12528,7 +11991,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001842
 name: sequence-level spectral count
 def: "The number of MS2 spectra identified for a raw peptide sequence without PTMs and charge state in spectral counting." [PSI:PI]
-xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002737 ! peptide-level quantification datatype
 relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
@@ -12536,7 +11998,6 @@ relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 id: MS:1001843
 name: MS1 feature maximum intensity
 def: "Maximum intensity of MS1 feature." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002735 ! feature-level quantification datatype
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -12544,7 +12005,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001844
 name: MS1 feature area
 def: "Area of MS1 feature." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002735 ! feature-level quantification datatype
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -12553,7 +12013,6 @@ id: MS:1001845
 name: peak area
 def: "OBSOLETE Area of MS1 peak (e.g. SILAC, 15N)." [PSI:PI]
 comment: This term was made obsolete because it was a duplication of MS:1001844.
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
 is_obsolete: true
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
@@ -12562,7 +12021,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001846
 name: isotopic pattern area
 def: "Area of all peaks belonging to the isotopic pattern of light or heavy peak (e.g. 15N)." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -12570,7 +12028,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001847
 name: reporter ion intensity
 def: "Intensity of MS2 reporter ion (e.g. iTraq)." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -12585,7 +12042,6 @@ id: MS:1001849
 name: sum of MatchedFeature values
 def: "OBSOLETE Peptide quantification value calculated as sum of MatchedFeature quantification values." [PSI:PI]
 comment: This term was made obsolete because the concept MatchedFeature was dropped.
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002735 ! feature-level quantification datatype
 is_obsolete: true
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
@@ -12594,7 +12050,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001850
 name: normalized peptide value
 def: "Normalized peptide value." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002737 ! peptide-level quantification datatype
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -12602,7 +12057,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001851
 name: protein value: sum of peptide values
 def: "Protein quantification value calculated as sum of peptide values." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002738 ! protein-level quantification datatype
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -12610,7 +12064,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001852
 name: normalized protein value
 def: "Normalized protein value." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002738 ! protein-level quantification datatype
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -12618,7 +12071,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001853
 name: max fold change
 def: "Global datatype: Maximum of all pair-wise fold changes of group means (e.g. Progenesis)." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -12626,7 +12078,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001854
 name: ANOVA p-value
 def: "Global datatype: p-value of ANOVA of group means (e.g. Progenesis)." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002072 ! p-value
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -12634,7 +12085,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001855
 name: t-test p-value
 def: "P-value of t-Test of two groups." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002072 ! p-value
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -12642,7 +12092,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001856
 name: reporter ion raw value
 def: "Intensity (or area) of MS2 reporter ion (e.g. iTraq)." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -12650,7 +12099,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001857
 name: reporter ion normalized value
 def: "Normalized value of MS2 reporter ion (e.g. iTraq)." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -12658,7 +12106,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001858
 name: XIC area
 def: "Area of the extracted ion chromatogram (e.g. of a transition in SRM)." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -12666,7 +12113,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001859
 name: normalized XIC area
 def: "Normalized area of the extracted ion chromatogram (e.g. of a transition in SRM)." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -12674,7 +12120,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001860
 name: protein value: mean of peptide ratios
 def: "Protein quantification value calculated as mean of peptide ratios." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002738 ! protein-level quantification datatype
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -12724,7 +12169,6 @@ is_a: MS:1001861 ! quantification data processing
 id: MS:1001868
 name: distinct peptide-level q-value
 def: "Estimation of the q-value for distinct peptides once redundant identifications of the same peptide have been removed (id est multiple PSMs, possibly with different mass modifications, mapping to the same sequence have been collapsed to one entry)." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002484 ! peptide-level statistical threshold
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
@@ -12733,7 +12177,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001869
 name: protein-level q-value
 def: "Estimation of the q-value for proteins." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001116 ! single protein identification statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
@@ -12742,7 +12185,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001870
 name: peptide sequence-level p-value
 def: "Estimation of the p-value for distinct peptides once redundant identifications of the same peptide have been removed (id est multiple PSMs have been collapsed to one entry)." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001092 ! peptide sequence-level identification statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
@@ -12751,7 +12193,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001871
 name: protein-level p-value
 def: "Estimation of the p-value for proteins." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001116 ! single protein identification statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
@@ -12760,7 +12201,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001872
 name: peptide sequence-level e-value
 def: "Estimation of the e-value for distinct peptides once redundant identifications of the same peptide have been removed (id est multiple PSMs have been collapsed to one entry)." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001092 ! peptide sequence-level identification statistic
 relationship: has_domain MS:1002306 ! value greater than zero
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
@@ -12769,7 +12209,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001873
 name: protein-level e-value
 def: "Estimation of the e-value for proteins." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001116 ! single protein identification statistic
 relationship: has_domain MS:1002306 ! value greater than zero
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
@@ -12779,7 +12218,6 @@ id: MS:1001874
 name: FDRScore
 def: "OBSOLETE A smoothing of the distribution of q-values calculated for PSMs from individual search engines, such that ordering of result quality is maintained and all FDRScore values are guaranteed to have a value > 0." [PMID:19253293]
 comment: This term was made obsolete because it was split into the more specific terms for PSM-level FDRScore (1002355), distinct peptide-level FDRScore (MS:1002360), protein-level FDRScore (MS:1002365) and protein group-level FDRScore (MS:1002374).
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1001153 ! search engine specific score
 is_obsolete: true
@@ -12789,7 +12227,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001875
 name: modification motif
 def: "The regular expression describing the sequence motif for a modification." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001056 ! modification specificity rule
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -12818,7 +12255,6 @@ is_a: MS:1001558 ! MALDI Solutions
 id: MS:1001879
 name: offset voltage
 def: "The potential difference between two adjacent interface voltages affecting in-source collision induced dissociation." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000482 ! source attribute
 relationship: has_units UO:0000218 ! volt
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
@@ -12845,7 +12281,6 @@ relationship: part_of MS:1000908 ! transition
 id: MS:1001883
 name: coefficient of variation
 def: "Variation of a set of signal measurements calculated as the standard deviation relative to the mean." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1001882 ! transition validation attribute
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
@@ -12853,7 +12288,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1001884
 name: signal-to-noise ratio
 def: "Unitless number providing the ratio of the total measured intensity of a signal relative to the estimated noise level for that signal." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1001882 ! transition validation attribute
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
@@ -12861,7 +12295,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1001885
 name: command-line parameters
 def: "Parameters string passed to a command-line interface software application, omitting the executable name." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000630 ! data processing parameter
 is_a: MS:1003201 ! library provenance attribute
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
@@ -12895,7 +12328,6 @@ is_a: MS:1002363 ! search engine specific score for proteins
 id: MS:1001890
 name: Progenesis:protein normalised abundance
 def: "The data type normalised abundance for proteins produced by Progenesis LC-MS." [PSI:MS]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002738 ! protein-level quantification datatype
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -12903,7 +12335,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001891
 name: Progenesis:peptide normalised abundance
 def: "The data type normalised abundance for peptides produced by Progenesis LC-MS." [PSI:MS]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002737 ! peptide-level quantification datatype
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -12911,7 +12342,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001892
 name: Progenesis:protein raw abundance
 def: "The data type raw abundance for proteins produced by Progenesis LC-MS." [PSI:MS]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002738 ! protein-level quantification datatype
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -12919,7 +12349,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001893
 name: Progenesis:peptide raw abundance
 def: "The data type raw abundance for peptide produced by Progenesis LC-MS." [PSI:MS]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002737 ! peptide-level quantification datatype
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -12927,7 +12356,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001894
 name: Progenesis:confidence score
 def: "The data type confidence score produced by Progenesis LC-MS." [PSI:MS]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -12935,7 +12363,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001895
 name: Progenesis:peptide count
 def: "The data type peptide count produced by Progenesis LC-MS." [PSI:MS]
-xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002737 ! peptide-level quantification datatype
 relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
@@ -12943,7 +12370,6 @@ relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 id: MS:1001896
 name: Progenesis:feature intensity
 def: "The data type feature intensity produced by Progenesis LC-MS." [PSI:MS]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002735 ! feature-level quantification datatype
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -12951,7 +12377,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001897
 name: MaxQuant:peptide counts (unique)
 def: "The data type peptide counts (unique) produced by MaxQuant." [PSI:MS]
-xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002737 ! peptide-level quantification datatype
 relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
@@ -12959,7 +12384,6 @@ relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 id: MS:1001898
 name: MaxQuant:peptide counts (all)
 def: "The data type peptide counts (all) produced by MaxQuant." [PSI:MS]
-xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002737 ! peptide-level quantification datatype
 relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
@@ -12967,7 +12391,6 @@ relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 id: MS:1001899
 name: MaxQuant:peptide counts (razor+unique)
 def: "The data type peptide counts (razor+unique) produced by MaxQuant." [PSI:MS]
-xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002737 ! peptide-level quantification datatype
 relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
@@ -12975,7 +12398,6 @@ relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 id: MS:1001900
 name: MaxQuant:sequence length
 def: "The data type sequence length produced by MaxQuant." [PSI:MS]
-xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002737 ! peptide-level quantification datatype
 relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
@@ -12983,7 +12405,6 @@ relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 id: MS:1001901
 name: MaxQuant:PEP
 def: "The data type PEP (posterior error probability) produced by MaxQuant." [PSI:MS]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -12991,7 +12412,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001902
 name: MaxQuant:LFQ intensity
 def: "The data type LFQ intensity produced by MaxQuant." [PSI:MS]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -12999,7 +12419,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001903
 name: MaxQuant:feature intensity
 def: "The data type feature intensity produced by MaxQuant." [PSI:MS]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002735 ! feature-level quantification datatype
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -13007,7 +12426,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001904
 name: MaxQuant:MS/MS count
 def: "The data type MS2 count produced by MaxQuant." [PSI:MS]
-xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
 relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
@@ -13015,7 +12433,6 @@ relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 id: MS:1001905
 name: emPAI value
 def: "The emPAI value of protein abundance, produced from the emPAI algorithm." [PSI:MS]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002738 ! protein-level quantification datatype
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -13023,7 +12440,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001906
 name: APEX value
 def: "The APEX value of protein abundance, produced from the APEX software." [PSI:MS]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002738 ! protein-level quantification datatype
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -13031,7 +12447,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001907
 name: retention time window width
 def: "The full width of a retention time window for a chromatographic peak." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000915 ! retention time window attribute
 relationship: has_units UO:0000010 ! second
 relationship: has_units UO:0000031 ! minute
@@ -13073,7 +12488,6 @@ is_a: MS:1001457 ! data processing software
 id: MS:1001913
 name: S-lens voltage
 def: "Potential difference setting of the Thermo Scientific S-lens stacked-ring ion guide in volts." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000482 ! source attribute
 relationship: has_units UO:0000218 ! volt
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
@@ -13118,7 +12532,6 @@ relationship: has_regexp MS:1001960 ! (?<=W)
 id: MS:1001919
 name: ProteomeXchange accession number
 def: "Main identifier of a ProteomeXchange dataset." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -13126,7 +12539,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1001921
 name: ProteomeXchange accession number version number
 def: "Version number of a ProteomeXchange accession number." [PSI:PI]
-xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
 relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term
 
@@ -13134,7 +12546,6 @@ relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type fo
 id: MS:1001922
 name: Digital Object Identifier (DOI)
 def: "DOI unique identifier of a publication." [PSI:PI, http://dx.doi.org]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 synonym: "doi" EXACT []
 is_a: MS:1000878 ! external reference identifier
 relationship: has_regexp MS:1002480 ! (10[.][0-9]\{4,\}(?:[.][0-9]+)*/(?:(?![\"&\'<>])[^ \t\\r\n\\v\\f])+)
@@ -13144,7 +12555,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1001923
 name: external reference keyword
 def: "Free text attribute that can enrich the information about an entity." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002840 ! external reference data
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -13152,7 +12562,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1001924
 name: journal article keyword
 def: "Keyword present in a scientific publication." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001923 ! external reference keyword
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -13160,7 +12569,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1001925
 name: submitter keyword
 def: "Keyword assigned by the data submitter." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001923 ! external reference keyword
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -13168,7 +12576,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1001926
 name: curator keyword
 def: "Keyword assigned by a data curator." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001923 ! external reference keyword
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -13176,7 +12583,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1001927
 name: Tranche file hash
 def: "Hash assigned by the Tranche resource to an individual file." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -13184,7 +12590,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1001928
 name: Tranche project hash
 def: "Hash assigned by the Tranche resource to a whole project." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -13192,7 +12597,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1001929
 name: PRIDE experiment URI
 def: "URI that allows the access to one experiment in the PRIDE database." [PSI:PI]
-xref: value-type:xsd\:anyURI "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
 relationship: has_value_type xsd\:anyURI ! The allowed value-type for this CV term
 
@@ -13200,7 +12604,6 @@ relationship: has_value_type xsd\:anyURI ! The allowed value-type for this CV te
 id: MS:1001930
 name: PRIDE project URI
 def: "URI that allows the access to one project in the PRIDE database." [PSI:PI]
-xref: value-type:xsd\:anyURI "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
 relationship: has_value_type xsd\:anyURI ! The allowed value-type for this CV term
 
@@ -13214,7 +12617,6 @@ relationship: part_of MS:1000458 ! source
 id: MS:1001932
 name: source interface model
 def: "The source interface model." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: part_of MS:1001931 ! source interface
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -13222,7 +12624,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1001933
 name: source sprayer
 def: "The source sprayer." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: part_of MS:1000458 ! source
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -13236,7 +12637,6 @@ relationship: part_of MS:1001933 ! source sprayer
 id: MS:1001935
 name: source sprayer manufacturer
 def: "The source sprayer manufacturer." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: part_of MS:1001933 ! source sprayer
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -13244,7 +12644,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1001936
 name: source sprayer model
 def: "The source sprayer model." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: part_of MS:1001933 ! source sprayer
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -13294,7 +12693,6 @@ is_a: MS:1001941 ! electrospray supply type
 id: MS:1001944
 name: Collision cell exit potential
 def: "Potential difference between Q2 and Q3 in a triple quadrupole instrument in volts." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000510 ! precursor activation attribute
 relationship: has_units UO:0000218 ! volt
 synonym: "CXP" EXACT []
@@ -13340,7 +12738,6 @@ is_a: MS:1000531 ! software
 id: MS:1001950
 name: PEAKS:peptideScore
 def: "The PEAKS peptide '-10lgP Score'." [PSI:MS]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -13348,7 +12745,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001951
 name: PEAKS:proteinScore
 def: "The PEAKS protein '-10lgP Score'." [PSI:MS]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -13356,7 +12752,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001952
 name: ZCore:probScore
 def: "The ZCore probability score." [PSI:MS]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -13364,7 +12759,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1001953
 name: source interface manufacturer
 def: "The source interface manufacturer." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: part_of MS:1001931 ! source interface
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -13372,7 +12766,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1001954
 name: acquisition parameter
 def: "Parameters used in the mass spectrometry acquisition." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: part_of MS:1001458 ! spectrum generation information
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -13416,7 +12809,6 @@ is_a: MS:1001180 ! Cleavage agent regular expression
 id: MS:1001961
 name: peptide spectrum match scoring algorithm
 def: "Algorithm used to score the match between a spectrum and a peptide ion." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: part_of MS:1001458 ! spectrum generation information
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -13424,7 +12816,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1001962
 name: Mascot:C13 counts
 def: "C13 peaks to use in peak detection." [PSI:MS]
-xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1002095 ! Mascot input parameter
 relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term
 
@@ -13432,7 +12823,6 @@ relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type fo
 id: MS:1001963
 name: ProteinExtractor:Weighting
 def: "Weighting factor for protein list compilation by ProteinExtractor." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002098 ! ProteinExtractor input parameter
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
@@ -13440,7 +12830,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1001964
 name: ProteinScape:second round Mascot
 def: "Flag indicating a second round search with Mascot." [PSI:MS]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002100 ! ProteinScape input parameter
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -13448,7 +12837,6 @@ relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV t
 id: MS:1001965
 name: ProteinScape:second round Phenyx
 def: "Flag indicating a second round search with Phenyx." [PSI:MS]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002100 ! ProteinScape input parameter
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -13462,7 +12850,6 @@ is_a: MS:1001221 ! product ion attribute
 id: MS:1001967
 name: product ion drift time
 def: "OBSOLETE The ion drift time of an MS2 product ion." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002222 ! SRM transition attribute
 relationship: has_units UO:0000028 ! millisecond
 comment: This term was made obsolete because it was replaced by ion mobility drift time (MS:1002476).
@@ -13479,7 +12866,6 @@ is_a: MS:1002689 ! PTM localization single result statistic
 id: MS:1001969
 name: phosphoRS score
 def: "phosphoRS score for PTM site location at the PSM-level." [DOI:10.1021/pr200611n, PMID:22073976]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001968 ! PTM localization PSM-level statistic
 relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
@@ -13488,7 +12874,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1001970
 name: phosphoRS sequence probability
 def: "Probability that the respective isoform is correct." [DOI:10.1021/pr200611n, PMID:22073976]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001968 ! PTM localization PSM-level statistic
 relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
@@ -13497,7 +12882,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1001971
 name: phosphoRS site probability
 def: "Estimate of the probability that the respective site is truly phosphorylated." [DOI:10.1021/pr200611n, PMID:22073976]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001968 ! PTM localization PSM-level statistic
 relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
@@ -13506,7 +12890,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1001972
 name: PTM scoring algorithm version
 def: "Version of the post-translational modification scoring algorithm." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001471 ! peptide modification details
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -13520,7 +12903,6 @@ is_a: MS:1001456 ! analysis software
 id: MS:1001974
 name: DeBunker:score
 def: "Score specific to DeBunker." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001968 ! PTM localization PSM-level statistic
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
@@ -13531,7 +12913,6 @@ id: MS:1001975
 name: delta m/z
 def: "The difference between a theoretically calculated m/z and the corresponding experimentally measured m/z. It can be expressed as absolute or relative value." [PSI:MS]
 synonym: "m/z difference" EXACT []
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001405 ! spectrum identification result details
 relationship: has_units UO:0000166 ! parts per notation unit
 relationship: has_units UO:0000187 ! percent
@@ -13543,7 +12924,6 @@ id: MS:1001976
 name: delta M
 def: "The difference between a theoretically calculated molecular mass M and the corresponding experimentally measured M. It can be expressed as absolute or relative value." [PSI:MS]
 synonym: "mass difference" EXACT []
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001405 ! spectrum identification result details
 relationship: has_units UO:0000166 ! parts per notation unit
 relationship: has_units UO:0000187 ! percent
@@ -13560,7 +12940,6 @@ is_a: MS:1001456 ! analysis software
 id: MS:1001978
 name: MSQuant:PTM-score
 def: "The PTM score from MSQuant software." [DOI:10.1021/pr900721e, PMID:19888749]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001968 ! PTM localization PSM-level statistic
 relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
@@ -13569,7 +12948,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1001979
 name: MaxQuant:PTM Score
 def: "The PTM score from MaxQuant software." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001968 ! PTM localization PSM-level statistic
 relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
@@ -13578,7 +12956,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1001980
 name: MaxQuant:Phospho (STY) Probabilities
 def: "The Phospho (STY) Probabilities from MaxQuant software." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001968 ! PTM localization PSM-level statistic
 relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
@@ -13587,7 +12964,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1001981
 name: MaxQuant:Phospho (STY) Score Diffs
 def: "The Phospho (STY) Score Diffs from MaxQuant software." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001968 ! PTM localization PSM-level statistic
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -13595,7 +12971,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1001982
 name: MaxQuant:P-site localization probability
 def: "The P-site localization probability value from MaxQuant software." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001968 ! PTM localization PSM-level statistic
 relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
@@ -13604,7 +12979,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1001983
 name: MaxQuant:PTM Delta Score
 def: "The PTM Delta Score value from MaxQuant software (Difference between highest scoring site and second highest)." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001968 ! PTM localization PSM-level statistic
 relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
@@ -13619,7 +12993,6 @@ is_a: MS:1001456 ! analysis software
 id: MS:1001985
 name: Ascore
 def: "A-score for PTM site location at the PSM-level." [DOI:10.1038/nbt1240, PMID:16964243]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001968 ! PTM localization PSM-level statistic
 relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
@@ -13628,7 +13001,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1001986
 name: H-Score
 def: "H-Score for peptide phosphorylation site location." [DOI:10.1021/pr1006813, PMID:20836569]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001968 ! PTM localization PSM-level statistic
 relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
@@ -13722,7 +13094,6 @@ is_a: MS:1000044 ! dissociation method
 id: MS:1002001
 name: MS1 label-based raw feature quantitation
 def: "MS1 label-based raw feature quantitation." [PSI:PI]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002018 ! MS1 label-based analysis
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -13730,7 +13101,6 @@ relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV t
 id: MS:1002002
 name: MS1 label-based peptide level quantitation
 def: "MS1 label-based peptide level quantitation." [PSI:PI]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002018 ! MS1 label-based analysis
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -13738,7 +13108,6 @@ relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV t
 id: MS:1002003
 name: MS1 label-based protein level quantitation
 def: "MS1 label-based protein level quantitation." [PSI:PI]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002018 ! MS1 label-based analysis
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -13746,7 +13115,6 @@ relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV t
 id: MS:1002004
 name: MS1 label-based proteingroup level quantitation
 def: "MS1 label-based proteingroup level quantitation." [PSI:PI]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002018 ! MS1 label-based analysis
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -13800,7 +13168,6 @@ is_a: MS:1000240 ! atmospheric pressure ionization
 id: MS:1002012
 name: Mascot:PTM site assignment confidence
 def: "Relative probability that PTM site assignment is correct, derived from the Mascot score difference between matches to the same spectrum (Mascot Delta Score)." [http://www.matrixscience.com/help/pt_mods_help.html#SITE]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001968 ! PTM localization PSM-level statistic
 relationship: has_units UO:0000187 ! percent
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
@@ -13809,7 +13176,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1002013
 name: collision energy ramp start
 def: "Collision energy at the start of the collision energy ramp." [PSI:PI]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000045 ! collision energy
 relationship: has_units UO:0000266 ! electronvolt
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
@@ -13818,7 +13184,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1002014
 name: collision energy ramp end
 def: "Collision energy at the end of the collision energy ramp." [PSI:PI]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000045 ! collision energy
 relationship: has_units UO:0000266 ! electronvolt
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
@@ -13827,7 +13192,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1002015
 name: spectral count peptide level quantitation
 def: "Spectral count peptide level quantitation." [PSI:PI]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001836 ! spectral counting quantitation analysis
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -13835,7 +13199,6 @@ relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV t
 id: MS:1002016
 name: spectral count protein level quantitation
 def: "Spectral count protein level quantitation." [PSI:PI]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001836 ! spectral counting quantitation analysis
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -13843,7 +13206,6 @@ relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV t
 id: MS:1002017
 name: spectral count proteingroup level quantitation
 def: "Spectral count proteingroup level quantitation." [PSI:PI]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001836 ! spectral counting quantitation analysis
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -13857,7 +13219,6 @@ is_a: MS:1001833 ! quantitation analysis summary
 id: MS:1002019
 name: label-free raw feature quantitation
 def: "Label-free raw feature quantitation." [PSI:PI]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001834 ! LC-MS label-free quantitation analysis
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -13865,7 +13226,6 @@ relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV t
 id: MS:1002020
 name: label-free peptide level quantitation
 def: "Label-free peptide level quantitation." [PSI:PI]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001834 ! LC-MS label-free quantitation analysis
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -13873,7 +13233,6 @@ relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV t
 id: MS:1002021
 name: label-free protein level quantitation
 def: "Label-free protein level quantitation." [PSI:PI]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001834 ! LC-MS label-free quantitation analysis
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -13881,7 +13240,6 @@ relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV t
 id: MS:1002022
 name: label-free proteingroup level quantitation
 def: "Label-free proteingroup level quantitation." [PSI:PI]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001834 ! LC-MS label-free quantitation analysis
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -13895,7 +13253,6 @@ is_a: MS:1001833 ! quantitation analysis summary
 id: MS:1002024
 name: MS2 tag-based feature level quantitation
 def: "MS2 tag-based feature level quantitation." [PSI:PI]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002023 ! MS2 tag-based analysis
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -13903,7 +13260,6 @@ relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV t
 id: MS:1002025
 name: MS2 tag-based peptide level quantitation
 def: "MS2 tag-based peptide level quantitation." [PSI:PI]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002023 ! MS2 tag-based analysis
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -13911,7 +13267,6 @@ relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV t
 id: MS:1002026
 name: MS2 tag-based protein level quantitation
 def: "MS2 tag-based protein level quantitation." [PSI:PI]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002023 ! MS2 tag-based analysis
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -13919,7 +13274,6 @@ relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV t
 id: MS:1002027
 name: MS2 tag-based proteingroup level quantitation
 def: "MS2 tag-based proteingroup level quantitation." [PSI:PI]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002023 ! MS2 tag-based analysis
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -13927,7 +13281,6 @@ relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV t
 id: MS:1002028
 name: nucleic acid base modification
 def: "Nucleic acid base modification (substitution, insertion or deletion)." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001471 ! peptide modification details
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -13935,7 +13288,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1002029
 name: original nucleic acid sequence
 def: "Specification of the original nucleic acid sequence, prior to a modification. The value slot should hold the DNA or RNA sequence." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001471 ! peptide modification details
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -13943,7 +13295,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1002030
 name: modified nucleic acid sequence
 def: "Specification of the modified nucleic acid sequence. The value slot should hold the DNA or RNA sequence." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001471 ! peptide modification details
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -13951,7 +13302,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1002031
 name: PASSEL transition group browser URI
 def: "URI to retrieve transition group data for a PASSEL (PeptideAtlas SRM Experiment Library) experiment." [PSI:PI]
-xref: value-type:xsd\:anyURI "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
 relationship: has_value_type xsd\:anyURI ! The allowed value-type for this CV term
 
@@ -13959,7 +13309,6 @@ relationship: has_value_type xsd\:anyURI ! The allowed value-type for this CV te
 id: MS:1002032
 name: PeptideAtlas dataset URI
 def: "URI that allows access to a PeptideAtlas dataset." [PSI:PI]
-xref: value-type:xsd\:anyURI "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
 relationship: has_value_type xsd\:anyURI ! The allowed value-type for this CV term
 
@@ -14011,7 +13360,6 @@ relationship: part_of MS:1000458 ! source
 id: MS:1002040
 name: inlet temperature
 def: "The temperature of the inlet of a mass spectrometer." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000482 ! source attribute
 is_a: MS:1002039 ! inlet attribute
 relationship: has_units UO:0000012 ! kelvin
@@ -14022,7 +13370,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1002041
 name: source temperature
 def: "The temperature of the source of a mass spectrometer." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000482 ! source attribute
 relationship: has_units UO:0000012 ! kelvin
 relationship: has_units UO:0000027 ! degree Celsius
@@ -14032,7 +13379,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1002042
 name: modulation time
 def: "The duration of a complete cycle of modulation in a comprehensive two-dimensional separation system, equals the length of a second dimension chromatogram, i.e., the time between two successive injections into the second column." [http://chromatographyonline.findanalytichem.com/lcgc/Column:+Coupling+Matters/Nomenclature-and-Conventions-in-Comprehensive-Mult/ArticleStandard/Article/detail/58429]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000857 ! run attribute
 relationship: has_units UO:0000010 ! second
 relationship: has_units UO:0000031 ! minute
@@ -14048,7 +13394,6 @@ is_a: MS:1001456 ! analysis software
 id: MS:1002044
 name: ProteinProspector:score
 def: "The ProteinProspector result 'Score'." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -14056,7 +13401,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002045
 name: ProteinProspector:expectation value
 def: "The ProteinProspector result 'Expectation value'." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -14064,7 +13408,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002046
 name: native source path
 def: "The original source path used for directory-based sources." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001458 ! spectrum generation information
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -14085,7 +13428,6 @@ is_a: MS:1001456 ! analysis software
 id: MS:1002049
 name: MS-GF:RawScore
 def: "MS-GF raw score." [PSI:PI]
-xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
@@ -14093,7 +13435,6 @@ relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 id: MS:1002050
 name: MS-GF:DeNovoScore
 def: "MS-GF de novo score." [PSI:PI]
-xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
 relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
@@ -14101,7 +13442,6 @@ relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 id: MS:1002051
 name: MS-GF:Energy
 def: "MS-GF energy score." [PSI:PI]
-xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term
 
@@ -14109,7 +13449,6 @@ relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type fo
 id: MS:1002052
 name: MS-GF:SpecEValue
 def: "MS-GF spectral E-value." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002353 ! PSM-level e-value
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002109 ! lower score better
@@ -14119,7 +13458,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002053
 name: MS-GF:EValue
 def: "MS-GF E-value." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002353 ! PSM-level e-value
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002109 ! lower score better
@@ -14129,7 +13467,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002054
 name: MS-GF:QValue
 def: "MS-GF Q-value." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002354 ! PSM-level q-value
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
@@ -14138,7 +13475,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002055
 name: MS-GF:PepQValue
 def: "MS-GF peptide-level Q-value." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -14146,7 +13482,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002056
 name: MS-GF:PEP
 def: "MS-GF posterior error probability." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -14197,7 +13532,6 @@ is_a: MS:1001139 ! quantitation software name
 id: MS:1002064
 name: peptide consensus RT
 def: "Peptide consensus retention time." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002737 ! peptide-level quantification datatype
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -14205,7 +13539,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002065
 name: peptide consensus m/z
 def: "Peptide consensus mass/charge ratio." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002737 ! peptide-level quantification datatype
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -14213,7 +13546,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002066
 name: ratio calculation method
 def: "Method used to calculate the ratio." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -14221,7 +13553,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002067
 name: protein value: median of peptide ratios
 def: "Protein quantification value calculated as median of peptide ratios." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002738 ! protein-level quantification datatype
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -14235,7 +13566,6 @@ is_a: MS:1001055 ! modification parameters
 id: MS:1002069
 name: metabolic labelling purity
 def: "Metabolic labelling: Description of labelling purity. Usually the purity of feeding material (e.g. 95%), or the inclusion rate derived from isotopic peak pattern shape." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001055 ! modification parameters
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -14243,7 +13573,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1002070
 name: t-test
 def: "Perform a t-test (two groups). Specify in string value, whether paired / unpaired, variance equal / different, one- / two-sided version is performed." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001861 ! quantification data processing
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -14251,7 +13580,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1002071
 name: ANOVA-test
 def: "Perform an ANOVA-test (more than two groups). Specify in string value, which version is performed." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001861 ! quantification data processing
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -14259,7 +13587,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1002072
 name: p-value
 def: "P-value as result of one of the processing steps described. Specify in the description, which processing step it was." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
@@ -14299,7 +13626,6 @@ id: MS:1002078
 name: ProteomeDiscoverer:1. Static Modification
 def: "OBSOLETE ProteomeDiscoverer's 1st static post-translational modification (PTM) input parameter." [PSI:PI]
 comment: This term was made obsolete because it's recommended to use ProteomeDiscoverer:Static Modification (MS:1001645) instead.
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
@@ -14309,7 +13635,6 @@ id: MS:1002079
 name: ProteomeDiscoverer:2. Static Modification
 def: "OBSOLETE ProteomeDiscoverer's 2nd static post-translational modification (PTM) input parameter." [PSI:PI]
 comment: This term was made obsolete because it's recommended to use ProteomeDiscoverer:Static Modification (MS:1001645) instead.
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
@@ -14318,7 +13643,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1002080
 name: ProteomeDiscoverer:Spectrum Selector:Precursor Clipping Range Before
 def: "Precursor clipping range before." [PSI:MS]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_units UO:0000221 ! dalton
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
@@ -14327,7 +13651,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002081
 name: ProteomeDiscoverer:Spectrum Selector:Precursor Clipping Range After
 def: "Precursor clipping range after." [PSI:MS]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_units UO:0000221 ! dalton
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
@@ -14336,7 +13659,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002082
 name: first column elution time
 def: "The time of elution from the first chromatographic column in the chromatographic separation step, relative to the start of chromatography on the first column." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000503 ! scan attribute
 relationship: has_units UO:0000010 ! second
 relationship: has_units UO:0000031 ! minute
@@ -14346,7 +13668,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1002083
 name: second column elution time
 def: "The time of elution from the second chromatographic column in the chromatographic separation step, relative to the start of the chromatography on the second column." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000503 ! scan attribute
 relationship: has_units UO:0000010 ! second
 relationship: has_units UO:0000031 ! minute
@@ -14386,7 +13707,6 @@ is_a: MS:1002084 ! multidimensional chromatography modulation description
 id: MS:1002089
 name: ProteomeDiscoverer:Peptide Without Protein XCorr Threshold
 def: "XCorr threshold for storing peptides that do not belong to a protein." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
@@ -14394,7 +13714,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1002090
 name: Calculate Probability Scores
 def: "Flag indicating that a probability score for the assessment that a reported peptide match is a random occurrence is calculated." [PSI:MS]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002094 ! common search engine input parameter
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -14402,7 +13721,6 @@ relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV t
 id: MS:1002091
 name: ProteomeDiscoverer:Maximum Delta Cn
 def: "Delta Cn threshold for filtering out PSM's." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
@@ -14410,7 +13728,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1002092
 name: Percolator:Validation based on
 def: "Algorithm (e.g. q-value or PEP) used for calculation of the validation score using Percolator." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002107 ! Percolator input parameter
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -14605,7 +13922,6 @@ id: MS:1002125
 name: combined FDRScore
 def: "OBSOLETE FDRScore values specifically obtained for distinct combinations of single, pairs or triplets of search engines making a given PSM, used for integrating results from these distinct pools." [PMID:19253293]
 comment: This term was made obsolete because it was split into the more specific terms for PSM-level combined FDRScore (MS:1002356), distinct peptide-level combined FDRScore (MS:1002361), protein-level combined FDRScore (MS:1002366) and protein group-level combined FDRScore (MS:1002375).
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1001153 ! search engine specific score
 is_obsolete: true
@@ -14778,7 +14094,6 @@ is_a: MS:1001806 ! quantification object attribute
 id: MS:1002153
 name: protein level PSM counts
 def: "The number of spectra identified for this protein in spectral counting." [PSI:PI]
-xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002738 ! protein-level quantification datatype
 relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
@@ -15141,7 +14456,6 @@ is_a: MS:1002009 ! isobaric label quantitation analysis
 id: MS:1002213
 name: PAnalyzer:conclusive protein
 def: "A protein identified by at least one unique (distinct, discrete) peptide (peptides are considered different only if they can be distinguished by evidence in mass spectrum)." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001600 ! protein inference confidence category
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -15149,7 +14463,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1002214
 name: PAnalyzer:indistinguishable protein
 def: "A member of a group of proteins sharing all peptides that are exclusive to the group (peptides are considered different only if they can be distinguished by evidence in mass spectrum)." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001600 ! protein inference confidence category
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -15157,7 +14470,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1002215
 name: PAnalyzer:non-conclusive protein
 def: "A protein sharing all its matched peptides with either conclusive or indistinguishable proteins (peptides are considered different only if they can be distinguished by evidence in mass spectrum)." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001600 ! protein inference confidence category
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -15165,7 +14477,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1002216
 name: PAnalyzer:ambiguous group member
 def: "A protein sharing at least one peptide not matched to either conclusive or indistinguishable proteins (peptides are considered different only if they can be distinguished by evidence in mass spectrum)." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001600 ! protein inference confidence category
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -15173,7 +14484,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1002217
 name: decoy peptide
 def: "A putative identified peptide issued from a decoy sequence database." [PSI:PI]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001105 ! peptide sequence-level identification attribute
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -15181,7 +14491,6 @@ relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV t
 id: MS:1002218
 name: percent collision energy ramp start
 def: "Collision energy at the start of the collision energy ramp in percent, normalized to the mass of the ion." [PSI:PI]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000138 ! normalized collision energy
 relationship: has_units UO:0000187 ! percent
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
@@ -15190,7 +14499,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1002219
 name: percent collision energy ramp end
 def: "Collision energy at the end of the collision energy ramp in percent, normalized to the mass of the ion." [PSI:PI]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000138 ! normalized collision energy
 relationship: has_units UO:0000187 ! percent
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
@@ -15219,7 +14527,6 @@ relationship: part_of MS:1000908 ! transition
 id: MS:1002223
 name: precursor ion detection probability
 def: "Probability of detecting precursor when parent protein is present." [PSI:PI]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002222 ! SRM transition attribute
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
@@ -15227,7 +14534,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1002224
 name: product ion detection probability
 def: "Probability of detecting product ion when precursor ion is present." [PSI:PI]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002222 ! SRM transition attribute
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
@@ -15255,7 +14561,6 @@ relationship: has_units MS:1000905 ! percent of base peak times 100
 id: MS:1002227
 name: number of product ion observations
 def: "The number of times the specific product ion has been observed in a series of SRM experiments." [PSI:PI]
-xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002222 ! SRM transition attribute
 relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
@@ -15263,7 +14568,6 @@ relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 id: MS:1002228
 name: number of precursor ion observations
 def: "The number of times the specific precursor ion has been observed in a series of SRM experiments." [PSI:PI]
-xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002222 ! SRM transition attribute
 relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
@@ -15271,7 +14575,6 @@ relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 id: MS:1002229
 name: ProteomeDiscoverer:Mascot:Significance Middle
 def: "Calculated relaxed significance when performing a decoy search for high-confidence peptides." [PSI:PI]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
@@ -15279,7 +14582,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1002230
 name: ProteomeDiscoverer:Mascot:Significance High
 def: "Calculated relaxed significance when performing a decoy search for medium-confidence peptides." [PSI:PI]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
@@ -15300,7 +14602,6 @@ relationship: has_regexp MS:1002231 ! regular expressions for a GUID
 id: MS:1002233
 name: ProteomeDiscoverer:SEQUEST:Low resolution spectra contained
 def: "Flag indicating if low-resolution spectra are taken into consideration." [PSI:PI]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -15309,7 +14610,6 @@ id: MS:1002234
 name: selected precursor m/z
 def: "Mass-to-charge ratio of a precursor ion selected for fragmentation." [PSI:PI]
 synonym: "selected ion m/z" RELATED []
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000455 ! ion selection attribute
 relationship: has_units MS:1000040 ! m/z
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
@@ -15318,7 +14618,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1002235
 name: ProteoGrouper:PDH score
 def: "A score assigned to a single protein accession (modelled as ProteinDetectionHypothesis in mzIdentML), based on summed peptide level scores." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -15326,7 +14625,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002236
 name: ProteoGrouper:PAG score
 def: "A score assigned to a protein group (modelled as ProteinAmbiguityGroup in mzIdentML), based on all summed peptide level scores that have been assigned to the group as unique or razor peptides." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002368 ! search engine specific score for protein groups
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -15400,7 +14698,6 @@ is_a: MS:1002237 ! mzidLib
 id: MS:1002248
 name: SEQUEST:spscore
 def: "The SEQUEST result 'SpScore'." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -15408,7 +14705,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002249
 name: SEQUEST:sprank
 def: "The SEQUEST result 'SpRank'." [PSI:PI]
-xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
@@ -15416,7 +14712,6 @@ relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 id: MS:1002250
 name: SEQUEST:deltacnstar
 def: "The SEQUEST result 'DeltaCnStar'." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -15430,7 +14725,6 @@ is_a: MS:1001456 ! analysis software
 id: MS:1002252
 name: Comet:xcorr
 def: "The Comet result 'XCorr'." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002108 ! higher score better
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
@@ -15439,7 +14733,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002253
 name: Comet:deltacn
 def: "The Comet result 'DeltaCn'." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -15447,7 +14740,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002254
 name: Comet:deltacnstar
 def: "The Comet result 'DeltaCnStar'." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -15455,7 +14747,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002255
 name: Comet:spscore
 def: "The Comet result 'SpScore'." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -15463,7 +14754,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002256
 name: Comet:sprank
 def: "The Comet result 'SpRank'." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -15471,7 +14761,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002257
 name: Comet:expectation value
 def: "The Comet result 'Expectation value'." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001153 ! search engine specific score
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -15479,7 +14768,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002258
 name: Comet:matched ions
 def: "The Comet result 'Matched Ions'." [PSI:PI]
-xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
@@ -15487,7 +14775,6 @@ relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 id: MS:1002259
 name: Comet:total ions
 def: "The Comet result 'Total Ions'." [PSI:PI]
-xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
@@ -15495,7 +14782,6 @@ relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 id: MS:1002260
 name: PSM:FDR threshold
 def: "False-discovery rate threshold for peptide-spectrum matches." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002483 ! PSM-level statistical threshold
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -15509,7 +14795,6 @@ is_a: MS:1001456 ! analysis software
 id: MS:1002262
 name: Byonic:Score
 def: "The Byonic score is the primary indicator of PSM correctness. The Byonic score reflects the absolute quality of the peptide-spectrum match, not the relative quality compared to other candidate peptides. Byonic scores range from 0 to about 1000, with 300 a good score, 400 a very good score, and PSMs with scores over 500 almost sure to be correct." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002108 ! higher score better
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
@@ -15518,7 +14803,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002263
 name: Byonic:Delta Score
 def: "The drop in Byonic score from the top-scoring peptide to the next peptide with distinct sequence. In this computation, the same peptide with different modifications is not considered distinct." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002108 ! higher score better
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
@@ -15527,7 +14811,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002264
 name: Byonic:DeltaMod Score
 def: "The drop in Byonic score from the top-scoring peptide to the next peptide different in any way, including placement of modifications. DeltaMod gives an indication of whether modifications are confidently localized; DeltaMod over 10.0 means that there is high likelihood that all modification placements are correct." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002108 ! higher score better
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
@@ -15536,7 +14819,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002265
 name: Byonic:PEP
 def: "Byonic posterior error probability." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002109 ! lower score better
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
@@ -15545,7 +14827,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002266
 name: Byonic:Peptide LogProb
 def: "The log p-value of the PSM. This is the log of the probability that the PSM with such a score and delta would arise by chance in a search of this size (the size of the protein database, as expanded by the modification rules). A log p-value of -3.0 should happen by chance on only one of a thousand spectra. Caveat: it is very hard to compute a p-value that works for all searches and all spectra, so read Byonic p-values with a certain amount of skepticism." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002109 ! lower score better
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
@@ -15554,7 +14835,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002267
 name: Byonic:Protein LogProb
 def: "The log p-value of the protein." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
 is_a: MS:1002363 ! search engine specific score for proteins
 relationship: has_order MS:1002109 ! lower score better
@@ -15564,7 +14844,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002268
 name: Byonic:Best LogProb
 def: "Best (most negative) log p-value of an individual PSM." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001116 ! single protein identification statistic
 is_a: MS:1001153 ! search engine specific score
 relationship: has_order MS:1002109 ! lower score better
@@ -15574,7 +14853,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002269
 name: Byonic:Best Score
 def: "Best (largest) Byonic score of a PSM." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
 relationship: has_order MS:1002108 ! higher score better
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
@@ -15601,7 +14879,6 @@ is_a: MS:1002270 ! chromatography separation
 id: MS:1002273
 name: detector potential
 def: "Detector potential difference in volts." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000481 ! detector attribute
 relationship: has_units UO:0000218 ! volt
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
@@ -15787,7 +15064,6 @@ is_a: MS:1000560 ! mass spectrometer file format
 id: MS:1002303
 name: Bruker Container nativeID format
 def: "Native identifier (UUID)." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000767 ! native spectrum identifier format
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -15825,7 +15101,6 @@ is_a: MS:1000026 ! detector type
 id: MS:1002309
 name: Byonic: Peptide AbsLogProb
 def: "The absolute value of the log-base10 of the Byonic posterior error probability (PEP) of the PSM." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002108 ! higher score better
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
@@ -15834,7 +15109,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002310
 name: Byonic: Protein AbsLogProb
 def: "The absolute value of the log-base10 of the Byonic posterior error probability (PEP) of the protein." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
 relationship: has_order MS:1002108 ! higher score better
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
@@ -15843,7 +15117,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002311
 name: Byonic: Peptide AbsLogProb2D
 def: "The absolute value of the log-base10 Byonic two-dimensional posterior error probability (PEP) of the PSM. The two-dimensional PEP takes into account protein ranking information as well as PSM information." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002108 ! higher score better
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
@@ -15876,7 +15149,6 @@ is_a: MS:1001405 ! spectrum identification result details
 id: MS:1002316
 name: ProteomeDiscoverer:Amanda:high confidence threshold
 def: "Strict confidence probability score." [PSI:PI]
-xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
@@ -15884,7 +15156,6 @@ relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 id: MS:1002317
 name: ProteomeDiscoverer:Amanda:middle confidence threshold
 def: "Relaxed confidence probability score." [PSI:PI]
-xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
@@ -15892,7 +15163,6 @@ relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 id: MS:1002318
 name: ProteomeDiscoverer:automatic workload
 def: "Flag indicating automatic estimation of the workload level." [PSI:PI]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -15900,7 +15170,6 @@ relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV t
 id: MS:1002319
 name: Amanda:AmandaScore
 def: "The Amanda score of the scoring function for a PSM." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -15908,7 +15177,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002320
 name: ProteomeDiscoverer:max differential modifications
 def: "Maximum dynamic modifications per PSM." [PSI:PI]
-xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
@@ -15916,7 +15184,6 @@ relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 id: MS:1002321
 name: ProteomeDiscoverer:max equal modifications
 def: "Maximum equal modifications per PSM." [PSI:PI]
-xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
@@ -15924,7 +15191,6 @@ relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 id: MS:1002322
 name: ProteomeDiscoverer:min peptide length
 def: "Minimum peptide length." [PSI:PI]
-xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
@@ -15932,7 +15198,6 @@ relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 id: MS:1002323
 name: ProteomeDiscoverer:max peptide length
 def: "Maximum peptide length." [PSI:PI]
-xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
@@ -15940,7 +15205,6 @@ relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 id: MS:1002324
 name: ProteomeDiscoverer:max number neutral loss
 def: "Maximum number of same neutral losses." [PSI:PI]
-xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
@@ -15948,7 +15212,6 @@ relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 id: MS:1002325
 name: ProteomeDiscoverer:max number neutral loss modifications
 def: "Max number of same neutral losses of modifications." [PSI:PI]
-xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
@@ -15956,7 +15219,6 @@ relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 id: MS:1002326
 name: ProteomeDiscoverer:use flanking ions
 def: "Flag for usage of flanking ions." [PSI:PI]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -15964,7 +15226,6 @@ relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV t
 id: MS:1002327
 name: ProteomeDiscoverer:max number of same modifs
 def: "The maximum number of possible equal modifications per PSM." [PSI:PI]
-xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
@@ -15972,7 +15233,6 @@ relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 id: MS:1002328
 name: ProteomeDiscoverer:perform deisotoping
 def: "Defines whether a simple deisotoping shall be performed." [PSI:PI]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -15980,7 +15240,6 @@ relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV t
 id: MS:1002329
 name: ProteomeDiscoverer:ion settings
 def: "Specifies the fragment ions and neutral losses that are calculated." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -15989,7 +15248,6 @@ id: MS:1002330
 name: ProteomeDiscoverer:3. Static Modification
 def: "OBSOLETE ProteomeDiscoverer's 3rd static post-translational modification (PTM) input parameter." [PSI:PI]
 comment: This term was made obsolete because it's recommended to use ProteomeDiscoverer:Static Modification (MS:1001645) instead.
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
@@ -15999,7 +15257,6 @@ id: MS:1002331
 name: ProteomeDiscoverer:5. Dynamic Modification
 def: "OBSOLETE ProteomeDiscoverer's 5th dynamic post-translational modification (PTM) input parameter." [PSI:PI]
 comment: This term was made obsolete because it's recommended to use ProteomeDiscoverer:Dynamic Modification (MS:1001644) instead.
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
@@ -16044,7 +15301,6 @@ is_a: MS:1001456 ! analysis software
 id: MS:1002338
 name: Andromeda:score
 def: "The probability based score of the Andromeda search engine." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002108 ! higher score better
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
@@ -16053,7 +15309,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002339
 name: site:global FDR
 def: "Estimation of global false discovery rate of peptides with a post-translational modification." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001405 ! spectrum identification result details
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -16061,7 +15316,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002340
 name: ProteomeXchange project tag
 def: "Tag that can be added to a ProteomeXchange dataset, to enable the grouping of datasets. One tag can be used for indicating that a given dataset is part of a bigger project, like e.g. the Human Proteome Project." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -16069,7 +15323,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1002341
 name: second-pass peptide identification
 def: "A putative identified peptide found in a second-pass search of protein sequences selected from a first-pass search." [PSI:PI]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001105 ! peptide sequence-level identification attribute
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -16128,7 +15381,6 @@ is_a: MS:1002304 ! domain range
 id: MS:1002350
 name: PSM-level global FDR
 def: "Estimation of the global false discovery rate of peptide spectrum matches." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002701 ! PSM-level result list statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
@@ -16137,7 +15389,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002351
 name: PSM-level local FDR
 def: "Estimation of the local false discovery rate of peptide spectrum matches." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002347 ! PSM-level identification statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
@@ -16146,7 +15397,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002352
 name: PSM-level p-value
 def: "Estimation of the p-value for peptide spectrum matches." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002347 ! PSM-level identification statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
@@ -16155,7 +15405,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002353
 name: PSM-level e-value
 def: "Estimation of the e-value for peptide spectrum matches." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002347 ! PSM-level identification statistic
 relationship: has_domain MS:1002306 ! value greater than zero
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
@@ -16164,7 +15413,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002354
 name: PSM-level q-value
 def: "Estimation of the q-value for peptide spectrum matches." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002347 ! PSM-level identification statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
@@ -16173,7 +15421,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002355
 name: PSM-level FDRScore
 def: "mzidLibrary FDRScore for peptide spectrum matches." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1002363 ! search engine specific score for proteins
 relationship: has_domain MS:1002349 ! value greater than zero but less than or equal to 1
@@ -16183,7 +15430,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002356
 name: PSM-level combined FDRScore
 def: "mzidLibrary Combined FDRScore for peptide spectrum matches specifically obtained for distinct combinations of single, pairs or triplets of search engines making a given PSM, used for integrating results from these distinct pools." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1002363 ! search engine specific score for proteins
 relationship: has_domain MS:1002349 ! value greater than zero but less than or equal to 1
@@ -16193,7 +15439,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002357
 name: PSM-level probability
 def: "Probability that the reported peptide ion is truly responsible for some or all of the components of the specified mass spectrum." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002347 ! PSM-level identification statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
@@ -16208,7 +15453,6 @@ is_a: MS:1001092 ! peptide sequence-level identification statistic
 id: MS:1002359
 name: peptide sequence-level local FDR
 def: "Estimation of the local false discovery rate for distinct peptides once redundant identifications of the same peptide have been removed (id est multiple PSMs have been collapsed to one entry)." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001092 ! peptide sequence-level identification statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
@@ -16217,7 +15461,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002360
 name: distinct peptide-level FDRScore
 def: "MzidLibrary FDRScore for distinct peptides once redundant identifications of the same peptide have been removed (id est multiple PSMs have been collapsed to one entry)." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002358 ! search engine specific peptide sequence-level identification statistic
 is_a: MS:1002363 ! search engine specific score for proteins
 relationship: has_domain MS:1002349 ! value greater than zero but less than or equal to one
@@ -16227,7 +15470,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002361
 name: distinct peptide-level combined FDRScore
 def: "Combined FDRScore for peptides once redundant identifications of the same peptide have been removed (id est multiple PSMs have been collapsed to one entry) specifically obtained for distinct combinations of single, pairs or triplets of search engines making a given peptide, used for integrating results from these distinct pools." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002358 ! search engine specific peptide sequence-level identification statistic
 is_a: MS:1002363 ! search engine specific score for proteins
 relationship: has_domain MS:1002349 ! value greater than zero but less than or equal to one
@@ -16237,7 +15479,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002362
 name: peptide sequence-level probability
 def: "Probability that the reported distinct peptide sequence (irrespective of mass modifications) has been correctly identified via the referenced PSMs." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001092 ! peptide sequence-level identification statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
@@ -16252,7 +15493,6 @@ is_a: MS:1001116 ! single protein identification statistic
 id: MS:1002364
 name: protein-level local FDR
 def: "Estimation of the local false discovery rate of proteins." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001116 ! single protein identification statistic
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -16260,7 +15500,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002365
 name: FDRScore for proteins
 def: "MzidLibrary FDRScore for proteins specifically obtained for distinct combinations of single, pairs or triplets of search engines making a given PSM, used for integrating results from these distinct pools." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
 relationship: has_domain MS:1002349 ! value greater than zero but less than or equal to one
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
@@ -16269,7 +15508,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002366
 name: combined FDRScore for proteins
 def: "MzidLibrary Combined FDRScore for proteins." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
 relationship: has_domain MS:1002349 ! value greater than zero but less than or equal to one
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
@@ -16278,7 +15516,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002367
 name: probability for proteins
 def: "Probability that a specific protein sequence has been correctly identified from the PSM and distinct peptide evidence, and based on the available protein sequences presented to the analysis software." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001116 ! single protein identification statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
@@ -16293,7 +15530,6 @@ is_a: MS:1002348 ! protein group-level identification statistic
 id: MS:1002369
 name: protein group-level global FDR
 def: "Estimation of the global false discovery rate of protein groups." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002706 ! protein group-level result list statistic
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -16301,7 +15537,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002370
 name: protein group-level local FDR
 def: "Estimation of the local false discovery rate of protein groups." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002348 ! protein group-level identification statistic
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -16309,7 +15544,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002371
 name: protein group-level p-value
 def: "Estimation of the p-value for protein groups." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002348 ! protein group-level identification statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
@@ -16318,7 +15552,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002372
 name: protein group-level e-value
 def: "Estimation of the e-value for protein groups." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002348 ! protein group-level identification statistic
 relationship: has_domain MS:1002306 ! value greater than zero
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
@@ -16327,7 +15560,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002373
 name: protein group-level q-value
 def: "Estimation of the q-value for protein groups." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002348 ! protein group-level identification statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
@@ -16336,7 +15568,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002374
 name: protein group-level FDRScore
 def: "mzidLibrary FDRScore for protein groups." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002368 ! search engine specific score for protein groups
 relationship: has_domain MS:1002349 ! value greater than zero but less than or equal to one
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
@@ -16345,7 +15576,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002375
 name: protein group-level combined FDRScore
 def: "mzidLibrary Combined FDRScore for proteins specifically obtained for distinct combinations of single, pairs or triplets of search engines making a given PSM, used for integrating results from these distinct pools." [PMID:19253293]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002368 ! search engine specific score for protein groups
 relationship: has_domain MS:1002349 ! value greater than zero but less than or equal to one
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
@@ -16354,7 +15584,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002376
 name: protein group-level probability
 def: "Probability that at least one of the members of a group of protein sequences has been correctly identified from the PSM and distinct peptide evidence, and based on the available protein sequences presented to the analysis software." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002348 ! protein group-level identification statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
@@ -16363,7 +15592,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002377
 name: ProteomeDiscoverer:Relaxed Score Threshold
 def: "Specifies the threshold value for relaxed scoring." [PSI:PI]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
@@ -16371,7 +15599,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1002378
 name: ProteomeDiscoverer:Strict Score Threshold
 def: "Specifies the threshold value for strict scoring." [PSI:PI]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
@@ -16379,7 +15606,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1002379
 name: ProteomeDiscoverer:Peptide Without Protein Cut Off Score
 def: "Cut off score for storing peptides that do not belong to a protein." [PSI:PI]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
@@ -16387,7 +15613,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1002380
 name: false localization rate
 def: "Estimation of the false localization rate for modification site assignment." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001405 ! spectrum identification result details
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -16456,7 +15681,6 @@ is_a: MS:1001302 ! search engine specific input parameter
 id: MS:1002390
 name: PIA:FDRScore calculated
 def: "Indicates whether the FDR score was calculated for the input file." [PSI:PI]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002389 ! PIA workflow parameter
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -16464,7 +15688,6 @@ relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV t
 id: MS:1002391
 name: PIA:Combined FDRScore calculated
 def: "Indicates whether the combined FDR score was calculated for the PIA compilation." [PSI:PI]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002389 ! PIA workflow parameter
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -16472,7 +15695,6 @@ relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV t
 id: MS:1002392
 name: PIA:PSM sets created
 def: "Indicates whether PSM sets were created." [PSI:PI]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002389 ! PIA workflow parameter
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -16480,7 +15702,6 @@ relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV t
 id: MS:1002393
 name: PIA:used top identifications for FDR
 def: "The number of top identifications per spectrum used for the FDR calculation, 0 means all." [PSI:PI]
-xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1002389 ! PIA workflow parameter
 relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term
 
@@ -16488,7 +15709,6 @@ relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for t
 id: MS:1002394
 name: PIA:protein score
 def: "The score given to a protein by any protein inference." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
 relationship: has_order MS:1002108 ! higher score better
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
@@ -16497,7 +15717,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002395
 name: PIA:protein inference
 def: "The used algorithm for the protein inference using PIA." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002389 ! PIA workflow parameter
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -16505,7 +15724,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1002396
 name: PIA:protein inference filter
 def: "A filter used by PIA for the protein inference." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002389 ! PIA workflow parameter
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -16513,7 +15731,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1002397
 name: PIA:protein inference scoring
 def: "The used scoring method for the protein inference using PIA." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002389 ! PIA workflow parameter
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -16521,7 +15738,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1002398
 name: PIA:protein inference used score
 def: "The used base score for the protein inference using PIA." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002389 ! PIA workflow parameter
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -16529,7 +15745,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1002399
 name: PIA:protein inference used PSMs
 def: "The method to determine the PSMs used for scoring by the protein inference." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002389 ! PIA workflow parameter
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -16537,7 +15752,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1002400
 name: PIA:filter
 def: "A filter used for the report generation." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002389 ! PIA workflow parameter
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -16563,7 +15777,6 @@ is_a: MS:1001101 ! protein group or subset relationship
 id: MS:1002404
 name: count of identified proteins
 def: "The number of proteins that have been identified, which must match the number of groups that pass the threshold in the file." [PSI:PI]
-xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002704 ! protein-level result list attribute
 relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
@@ -16577,7 +15790,6 @@ is_a: MS:1002699 ! result list attribute
 id: MS:1002406
 name: count of identified clusters
 def: "The number of protein clusters that have been identified, which must match the number of clusters that pass the threshold in the file." [DOI:10.1002/pmic.201400080, PMID:25092112]
-xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002405 ! protein group-level result list attribute
 relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
@@ -16585,7 +15797,6 @@ relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 id: MS:1002407
 name: cluster identifier
 def: "An identifier applied to protein groups to indicate that they are linked by shared peptides." [PSI:PI]
-xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002698 ! protein cluster identification attribute
 relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
@@ -16593,7 +15804,6 @@ relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 id: MS:1002408
 name: number of distinct protein sequences
 def: "The number of protein clusters that have been identified, which must match the number of clusters that pass the threshold in the file." [PSI:PI]
-xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002405 ! protein group-level result list attribute
 relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
@@ -16620,7 +15830,6 @@ is_a: MS:1002128 ! method file format
 id: MS:1002412
 name: total XIC area
 def: "Summed area of all the extracted ion chromatogram for the peptide (e.g. of all the transitions in SRM)." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002737 ! peptide-level quantification datatype
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -16628,7 +15837,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002413
 name: product background
 def: "The background area for the quantified transition." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -16642,7 +15850,6 @@ is_a: MS:1001457 ! data processing software
 id: MS:1002415
 name: protein group passes threshold
 def: "A Boolean attribute to determine whether the protein group has passed the threshold indicated in the file." [PSI:PI]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002346 ! protein group-level identification attribute
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -16674,7 +15881,6 @@ is_a: MS:1000494 ! Thermo Scientific instrument model
 id: MS:1002420
 name: PASSEL experiment URI
 def: "URI that allows access to a PASSEL experiment." [PSI:PI]
-xref: value-type:xsd\:anyURI "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
 relationship: has_value_type xsd\:anyURI ! The allowed value-type for this CV term
 
@@ -16688,7 +15894,6 @@ is_a: MS:1001302 ! search engine specific input parameter
 id: MS:1002422
 name: Paragon: sample type
 def: "The Paragon method setting indicating the type of sample at the high level, generally meaning the type of quantitation labelling or lack thereof. 'Identification' is indicated for samples without any labels for quantitation." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002421 ! Paragon input parameter
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -16696,7 +15901,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1002423
 name: Paragon: cysteine alkylation
 def: "The Paragon method setting indicating the actual cysteine alkylation agent; 'None' is indicated if there was no cysteine alkylation." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002421 ! Paragon input parameter
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -16704,7 +15908,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1002424
 name: Paragon: instrument setting
 def: "The Paragon method setting (translating to a large number of lower level settings) indicating the instrument used or a category of instrument." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002421 ! Paragon input parameter
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -16712,7 +15915,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1002425
 name: Paragon: search effort
 def: "The Paragon method setting that controls the two major modes of search effort of the Paragon algorithm: the Rapid mode uses a conventional database search, while the Thorough mode uses a hybrid search, starting with the same approach as the Rapid mode but then follows it with a separate tag-based approach enabling a more extensive search." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002421 ! Paragon input parameter
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -16720,7 +15922,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1002426
 name: Paragon: ID focus
 def: "A Paragon method setting that allows the inclusion of large sets of features such as biological modification or substitutions." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002421 ! Paragon input parameter
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -16728,7 +15929,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1002427
 name: Paragon: FDR analysis
 def: "The Paragon method setting that controls whether FDR analysis is conducted." [PSI:PI]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002421 ! Paragon input parameter
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -16736,7 +15936,6 @@ relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV t
 id: MS:1002428
 name: Paragon: quantitation
 def: "The Paragon method setting that controls whether quantitation analysis is conducted." [PSI:PI]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002421 ! Paragon input parameter
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -16744,7 +15943,6 @@ relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV t
 id: MS:1002429
 name: Paragon: background correction
 def: "The Paragon method setting that controls whether the 'Background Correction' analysis is conducted; this processing estimates a correction to the attenuation in extremity ratios that can occur in isobaric quantatitation workflows on complex samples." [PSI:PI]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002421 ! Paragon input parameter
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -16752,7 +15950,6 @@ relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV t
 id: MS:1002430
 name: Paragon: bias correction
 def: "The Paragon method setting that controls whether 'Bias Correction' is invoked in quantitation analysis; this correction is a normalization to set the central tendency of protein ratios to unity." [PSI:PI]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002421 ! Paragon input parameter
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -16760,7 +15957,6 @@ relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV t
 id: MS:1002431
 name: Paragon: channel to use as denominator in ratios
 def: "The Paragon method setting that controls which label channel is used as the denominator in calculating relative expression ratios." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002421 ! Paragon input parameter
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -16774,7 +15970,6 @@ is_a: MS:1001249 ! search input details
 id: MS:1002433
 name: Paragon: modified data dictionary or parameter translation
 def: "This metric detects if any changes have been made to the originally installed key control files for the software; if no changes have been made, then the software version and settings are sufficient to enable exact reproduction; if changes have been made, then the modified ParameterTranslation- and ProteinPilot DataDictionary-XML files much also be provided in order to exactly reproduce a result." [PSI:PI]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002432 ! search engine specific input metadata
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -16782,7 +15977,6 @@ relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV t
 id: MS:1002434
 name: number of spectra searched
 def: "Number of spectra in a search." [PSI:PI]
-xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1001249 ! search input details
 relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
@@ -16790,7 +15984,6 @@ relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 id: MS:1002435
 name: data processing start time
 def: "The time that a data processing action was started." [PSI:MS]
-xref: value-type:xsd\:dateTime "The allowed value-type for this CV term."
 is_a: MS:1000630 ! data processing parameter
 relationship: has_value_type xsd\:dateTime ! The allowed value-type for this CV term
 
@@ -16798,7 +15991,6 @@ relationship: has_value_type xsd\:dateTime ! The allowed value-type for this CV 
 id: MS:1002436
 name: Paragon: digestion
 def: "The Paragon method setting indicating the actual digestion agent - unlike other search tools, this setting does not include options that control partial specificity like 'semitrypsin'; if trypsin is used, trypsin is set, and partially conforming peptides are found in the Thorough mode of search; 'None' should be indicated only if there was really no digestion done." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001249 ! search input details
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -16806,7 +15998,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1002437
 name: number of decoy sequences
 def: "The number of decoy sequences, if the concatenated target-decoy approach is used." [PSI:PI]
-xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
 is_a: MS:1001011 ! search database details
 relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term
 
@@ -16868,7 +16059,6 @@ is_a: MS:1000490 ! Agilent instrument model
 id: MS:1002447
 name: Paragon:special factor
 def: "The Paragon method setting indicating a list of one or more 'special factors', which generally capture secondary effects (relative to other settings) as a set of probabilities of modification features that override the assumed levels. For example the 'gel-based ID' special factor causes an increase probability of oxidation on several resides because of the air exposure impact on a gel, in addition to other effects." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002421 ! Paragon input parameter
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -16876,7 +16066,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1002448
 name: PEAKS:inChorusPeptideScore
 def: "The PEAKS inChorus peptide score." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -16884,7 +16073,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002449
 name: PEAKS:inChorusProteinScore
 def: "The PEAKS inChorus protein score." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -17001,7 +16189,6 @@ is_a: MS:1002701 ! PSM-level result list statistic
 id: MS:1002466
 name: PeptideShaker PSM score
 def: "The probability based PeptideShaker PSM score." [PSI:PI]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002108 ! higher score better
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
@@ -17010,7 +16197,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1002467
 name: PeptideShaker PSM confidence
 def: "The probability based PeptideShaker PSM confidence." [PSI:PI]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002108 ! higher score better
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
@@ -17019,7 +16205,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1002468
 name: PeptideShaker peptide score
 def: "The probability based PeptideShaker peptide score." [PSI:PI]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002358 ! search engine specific peptide sequence-level identification statistic
 is_a: MS:1002363 ! search engine specific score for proteins
 relationship: has_order MS:1002108 ! higher score better
@@ -17029,7 +16214,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1002469
 name: PeptideShaker peptide confidence
 def: "The probability based PeptideShaker peptide confidence." [PSI:PI]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
 relationship: has_order MS:1002108 ! higher score better
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
@@ -17038,7 +16222,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1002470
 name: PeptideShaker protein group score
 def: "The probability based PeptideShaker protein group score." [PSI:PI]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
 is_a: MS:1002368 ! search engine specific score for protein groups
 relationship: has_order MS:1002108 ! higher score better
@@ -17048,7 +16231,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1002471
 name: PeptideShaker protein group confidence
 def: "The probability based PeptideShaker protein group confidence." [PSI:PI]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
 relationship: has_order MS:1002108 ! higher score better
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
@@ -17069,7 +16251,6 @@ is_a: MS:1001249 ! search input details
 id: MS:1002474
 name: ProteoAnnotator:non-canonical gene model score
 def: "The sum of peptide-level scores for peptides mapped only to non-canonical gene models within the group." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002368 ! search engine specific score for protein groups
 relationship: has_order MS:1002108 ! higher score better
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
@@ -17078,7 +16259,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002475
 name: ProteoAnnotator:count alternative peptides
 def: "The count of the number of peptide sequences mapped to non-canonical gene models only within the group." [PSI:PI]
-xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002368 ! search engine specific score for protein groups
 relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
@@ -17086,7 +16266,6 @@ relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 id: MS:1002476
 name: ion mobility drift time
 def: "Drift time of an ion or spectrum of ions as measured in an ion mobility mass spectrometer. This time might refer to the central value of a bin into which all ions within a narrow range of drift time have been aggregated." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000455 ! ion selection attribute
 is_a: MS:1002892 ! ion mobility attribute
 relationship: has_units UO:0000028 ! millisecond
@@ -17096,7 +16275,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1002477
 name: mean ion mobility drift time array
 def: "Array of population mean ion mobility values from a drift time device, reported in seconds (or milliseconds), corresponding to a spectrum of individual peaks encoded with an m/z array." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002893 ! ion mobility array
 relationship: has_units UO:0000028 ! millisecond
 relationship: has_units UO:0000010 ! second
@@ -17161,7 +16339,6 @@ is_a: MS:1002572 ! protein detection statistical threshold
 id: MS:1002487
 name: MassIVE dataset identifier
 def: "Dataset identifier issued by the MassIVE repository. A dataset can refer to either a single sample as part of a study, or all samples that are part of the study corresponding to a publication." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -17169,7 +16346,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1002488
 name: MassIVE dataset URI
 def: "URI that allows the access to one dataset in the MassIVE repository. A dataset can refer to either a single sample as part of a study, or all samples that are part of the study corresponding to a publication." [PSI:PI]
-xref: value-type:xsd\:anyURI "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
 relationship: has_value_type xsd\:anyURI ! The allowed value-type for this CV term
 
@@ -17246,7 +16422,6 @@ is_obsolete: true
 id: MS:1002500
 name: peptide passes threshold
 def: "A Boolean attribute to determine whether the peptide has passed the threshold indicated in the file." [PSI:PI]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001105 ! peptide sequence-level identification attribute
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -17272,7 +16447,6 @@ is_a: MS:1001105 ! peptide sequence-level identification attribute
 id: MS:1002504
 name: modification index
 def: "The order of modifications to be referenced elsewhere in the document." [PSI:PI]
-xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1001055 ! modification parameters
 relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
@@ -17292,7 +16466,6 @@ is_a: MS:1001055 ! modification parameters
 id: MS:1002507
 name: modification rescoring:false localization rate
 def: "Mod position score: false localization rate." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002506 ! modification position score
 relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
@@ -17307,7 +16480,6 @@ is_a: MS:1002694 ! single identification result attribute
 id: MS:1002509
 name: cross-link donor
 def: "The Cross-linking donor, assigned according to the following rules: the export software SHOULD use the following rules to choose the cross-link donor as the: longer peptide, then higher peptide neutral mass, then alphabetical order." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002508 ! cross-linking attribute
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -17315,7 +16487,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1002510
 name: cross-link acceptor
 def: "Cross-linking acceptor, assigned according to the following rules: the export software SHOULD use the following rules to choose the cross-link donor as the: longer peptide, then higher peptide neutral mass, then alphabetical order." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002508 ! cross-linking attribute
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -17323,7 +16494,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1002511
 name: cross-link spectrum identification item
 def: "Cross-linked spectrum identification item." [PSI:PI]
-xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002508 ! cross-linking attribute
 relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
@@ -17331,7 +16501,6 @@ relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 id: MS:1002512
 name: cross-linking score
 def: "Cross-linking scoring value." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -17339,7 +16508,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002513
 name: molecules per cell
 def: "The absolute abundance of protein in a cell." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -17353,7 +16521,6 @@ is_a: MS:1001833 ! quantitation analysis summary
 id: MS:1002515
 name: internal peptide reference used
 def: "States whether an internal peptide reference is used or not in absolute quantitation analysis." [PSI:PI]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001832 ! quantitation software comment or customizations
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -17361,7 +16528,6 @@ relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV t
 id: MS:1002516
 name: internal protein reference used
 def: "States whether an internal protein reference is used or not in absolute quantitation analysis." [PSI:PI]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1001832 ! quantitation software comment or customizations
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -17369,7 +16535,6 @@ relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV t
 id: MS:1002517
 name: internal reference abundance
 def: "The absolute abundance of the spiked in reference peptide or protein used for absolute quantitation analysis." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -17377,7 +16542,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002518
 name: Progenesis:protein group normalised abundance
 def: "The data type normalised abundance for protein groups produced by Progenesis LC-MS." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002739 ! protein group-level quantification datatype
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -17385,7 +16549,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002519
 name: Progenesis:protein group raw abundance
 def: "The data type raw abundance for protein groups produced by Progenesis LC-MS." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002739 ! protein group-level quantification datatype
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -17393,7 +16556,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002520
 name: peptide group ID
 def: "Peptide group identifier for peptide-level stats." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001105 ! peptide sequence-level identification attribute
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -17407,7 +16569,6 @@ is_a: MS:1000857 ! run attribute
 id: MS:1002522
 name: ProteomeDiscoverer:1. Static Terminal Modification
 def: "Determine 1st static terminal post-translational modifications (PTMs)." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -17486,7 +16647,6 @@ is_a: MS:1000121 ! SCIEX instrument model
 id: MS:1002534
 name: ProLuCID:xcorr
 def: "The ProLuCID result 'XCorr'." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002108 ! higher score better
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
@@ -17495,7 +16655,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002535
 name: ProLuCID:deltacn
 def: "The ProLuCID result 'DeltaCn'." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -17503,7 +16662,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002536
 name: D-Score
 def: "D-Score for PTM site location at the PSM-level." [PMID:23307401]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001968 ! PTM localization PSM-level statistic
 relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
@@ -17512,7 +16670,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1002537
 name: MD-Score
 def: "MD-Score for PTM site location at the PSM-level." [PMID:21057138]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001968 ! PTM localization PSM-level statistic
 relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
@@ -17521,7 +16678,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1002538
 name: PTM localization confidence metric
 def: "Localization confidence metric for a post translational modification (PTM)." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001405 ! spectrum identification result details
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -17529,7 +16685,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1002539
 name: PeptideShaker PTM confidence type
 def: "PeptideShaker quality criteria for the confidence of PTM localizations." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002538 ! PTM localization confidence metric
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -17537,7 +16692,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1002540
 name: PeptideShaker PSM confidence type
 def: "PeptideShaker quality criteria for the confidence of PSM's." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002347 ! PSM-level identification statistic
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -17545,7 +16699,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1002541
 name: PeptideShaker peptide confidence type
 def: "PeptideShaker quality criteria for the confidence of peptide identifications." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002358 ! search engine specific peptide sequence-level identification statistic
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -17553,7 +16706,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1002542
 name: PeptideShaker protein confidence type
 def: "PeptideShaker quality criteria for the confidence of protein identifications." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001116 ! single protein identification statistic
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -17573,7 +16725,6 @@ is_a: MS:1001456 ! analysis software
 id: MS:1002545
 name: xi:score
 def: "The xi result 'Score'." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002108 ! higher score better
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
@@ -17607,7 +16758,6 @@ is_a: MS:1002689 ! PTM localization single result statistic
 id: MS:1002550
 name: peptide:phosphoRS score
 def: "phosphoRS score for PTM site location at the peptide-level." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002549 ! PTM localization distinct peptide-level statistic
 relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
@@ -17616,7 +16766,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1002551
 name: peptide:Ascore
 def: "A-score for PTM site location at the peptide-level." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002549 ! PTM localization distinct peptide-level statistic
 relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
@@ -17625,7 +16774,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1002552
 name: peptide:H-Score
 def: "H-Score for peptide phosphorylation site location at the peptide-level." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002549 ! PTM localization distinct peptide-level statistic
 relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
@@ -17634,7 +16782,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1002553
 name: peptide:D-Score
 def: "D-Score for PTM site location at the peptide-level." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002549 ! PTM localization distinct peptide-level statistic
 relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
@@ -17643,7 +16790,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1002554
 name: peptide:MD-Score
 def: "MD-Score for PTM site location at the peptide-level." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002549 ! PTM localization distinct peptide-level statistic
 relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
@@ -17658,7 +16804,6 @@ is_a: MS:1001405 ! spectrum identification result details
 id: MS:1002556
 name: Ascore threshold
 def: "Threshold for Ascore PTM site location score." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002555 ! PTM localization score threshold
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -17666,7 +16811,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002557
 name: D-Score threshold
 def: "Threshold for D-score PTM site location score." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002555 ! PTM localization score threshold
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -17674,7 +16818,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002558
 name: MD-Score threshold
 def: "Threshold for MD-score PTM site location score." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002555 ! PTM localization score threshold
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -17682,7 +16825,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002559
 name: H-Score threshold
 def: "Threshold for H-score PTM site location score." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002555 ! PTM localization score threshold
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -17690,7 +16832,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002560
 name: DeBunker:score threshold
 def: "Threshold for DeBunker PTM site location score." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002555 ! PTM localization score threshold
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -17698,7 +16839,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002561
 name: Mascot:PTM site assignment confidence threshold
 def: "Threshold for Mascot PTM site assignment confidence." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002555 ! PTM localization score threshold
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -17706,7 +16846,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002562
 name: MSQuant:PTM-score threshold
 def: "Threshold for MSQuant:PTM-score." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002555 ! PTM localization score threshold
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -17714,7 +16853,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002563
 name: MaxQuant:PTM Score threshold
 def: "Threshold for MaxQuant:PTM Score." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002555 ! PTM localization score threshold
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -17722,7 +16860,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002564
 name: MaxQuant:P-site localization probability threshold
 def: "Threshold for MaxQuant:P-site localization probability." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002555 ! PTM localization score threshold
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -17730,7 +16867,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002565
 name: MaxQuant:PTM Delta Score threshold
 def: "Threshold for MaxQuant:PTM Delta Score." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002555 ! PTM localization score threshold
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -17738,7 +16874,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002566
 name: MaxQuant:Phospho (STY) Probabilities threshold
 def: "Threshold for MaxQuant:Phospho (STY) Probabilities." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002555 ! PTM localization score threshold
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -17746,7 +16881,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002567
 name: phosphoRS score threshold
 def: "Threshold for phosphoRS score." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002555 ! PTM localization score threshold
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -17754,7 +16888,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002568
 name: phosphoRS site probability threshold
 def: "Threshold for phosphoRS site probability." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002555 ! PTM localization score threshold
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -17762,7 +16895,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002569
 name: ProteomeDiscoverer:Number of Spectra Processed At Once
 def: "Number of spectra processed at once in a ProteomeDiscoverer search." [PSI:PI]
-xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
@@ -17770,7 +16902,6 @@ relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 id: MS:1002570
 name: sequence multiply subsumable protein
 def: "A protein for which the matched peptide sequences are the same, or a subset of, the matched peptide sequences for two or more other proteins combined. These other proteins need not all be in the same group." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001101 ! protein group or subset relationship
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -17778,7 +16909,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1002571
 name: spectrum multiply subsumable protein
 def: "A protein for which the matched spectra are the same, or a subset of, the matched spectra for two or more other proteins combined. These other proteins need not all be in the same group." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001101 ! protein group or subset relationship
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -17948,7 +17078,6 @@ is_a: MS:1001456 ! analysis software
 id: MS:1002599
 name: splash key
 def: "Spectral Hash key, an unique identifier for spectra." [PMID:27824832]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001405 ! spectrum identification result details
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -18151,7 +17280,6 @@ is_a: MS:1003181 ! combined dissociation method
 id: MS:1002632
 name: jPOST dataset identifier
 def: "Dataset identifier issued by the jPOST repository. A dataset can refer to either a single sample as part of a study, or all samples that are part of the study corresponding to a publication." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -18159,7 +17287,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1002633
 name: jPOST dataset URI
 def: "URI that allows the access to one dataset in the jPOST repository. A dataset can refer to either a single sample as part of a study, or all samples that are part of the study corresponding to a publication." [PSI:PI]
-xref: value-type:xsd\:anyURI "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
 relationship: has_value_type xsd\:anyURI ! The allowed value-type for this CV term
 
@@ -18185,7 +17312,6 @@ is_a: MS:1001105 ! peptide sequence-level identification attribute
 id: MS:1002637
 name: chromosome name
 def: "The name or number of the chromosome to which a given peptide has been mapped." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002636 ! proteogenomics attribute
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -18193,7 +17319,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1002638
 name: chromosome strand
 def: "The strand (+ or -) to which the peptide has been mapped." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002636 ! proteogenomics attribute
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -18202,7 +17327,6 @@ id: MS:1002639
 name: peptide start on chromosome
 def: "OBSOLETE The overall start position on the chromosome to which a peptide has been mapped i.e. the position of the first base of the first codon, using a zero-based counting system." [PSI:PI]
 comment: This term was obsoleted because it contains redundant info contained in term MS:1002643 - peptide start positions on chromosome.
-xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002636 ! proteogenomics attribute
 is_obsolete: true
 relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
@@ -18211,7 +17335,6 @@ relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 id: MS:1002640
 name: peptide end on chromosome
 def: "The overall end position on the chromosome to which a peptide has been mapped i.e. the position of the third base of the last codon, using a zero-based counting system." [PSI:PI]
-xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002636 ! proteogenomics attribute
 relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
@@ -18219,7 +17342,6 @@ relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 id: MS:1002641
 name: peptide exon count
 def: "The number of exons to which the peptide has been mapped." [PSI:PI]
-xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002636 ! proteogenomics attribute
 relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
@@ -18227,7 +17349,6 @@ relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 id: MS:1002642
 name: peptide exon nucleotide sizes
 def: "A comma separated list of the number of DNA bases within each exon to which a peptide has been mapped. Assuming standard operation of a search engine, the peptide exon sizes should sum to exactly three times the peptide length." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002636 ! proteogenomics attribute
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -18235,7 +17356,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1002643
 name: peptide start positions on chromosome
 def: "A comma separated list of start positions within exons to which the peptide has been mapped, relative to peptide-chromosome start, assuming a zero-based counting system. The first value MUST match the value in peptide start on chromosome." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002636 ! proteogenomics attribute
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -18243,7 +17363,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1002644
 name: genome reference version
 def: "The reference genome and versioning string as used for mapping. All coordinates are within this frame of reference." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002636 ! proteogenomics attribute
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -18265,7 +17384,6 @@ relationship: part_of MS:1000577 ! source data file
 id: MS:1002647
 name: Thermo nativeID format, combined spectra
 def: "Thermo comma separated list of spectra that have been combined prior to searching or interpretation." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002646 ! native spectrum identifier format, combined spectra
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -18273,7 +17391,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1002648
 name: Waters nativeID format, combined spectra
 def: "Waters comma separated list of spectra that have been combined prior to searching or interpretation." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002646 ! native spectrum identifier format, combined spectra
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -18281,7 +17398,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1002649
 name: WIFF nativeID format, combined spectra
 def: "WIFF comma separated list of spectra that have been combined prior to searching or interpretation." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002646 ! native spectrum identifier format, combined spectra
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -18289,7 +17405,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1002650
 name: Bruker/Agilent YEP nativeID format, combined spectra
 def: "Bruker/Agilent comma separated list of spectra that have been combined prior to searching or interpretation." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002646 ! native spectrum identifier format, combined spectra
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -18297,7 +17412,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1002651
 name: Bruker BAF nativeID format, combined spectra
 def: "Bruker BAF comma separated list of spectra that have been combined prior to searching or interpretation." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002646 ! native spectrum identifier format, combined spectra
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -18306,7 +17420,6 @@ id: MS:1002652
 name: Bruker FID nativeID format, combined spectra
 def: "Bruker FID comma separated list of spectra that have been combined prior to searching or interpretation." [PSI:PI]
 comment: The nativeID must be the same as the source file ID.
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002646 ! native spectrum identifier format, combined spectra
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -18315,7 +17428,6 @@ id: MS:1002653
 name: multiple peak list nativeID format, combined spectra
 def: "Comma separated list of spectra that have been combined prior to searching or interpretation." [PSI:PI]
 comment: Used for conversion of peak list files with multiple spectra, i.e. MGF, PKL, merged DTA files. Index is the spectrum number in the file, starting from 0.
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002646 ! native spectrum identifier format, combined spectra
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -18324,7 +17436,6 @@ id: MS:1002654
 name: single peak list nativeID format, combined spectra
 def: "Comma separated list of spectra that have been combined prior to searching or interpretation." [PSI:PI]
 comment: The nativeID must be the same as the source file ID. Used for conversion of peak list files with one spectrum per file, typically folder of PKL or DTAs, each sourceFileRef is different.
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002646 ! native spectrum identifier format, combined spectra
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -18333,7 +17444,6 @@ id: MS:1002655
 name: scan number only nativeID format, combined spectra
 def: "Comma separated list of spectra that have been combined prior to searching or interpretation." [PSI:PI]
 comment: Used for conversion from mzXML, or DTA folder where native scan numbers can be derived.
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002646 ! native spectrum identifier format, combined spectra
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -18342,7 +17452,6 @@ id: MS:1002656
 name: spectrum identifier nativeID format, combined spectra
 def: "Comma separated list of spectra that have been combined prior to searching or interpretation." [PSI:PI]
 comment: Used for conversion from mzData. The spectrum id attribute is referenced.
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002646 ! native spectrum identifier format, combined spectra
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -18351,7 +17460,6 @@ id: MS:1002657
 name: mzML unique identifier, combined spectra
 def: "Comma separated list of spectra that have been combined prior to searching or interpretation." [PSI:PI]
 comment: A unique identifier of a spectrum stored in an mzML file.
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002646 ! native spectrum identifier format, combined spectra
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -18384,7 +17492,6 @@ is_a: MS:1001456 ! analysis software
 id: MS:1002662
 name: Morpheus:Morpheus score
 def: "Morpheus score for PSMs." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002108 ! higher score better
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
@@ -18393,7 +17500,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002663
 name: Morpheus:summed Morpheus score
 def: "Summed Morpheus score for protein groups." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002368 ! search engine specific score for protein groups
 relationship: has_order MS:1002108 ! higher score better
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
@@ -18402,7 +17508,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002664
 name: interaction score derived from cross-linking
 def: "Parent term for interaction scores derived from cross-linking." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002675 ! cross-linking result details
 relationship: has_regexp MS:1002665 ! ([:digit:]+[.][a|b]:[:digit:]+:[:digit:]+[.][:digit:]+([Ee][+-][0-9]+)*:(true|false]\{1\}))
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
@@ -18429,7 +17534,6 @@ is_a: MS:1001536 ! Bruker Daltonics micrOTOF series
 id: MS:1002668
 name: frag: iTRAQ 4plex reporter ion
 def: "Standard reporter ion for iTRAQ 4Plex. The value slot holds the integer mass of the iTRAQ 4Plex reporter ion, e.g. 114." [PSI:PI]
-xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002307 ! fragmentation ion type
 relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
@@ -18437,7 +17541,6 @@ relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 id: MS:1002669
 name: frag: iTRAQ 8plex reporter ion
 def: "Standard reporter ion for iTRAQ 8Plex. The value slot holds the integer mass of the iTRAQ 8Plex reporter ion, e.g. 113." [PSI:PI]
-xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002307 ! fragmentation ion type
 relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
@@ -18445,7 +17548,6 @@ relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 id: MS:1002670
 name: frag: TMT reporter ion
 def: "Standard reporter ion for TMT. The value slot holds the integer mass of the TMT reporter ion and can be suffixed with either N or C, indicating whether the mass difference is encoded at a Nitrogen or Carbon atom, e.g. 127N." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002307 ! fragmentation ion type
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -18453,7 +17555,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1002671
 name: frag: TMT ETD reporter ion
 def: "Standard reporter ion for TMT with ETD fragmentation. The value slot holds the integer mass of the TMT ETD reporter ion and can be suffixed with either N or C, indicating whether the mass difference is encoded at a Nitrogen or Carbon atom, e.g. 127C." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002307 ! fragmentation ion type
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -18485,7 +17586,6 @@ relationship: part_of MS:1001000 ! spectrum interpretation
 id: MS:1002676
 name: protein-pair-level global FDR
 def: "Estimation of the global false discovery rate of proteins-pairs in cross-linking experiments." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002664 ! interaction score derived from cross-linking
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
 relationship: has_regexp MS:1002665 ! ([:digit:]+[.][a|b]:[:digit:]+:[:digit:]+[.][:digit:]+([Ee][+-][0-9]+)*:(true|false]\{1\}))
@@ -18495,7 +17595,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002677
 name: residue-pair-level global FDR
 def: "Estimation of the global false discovery rate of residue-pairs in cross-linking experiments." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002664 ! interaction score derived from cross-linking
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
 relationship: has_regexp MS:1002665 ! ([:digit:]+[.][a|b]:[:digit:]+:[:digit:]+[.][:digit:]+([Ee][+-][0-9]+)*:(true|false]\{1\}))
@@ -18517,7 +17616,6 @@ is_a: MS:1000133 ! collision-induced dissociation
 id: MS:1002680
 name: supplemental collision energy
 def: "Energy for an ion experiencing supplemental collision with a stationary gas particle resulting in dissociation of the ion." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000510 ! precursor activation attribute
 relationship: has_units UO:0000266 ! electronvolt
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
@@ -18526,7 +17624,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1002681
 name: OpenXQuest:combined score
 def: "OpenXQuest's combined score for a cross-link spectrum match." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1001153 ! search engine specific score
 relationship: has_order MS:1002108 ! higher score better
@@ -18536,7 +17633,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002682
 name: OpenXQuest:xcorr xlink
 def: "OpenXQuest's cross-correlation of cross-linked ions subscore." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1001153 ! search engine specific score
 relationship: has_order MS:1002108 ! higher score better
@@ -18546,7 +17642,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002683
 name: OpenXQuest:xcorr common
 def: "OpenXQuest's cross-correlation of unlinked ions subscore." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1001153 ! search engine specific score
 relationship: has_order MS:1002108 ! higher score better
@@ -18556,7 +17651,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002684
 name: OpenXQuest:match-odds
 def: "OpenXQuest's match-odds subscore." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1001153 ! search engine specific score
 relationship: has_order MS:1002108 ! higher score better
@@ -18567,7 +17661,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002685
 name: OpenXQuest:intsum
 def: "OpenXQuest's sum of matched peak intensity subscore." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1001153 ! search engine specific score
 relationship: has_order MS:1002108 ! higher score better
@@ -18578,7 +17671,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002686
 name: OpenXQuest:wTIC
 def: "OpenXQuest's weighted percent of total ion current subscore." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1001153 ! search engine specific score
 relationship: has_order MS:1002108 ! higher score better
@@ -18761,7 +17853,6 @@ is_a: MS:1001456 ! analysis software
 id: MS:1002721
 name: MSPathFinder:SpecEValue
 def: "MSPathFinder spectral E-value." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002353 ! PSM-level e-value
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002109 ! lower score better
@@ -18771,7 +17862,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002722
 name: MSPathFinder:EValue
 def: "MSPathFinder E-value." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002353 ! PSM-level e-value
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002109 ! lower score better
@@ -18781,7 +17871,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002723
 name: MSPathFinder:QValue
 def: "MSPathFinder Q-value." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002354 ! PSM-level q-value
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
@@ -18790,7 +17879,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002724
 name: MSPathFinder:PepQValue
 def: "MSPathFinder peptide-level Q-value." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -18798,7 +17886,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002725
 name: MSPathFinder:RawScore
 def: "MSPathFinder raw score." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -18848,7 +17935,6 @@ is_a: MS:1000494 ! Thermo Scientific instrument model
 id: MS:1002733
 name: peptide-level spectral count
 def: "The number of MS2 spectra identified for a peptide sequence specified by the amino acid one-letter codes plus optional PTMs in spectral counting." [PSI:PI]
-xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002737 ! peptide-level quantification datatype
 relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
@@ -18856,7 +17942,6 @@ relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 id: MS:1002734
 name: peptide ion-level spectral count
 def: "The number of MS2 spectra identified for a molecular ion defined by the peptide sequence represented by the amino acid one-letter codes, plus optional PTMs plus optional charged aducts plus the charge state, in spectral counting." [PSI:PI]
-xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002737 ! peptide-level quantification datatype
 relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
@@ -18958,7 +18043,6 @@ is_a: MS:1000572 ! binary data compression type
 id: MS:1002749
 name: Mascot:IntegratedSpectralLibrarySearch
 def: "Means that Mascot has integrated the search results of database and spectral library search into a single data set." [PSI:PI]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002095 ! Mascot input parameter
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -19328,7 +18412,6 @@ relationship: part_of MS:1000353 ! adduct ion
 id: MS:1002810
 name: adduct ion X m/z
 def: "Theoretical m/z of the X component in the adduct (addition product) M+X or M-X. This term was formerly called 'adduct ion mass', but it is not really a mass. It corresponds to the column mislabelled as 'mass' at https://fiehnlab.ucdavis.edu/staff/kind/Metabolomics/MS-Adduct-Calculator." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1003056 ! adduct ion property
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 relationship: has_units MS:1000040 ! m/z
@@ -19337,7 +18420,6 @@ relationship: has_units MS:1000040 ! m/z
 id: MS:1002811
 name: adduct ion isotope
 def: "Isotope of the matrix molecule M of an adduct formation." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1003056 ! adduct ion property
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -19351,7 +18433,6 @@ is_a: MS:1002479 ! regular expression
 id: MS:1002813
 name: adduct ion formula
 def: "Adduct formation formula of the form M+X or M-X, as constrained by the provided regular expression." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002809 ! adduct ion attribute
 relationship: has_regexp MS:1002812 ! (\[[:digit:]{0,1}M([+][:digit:]{0,1}(H|K|(Na)|(Li)|(Cl)|(Br)|(NH3)|(NH4)|(CH3OH)|(IsoProp)|(DMSO)|(FA)|(Hac)|(TFA)|(NaCOOH)|(HCOOH)|(CF3COOH)|(ACN))){0,}([-][:digit:]{0,1}(H|(H2O)|(CH2)|(CH4)|(NH3)|(CO)|(CO2)|(COCH2)|(HCOOH)|(C2H4)|(C4H8)|(C3H2O3)|(C5H8O4)|(C6H10O4)|(C6H10O5)|(C6H8O6))){0,}\][:digit:]{0,1}[+-])
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
@@ -19367,7 +18448,6 @@ is_a: UO:0000000 ! unit
 id: MS:1002815
 name: inverse reduced ion mobility
 def: "Ion mobility measurement for an ion or spectrum of ions as measured in an ion mobility mass spectrometer. This might refer to the central value of a bin into which all ions within a narrow range of mobilities have been aggregated." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000455 ! ion selection attribute
 is_a: MS:1002892 ! ion mobility attribute
 relationship: has_units MS:1002814 ! volt-second per square centimeter
@@ -19377,7 +18457,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1002816
 name: mean ion mobility array
 def: "Array of population mean ion mobility values (K or K0) based on ion separation in gaseous phase due to different ion mobilities under an electric field based on ion size, m/z and shape, corresponding to a spectrum of individual peaks encoded with an m/z array." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002893 ! ion mobility array
 relationship: has_units UO:0000028 ! millisecond
 relationship: has_units UO:0000010 ! second
@@ -19399,7 +18478,6 @@ is_a: MS:1000767 ! native spectrum identifier format
 id: MS:1002819
 name: Bruker TDF nativeID format, combined spectra
 def: "Bruker TDF comma separated list of spectra that have been combined prior to searching or interpretation." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002646 ! native spectrum identifier format, combined spectra
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -19451,7 +18529,6 @@ is_a: MS:1001456 ! analysis software
 id: MS:1002827
 name: MetaMorpheus:score
 def: "MetaMorpheus score for PSMs." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002108 ! higher score better
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
@@ -19460,7 +18537,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002828
 name: MetaMorpheus:protein score
 def: "MetaMorpheus score for protein groups." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002368 ! search engine specific score for protein groups
 relationship: has_order MS:1002108 ! higher score better
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
@@ -19469,7 +18545,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002829
 name: XCMS:into
 def: "Feature intensity produced by XCMS findPeaks() from integrated peak intensity." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002735 ! feature-level quantification datatype
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -19477,7 +18552,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002830
 name: XCMS:intf
 def: "Feature intensity produced by XCMS findPeaks() from baseline corrected integrated peak intensity." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002735 ! feature-level quantification datatype
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -19485,7 +18559,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002831
 name: XCMS:maxo
 def: "Feature intensity produced by XCMS findPeaks() from maximum peak intensity." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002735 ! feature-level quantification datatype
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -19493,7 +18566,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002832
 name: XCMS:area
 def: "Feature intensity produced by XCMS findPeaks() from feature area that is not normalized by the scan rate." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002735 ! feature-level quantification datatype
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -19507,7 +18579,6 @@ is_a: MS:1000857 ! run attribute
 id: MS:1002834
 name: ProteomeDiscoverer:Delta Score
 def: "The Delta Score reported by Proteome Discoverer version 2." [PSI:PI]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
@@ -19521,7 +18592,6 @@ is_a: MS:1000494 ! Thermo Scientific instrument model
 id: MS:1002836
 name: iProX dataset identifier
 def: "Dataset identifier issued by the iProX repository. A dataset can refer to either a single sample as part of a study, or all samples that are part of the study corresponding to a publication." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -19529,7 +18599,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1002837
 name: iProX dataset URI
 def: "URI that allows the access to one dataset in the iProX repository. A dataset can refer to either a single sample as part of a study, or all samples that are part of the study corresponding to a publication." [PSI:PI]
-xref: value-type:xsd\:anyURI "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
 relationship: has_value_type xsd\:anyURI ! The allowed value-type for this CV term
 
@@ -19555,7 +18624,6 @@ relationship: part_of MS:0000000 ! Proteomics Standards Initiative Mass Spectrom
 id: MS:1002841
 name: external HDF5 dataset
 def: "The HDF5 dataset location containing the binary data, relative to the dataset containing the mzML. Also indicates that there is no data in the <binary> section of the BinaryDataArray." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002840 ! external reference data
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -19563,7 +18631,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1002842
 name: external offset
 def: "The position in the external data where the array begins." [PSI:PI]
-xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 relationship: has_units UO:0000189 ! Count
 is_a: MS:1002840 ! external reference data
 relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term
@@ -19572,7 +18639,6 @@ relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type fo
 id: MS:1002843
 name: external array length
 def: "Describes how many fields an array contains." [PSI:PI]
-xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 relationship: has_units UO:0000189 ! Count
 is_a: MS:1002840 ! external reference data
 relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term
@@ -19587,7 +18653,6 @@ is_a: MS:1001458 ! spectrum generation information
 id: MS:1002845
 name: Associated file URI
 def: "URI of one external file associated to the PRIDE experiment (maybe through a PX submission)." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002844 ! Experiment additional parameter
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -19595,7 +18660,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1002846
 name: Associated raw file URI
 def: "URI of one raw data file associated to the PRIDE experiment (maybe through a PX submission)." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002845 ! Associated file URI
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -19603,7 +18667,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1002847
 name: ProteomeCentral dataset URI
 def: "URI associated to one PX submission in ProteomeCentral." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002844 ! Experiment additional parameter
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -19611,7 +18674,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1002848
 name: Result file URI
 def: "URI of one file labeled as 'Result', associated to one PX submission." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002845 ! Associated file URI
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -19619,7 +18681,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1002849
 name: Search engine output file URI
 def: "URI of one search engine output file associated to one PX submission." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002845 ! Associated file URI
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -19627,7 +18688,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1002850
 name: Peak list file URI
 def: "URI of one of one search engine output file associated to one PX submission." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002845 ! Associated file URI
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -19635,7 +18695,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1002851
 name: Other type file URI
 def: "URI of one file labeled as 'Other', associated to one PX submission." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002845 ! Associated file URI
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -19643,7 +18702,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1002852
 name: Dataset FTP location
 def: "FTP location of one entire PX data set." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002844 ! Experiment additional parameter
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -19687,7 +18745,6 @@ is_a: MS:1002844 ! Experiment additional parameter
 id: MS:1002859
 name: Additional associated raw file URI
 def: "Additional URI of one raw data file associated to the PRIDE experiment (maybe through a PX submission). The URI is provided via an additional resource to PRIDE." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002845 ! Associated file URI
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -19695,7 +18752,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1002860
 name: Gel image file URI
 def: "URI of one gel image file associated to one PX submission." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002845 ! Associated file URI
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -19703,7 +18759,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1002861
 name: Reprocessed complete dataset
 def: "All the raw files included in the original dataset (or group of original datasets) have been reanalysed." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002844 ! Experiment additional parameter
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -19711,7 +18766,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1002862
 name: Reprocessed subset dataset
 def: "A subset of the raw files included in the original dataset (or group of original datasets) has been reanalysed." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002844 ! Experiment additional parameter
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -19737,7 +18791,6 @@ is_a: MS:1002844 ! Experiment additional parameter
 id: MS:1002866
 name: Reference
 def: "Literature reference associated with one dataset (including the authors, title, year and journal details). The value field can be used for the PubMedID, or to specify if one manuscript is just submitted or accepted, but it does not have a PubMedID yet." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002844 ! Experiment additional parameter
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -19778,7 +18831,6 @@ is_a: MS:1001457 ! data processing software
 id: MS:1002872
 name: Panorama Public dataset identifier
 def: "Dataset identifier issued by the Panorama Public repository. A dataset can refer to either a single sample as part of a study, or all samples that are part of the study corresponding to a publication." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -19786,7 +18838,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1002873
 name: Panorama Public dataset URI
 def: "URI that allows the access to one dataset in the Panorama Public repository. A dataset can refer to either a single sample as part of a study, or all samples that are part of the study corresponding to a publication." [PSI:PI]
-xref: value-type:xsd\:anyURI "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
 relationship: has_value_type xsd\:anyURI ! The allowed value-type for this CV term
 
@@ -19872,7 +18923,6 @@ is_a: MS:1001805 ! quantification datatype
 id: MS:1002887
 name: Progenesis QI normalised abundance
 def: "The normalised abundance produced by Progenesis QI LC-MS." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002886 ! small molecule quantification datatype
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -19886,7 +18936,6 @@ is_a: MS:1002694 ! single identification result attribute
 id: MS:1002889
 name: Progenesis MetaScope score
 def: "The confidence score produced by Progenesis QI." [PSI:PI]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002888 ! small molecule confidence measure
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
@@ -19894,7 +18943,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1002890
 name: fragmentation score
 def: "The fragmentation confidence score." [PSI:PI]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002888 ! small molecule confidence measure
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
@@ -19902,7 +18950,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1002891
 name: isotopic fit score
 def: "The isotopic fit confidence score." [PSI:PI]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002888 ! small molecule confidence measure
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
@@ -19923,7 +18970,6 @@ is_a: MS:1000513 ! binary data array
 id: MS:1002894
 name: InChIKey
 def: "Unique chemical structure identifier for chemical compounds." [PMID:273343401]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001405 ! spectrum identification result details
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -19937,7 +18983,6 @@ is_a: MS:1002694 ! single identification result attribute
 id: MS:1002896
 name: compound identification confidence level
 def: "Confidence level for annotation of identified compounds as defined by the Metabolomics Standards Initiative (MSI). The value slot can have the values 'Level 0' until 'Level 4'." [PMID:29748461]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002895 ! small molecule identification attribute
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -19946,7 +18991,6 @@ id: MS:1002897
 name: isotopomer peak
 def: "OBSOLETE Identifies a peak when no de-isotoping has been performed. The value slot reports the isotopomer peak, e.g. '2H', '13C', '15N', '18O', '31P'." [PSI:PI]
 comment: This term was obsoleted because it was replaced by the more exact terms MS:1002956 'isotopic ion MS peak', MS:1002957 'isotopomer MS peak' and MS:1002958 'isotopologue MS peak' instead.
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000231 ! peak
 is_obsolete: true
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
@@ -20009,7 +19053,6 @@ is_a: MS:1002905 ! proteoform-level identification statistic
 id: MS:1002907
 name: proteoform-level global FDR
 def: "Estimation of the global false discovery rate of proteoforms." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002905 ! proteoform-level identification statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
@@ -20018,7 +19061,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002908
 name: proteoform-level local FDR
 def: "Estimation of the local false discovery rate of proteoforms." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002905 ! proteoform-level identification statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
@@ -20033,7 +19075,6 @@ is_a: MS:1002573 ! spectrum identification statistical threshold
 id: MS:1002910
 name: proteoform-level global FDR threshold
 def: "Threshold for the global false discovery rate of proteoforms." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002909 ! proteoform-level statistical threshold
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -20041,7 +19082,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002911
 name: proteoform-level local FDR threshold
 def: "Threshold for the local false discovery rate of proteoforms." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002909 ! proteoform-level statistical threshold
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -20067,7 +19107,6 @@ is_a: MS:1002912 ! TopPIC input parameter
 id: MS:1002915
 name: TopPIC:error tolerance
 def: "Error tolerance for precursor and fragment masses in PPM." [PSI:PI]
-xref: value-type:xsd\:integer "The allowed value-type for this CV term."
 is_a: MS:1002912 ! TopPIC input parameter
 relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term
 
@@ -20075,7 +19114,6 @@ relationship: has_value_type xsd\:integer ! The allowed value-type for this CV t
 id: MS:1002916
 name: TopPIC:max shift
 def: "Maximum value of the mass shift (in Dalton) of an unexpected modification." [PSI:PI]
-xref: value-type:xsd\:integer "The allowed value-type for this CV term."
 is_a: MS:1002912 ! TopPIC input parameter
 relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term
 
@@ -20083,7 +19121,6 @@ relationship: has_value_type xsd\:integer ! The allowed value-type for this CV t
 id: MS:1002917
 name: TopPIC:min shift
 def: "Minimum value of the mass shift (in Dalton) of an unexpected modification." [PSI:PI]
-xref: value-type:xsd\:integer "The allowed value-type for this CV term."
 is_a: MS:1002912 ! TopPIC input parameter
 relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term
 
@@ -20091,7 +19128,6 @@ relationship: has_value_type xsd\:integer ! The allowed value-type for this CV t
 id: MS:1002918
 name: TopPIC:shift num
 def: "Maximum number of unexpected modifications in a proteoform spectrum match." [PSI:PI]
-xref: value-type:xsd\:integer "The allowed value-type for this CV term."
 is_a: MS:1002912 ! TopPIC input parameter
 relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term
 
@@ -20099,7 +19135,6 @@ relationship: has_value_type xsd\:integer ! The allowed value-type for this CV t
 id: MS:1002919
 name: TopPIC:spectral cutoff type
 def: "Spectrum-level cutoff type for filtering identified proteoform spectrum matches." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002912 ! TopPIC input parameter
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -20107,7 +19142,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1002920
 name: TopPIC:spectral cutoff value
 def: "Spectrum-level cutoff value for filtering identified proteoform spectrum matches." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002912 ! TopPIC input parameter
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -20115,7 +19149,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002921
 name: TopPIC:proteoform-level cutoff type
 def: "Proteoform-level cutoff type for filtering identified proteoform spectrum matches." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002912 ! TopPIC input parameter
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -20123,7 +19156,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1002922
 name: TopPIC:proteoform-level cutoff value
 def: "Proteoform-level cutoff value for filtering identified proteoform spectrum matches." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002912 ! TopPIC input parameter
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -20131,7 +19163,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002923
 name: TopPIC:generating function
 def: "P-value and E-value estimation using generating function." [PSI:PI]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002912 ! TopPIC input parameter
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -20139,7 +19170,6 @@ relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV t
 id: MS:1002924
 name: TopPIC:combined spectrum number
 def: "Number of combined spectra." [PSI:PI]
-xref: value-type:xsd\:integer "The allowed value-type for this CV term."
 is_a: MS:1002912 ! TopPIC input parameter
 relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term
 
@@ -20153,7 +19183,6 @@ is_a: MS:1002912 ! TopPIC input parameter
 id: MS:1002926
 name: TopPIC:thread number
 def: "Number of threads used in TopPIC." [PSI:PI]
-xref: value-type:xsd\:integer "The allowed value-type for this CV term."
 is_a: MS:1002912 ! TopPIC input parameter
 relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term
 
@@ -20161,7 +19190,6 @@ relationship: has_value_type xsd\:integer ! The allowed value-type for this CV t
 id: MS:1002927
 name: TopPIC:use TopFD feature
 def: "Proteoform identification using TopFD feature file." [PSI:PI]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002912 ! TopPIC input parameter
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -20169,7 +19197,6 @@ relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV t
 id: MS:1002928
 name: TopPIC:spectral E-value
 def: "TopPIC spectrum-level E-value." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1002353 ! PSM-level e-value
 relationship: has_order MS:1002109 ! lower score better
@@ -20179,7 +19206,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002929
 name: TopPIC:spectral FDR
 def: "TopPIC spectrum-level FDR." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1002351 ! PSM-level local FDR
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
@@ -20188,7 +19214,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002930
 name: TopPIC:proteoform-level FDR
 def: "TopPIC proteoform-level FDR." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002908 ! proteoform-level local FDR
 is_a: MS:1002906 ! search engine specific score for proteoforms
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
@@ -20197,7 +19222,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002931
 name: TopPIC:spectral p-value
 def: "TopPIC spectrum-level p-value." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1002352 ! PSM-level p-value
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
@@ -20206,7 +19230,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002932
 name: TopPIC:MIScore
 def: "Modification identification score." [PMID:27291504]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001968 ! PTM localization PSM-level statistic
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -20214,7 +19237,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1002933
 name: TopPIC:MIScore threshold
 def: "TopPIC:MIScore threshold." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002555 ! PTM localization score threshold
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -20240,7 +19262,6 @@ is_a: MS:1002934 ! TopMG input parameter
 id: MS:1002937
 name: TopMG:error tolerance
 def: "Error tolerance for precursor and fragment masses in PPM." [PSI:PI]
-xref: value-type:xsd\:integer "The allowed value-type for this CV term."
 is_a: MS:1002934 ! TopMG input parameter
 relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term
 
@@ -20248,7 +19269,6 @@ relationship: has_value_type xsd\:integer ! The allowed value-type for this CV t
 id: MS:1002938
 name: TopMG:max shift
 def: "Maximum value of the mass shift (in Dalton)." [PSI:PI]
-xref: value-type:xsd\:integer "The allowed value-type for this CV term."
 is_a: MS:1002934 ! TopMG input parameter
 relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term
 
@@ -20256,7 +19276,6 @@ relationship: has_value_type xsd\:integer ! The allowed value-type for this CV t
 id: MS:1002939
 name: TopMG:spectral cutoff type
 def: "Spectrum-level cutoff type for filtering identified proteoform spectrum matches." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002934 ! TopMG input parameter
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -20264,7 +19283,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1002940
 name: TopMG:spectral cutoff value
 def: "Spectrum-level cutoff value for filtering identified proteoform spectrum matches." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002934 ! TopMG input parameter
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -20272,7 +19290,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002941
 name: TopMG:proteoform-level cutoff type
 def: "Proteoform-level cutoff type for filtering identified proteoform spectrum matches." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002934 ! TopMG input parameter
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -20280,7 +19297,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1002942
 name: TopMG:proteoform-level cutoff value
 def: "Proteoform-level cutoff value for filtering identified proteoform spectrum matches." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002934 ! TopMG input parameter
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -20294,7 +19310,6 @@ is_a: MS:1002934 ! TopMG input parameter
 id: MS:1002944
 name: TopMG:thread number
 def: "Number of threads used in TopMG." [PSI:PI]
-xref: value-type:xsd\:integer "The allowed value-type for this CV term."
 is_a: MS:1002934 ! TopMG input parameter
 relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term
 
@@ -20302,7 +19317,6 @@ relationship: has_value_type xsd\:integer ! The allowed value-type for this CV t
 id: MS:1002945
 name: TopMG:use TopFD feature
 def: "Proteoform identification using TopFD feature file." [PSI:PI]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002934 ! TopMG input parameter
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -20310,7 +19324,6 @@ relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV t
 id: MS:1002946
 name: TopMG:proteoform graph gap size
 def: "Gap size in constructing proteoform graph." [PSI:PI]
-xref: value-type:xsd\:integer "The allowed value-type for this CV term."
 is_a: MS:1002934 ! TopMG input parameter
 relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term
 
@@ -20318,7 +19331,6 @@ relationship: has_value_type xsd\:integer ! The allowed value-type for this CV t
 id: MS:1002947
 name: TopMG:variable PTM number
 def: "Maximum number of variable PTMs." [PSI:PI]
-xref: value-type:xsd\:integer "The allowed value-type for this CV term."
 is_a: MS:1002934 ! TopMG input parameter
 relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term
 
@@ -20326,7 +19338,6 @@ relationship: has_value_type xsd\:integer ! The allowed value-type for this CV t
 id: MS:1002948
 name: TopMG:variable PTM number in proteoform graph gap
 def: "Maximum number of variable PTMs in a proteoform graph gap." [PSI:PI]
-xref: value-type:xsd\:integer "The allowed value-type for this CV term."
 is_a: MS:1002934 ! TopMG input parameter
 relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term
 
@@ -20334,7 +19345,6 @@ relationship: has_value_type xsd\:integer ! The allowed value-type for this CV t
 id: MS:1002949
 name: TopMG:use ASF-DIAGONAL
 def: "Protein filtering using ASF-DIAGONAL method." [PMID:29327814]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1002934 ! TopMG input parameter
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
@@ -20342,7 +19352,6 @@ relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV t
 id: MS:1002950
 name: TopMG:spectral E-value
 def: "TopMG spectrum-level E-value." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002353 ! PSM-level e-value
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002109 ! lower score better
@@ -20352,7 +19361,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002951
 name: TopMG:spectral FDR
 def: "TopMG spectrum-level FDR." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002351 ! PSM-level local FDR
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
@@ -20361,7 +19369,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002952
 name: TopMG:proteoform-level FDR
 def: "TopMG proteoform-level FDR." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002908 ! proteoform-level local FDR
 is_a: MS:1002906 ! search engine specific score for proteoforms
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
@@ -20370,7 +19377,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002953
 name: TopMG:spectral p-value
 def: "TopMG spectrum-level p-value." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002352 ! PSM-level p-value
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
@@ -20379,7 +19385,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002954
 name: collisional cross sectional area
 def: "Structural molecular descriptor for the effective interaction area between the ion and neutral gas measured in ion mobility mass spectrometry." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1000861 ! molecular entity property
 relationship: has_units UO:0000324 ! square angstrom
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
@@ -20388,7 +19393,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002955
 name: hr-ms compound identification confidence level
 def: "Refined High Resolution mass spectrometry confidence level for annotation of identified compounds as proposed by Schymanski et al. The value slot can have the values 'Level 1', 'Level 2', 'Level 2a', 'Level 2b', 'Level 3', 'Level 4', and 'Level 5'." [PMID:24476540]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002895 ! small molecule identification attribute
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -20396,7 +19400,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1002956
 name: isotopic ion MS peak
 def: "A mass spectrometry peak that represents one or more isotopic ions. The value slot contains a description of the represented isotope set, e.g. 'M+1 peak'." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000231 ! peak
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -20404,7 +19407,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1002957
 name: isotopomer MS peak
 def: "The described isotopomer mass spectrometric signal. The value slot contains a description of the represented isotopomer, e.g. '13C peak', '15N peak', '2H peak', '18O peak' or '31P peak'." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002956 ! isotopic ion MS peak
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -20412,7 +19414,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1002958
 name: isotopologue MS peak
 def: "The described isotopologue mass spectrometric signal. The value slot contains a description of the represented isotopologue, e.g. '13C1 peak' or '15N1 peak'." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002956 ! isotopic ion MS peak
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -20420,7 +19421,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1002959
 name: isomer
 def: "One of several species (or molecular entities) that have the same atomic composition (molecular formula) but different line formulae or different stereochemical formulae." [https://goldbook.iupac.org/html/I/I03289.html]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000859 ! molecule
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -20428,7 +19428,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1002960
 name: isotopomer
 def: "An isomer that differs from another only in the spatial distribution of the constitutive isotopic atoms." [https://goldbook.iupac.org/html/I/I03352.html]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002959 ! isomer
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -20436,7 +19435,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1002961
 name: isotopologue
 def: "A molecular entity that differs only in isotopic composition (number of isotopic substitutions)." [https://goldbook.iupac.org/html/I/I03351.html]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002959 ! isomer
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -20615,7 +19613,6 @@ is_a: MS:1001456 ! analysis software
 id: MS:1002988
 name: IdentiPy:RHNS
 def: "The IdentiPy result 'RHNS'." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001153 ! search engine specific score
 relationship: has_order MS:1002108 ! higher score better
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
@@ -20624,7 +19621,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1002989
 name: IdentiPy:hyperscore
 def: "The IdentiPy result 'hyperscore'." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001153 ! search engine specific score
 relationship: has_order MS:1002108 ! higher score better
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
@@ -20645,7 +19641,6 @@ is_a: MS:1002333 ! conversion software
 id: MS:1002995
 name: Andromeda:PEP
 def: "Posterior error probability of the best identified peptide of the Andromeda search engine." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
 relationship: has_order MS:1002108 ! higher score better
@@ -20661,7 +19656,6 @@ is_a: MS:1000560 ! mass spectrometer file format
 id: MS:1002997
 name: ProteomeXchange dataset identifier reanalysis number
 def: "Index number of a reanalysis within a ProteomeXchange reprocessed dataset identifier container (RPXD)." [PSI:PI]
-xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
 relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term
 
@@ -20717,7 +19711,6 @@ is_a: MS:1003123 ! Bruker Daltonics timsTOF series
 id: MS:1003006
 name: mean inverse reduced ion mobility array
 def: "Array of population mean ion mobility values based on ion separation in gaseous phase due to different ion mobilities under an electric field based on ion size, m/z and shape, normalized for the local conditions and reported in volt-second per square centimeter, corresponding to a spectrum of individual peaks encoded with an m/z array." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002893 ! ion mobility array
 relationship: has_units MS:1002814 ! volt-second per square centimeter
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
@@ -20726,7 +19719,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1003007
 name: raw ion mobility array
 def: "Array of raw ion mobility values (K or K0) based on ion separation in gaseous phase due to different ion mobilities under an electric field based on ion size, m/z and shape, corresponding to a spectrum of individual peaks encoded with an m/z array." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002893 ! ion mobility array
 relationship: has_units UO:0000028 ! millisecond
 relationship: has_units UO:0000010 ! second
@@ -20736,7 +19728,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1003008
 name: raw inverse reduced ion mobility array
 def: "Array of raw ion mobility values based on ion separation in gaseous phase due to different ion mobilities under an electric field based on ion size, m/z and shape, normalized for the local conditions and reported in volt-second per square centimeter, corresponding to a spectrum of individual peaks encoded with an m/z array." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002893 ! ion mobility array
 relationship: has_units MS:1002814 ! volt-second per square centimeter
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
@@ -20789,7 +19780,6 @@ is_a: MS:1000860 ! peptide
 id: MS:1003016
 name: ProteinProphet:peptide weight
 def: "Fraction of peptide evidence attributable to a protein or a set of indistinguishable proteins." [PSI:PI]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002490 ! peptide-level scoring
 is_a: MS:1001153 ! search engine specific score
 relationship: has_order MS:1002108 ! higher score better
@@ -20800,7 +19790,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1003017
 name: ProteinProphet:peptide group weight
 def: "Fraction of peptide evidence attributable to a group of proteins." [PSI:PI]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002490 ! peptide-level scoring
 is_a: MS:1001153 ! search engine specific score
 relationship: has_order MS:1002108 ! higher score better
@@ -20849,7 +19838,6 @@ is_a: MS:1000752 ! TOPP software
 id: MS:1003024
 name: OpenPepXL:score
 def: "The OpenPepXL score for a cross-link spectrum match." [PSI:PI]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1001153 ! search engine specific score
 relationship: has_order MS:1002108 ! higher score better
@@ -20889,7 +19877,6 @@ is_a: MS:1000494 ! Thermo Scientific instrument model
 id: MS:1003030
 name: Mascot:MinNumSigUniqueSeqs
 def: "Minimum number of significant unique sequences required in a protein hit. The setting is only relevant if the protein grouping strategy is 'family clustering'." [PSI:PI]
-xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
 is_a: MS:1002095 ! Mascot input parameter
 relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term
 
@@ -20897,7 +19884,6 @@ relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type fo
 id: MS:1003031
 name: CPTAC accession number
 def: "Main identifier of a CPTAC dataset." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -20905,7 +19891,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1003032
 name: compound identification confidence code in MS-DIAL
 def: "The confidence code to describe the confidence of annotated compounds as defined by the MS-DIAL program." [PMID:25938372, http://prime.psc.riken.jp/Metabolomics_Software/MS-DIAL]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002895 ! small molecule identification attribute
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -21218,7 +20203,6 @@ id: MS:1003081
 name: unidentified modification monoisotopic mass delta
 def: "Monoisotopic mass delta in Daltons of an amino acid residue modification whose atomic composition or molecular identity has not been determined. This term should not be used for modifications of known molecular identity such as those available in Unimod, RESID or PSI-MOD. This term MUST NOT be used inside the <Modification> element in mzIdentML." [PSI:PI]
 is_a: MS:1001471 ! peptide modification details
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 relationship: has_units UO:0000221 ! dalton
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -21239,7 +20223,6 @@ is_a: MS:1000577 ! source data file
 id: MS:1003084
 name: processed data file
 def: "File that contains data that has been substantially processed or transformed from what was originally acquired by an instrument." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000577 ! source data file
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -21247,7 +20230,6 @@ relationship: has_value_type xsd\:string ! The allowed value-type for this CV te
 id: MS:1003085
 name: previous MSn-1 scan precursor intensity
 def: "Intensity of the precursor ion in the previous MSn-1 scan (prior in time to the referencing MSn scan). For an MS2 scan, this means the MS1 precursor intensity. It is unspecified on whether this is an apex (across m/z) intensity, integrated (across m/z) intensity, a centroided peak intensity of unknown origin, or even summed across several isotopes." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001141 ! intensity of precursor ion
 is_a: MS:1000499 ! spectrum attribute
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
@@ -21256,7 +20238,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1003086
 name: precursor apex intensity
 def: "Intensity of the precursor ion current as measured by its apex point over time and m/z. It is unspecified whether this is the intensity of the selected isotope or the most intense isotope." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1001141 ! intensity of precursor ion
 is_a: MS:1000499 ! spectrum attribute
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
@@ -21296,7 +20277,6 @@ relationship: part_of MS:1000625 ! chromatogram
 id: MS:1003092
 name: number of mantissa bits truncated
 def: "Number of extraneous mantissa bits truncated to improve subsequent compression." [PSI:MS]
-xref: value-type:xsd\:positiveInteger "Number of mantissa bits truncated."
 is_a: MS:1003091 ! binary data compression parameter
 relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term
 
@@ -21329,7 +20309,6 @@ is_a: MS:1000494 ! Thermo Scientific instrument model
 id: MS:1003097
 name: MaxQuant protein group-level score
 def: "The probability based MaxQuant protein group score." [PSI:MS]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002368 ! search engine specific score for protein groups
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -21337,7 +20316,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1003098
 name: Andromeda peptide PEP
 def: "Peptide probability from Andromeda." [PSI:MS]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002358 ! search engine specific peptide sequence-level identification statistic
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -21345,7 +20323,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1003099
 name: MaxQuant-DIA peptide PEP
 def: "Peptide probability from MaxQuant-DIA algorithm." [PSI:MS]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002358 ! search engine specific peptide sequence-level identification statistic
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -21353,7 +20330,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1003100
 name: MaxQuant-DIA score
 def: "PSM evidence score from MaxQuant-DIA algorithm." [PSI:MS]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -21361,7 +20337,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1003101
 name: MaxQuant-DIA PEP
 def: "PSM evidence PEP probability from MaxQuant-DIA algorithm." [PSI:MS]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -21369,7 +20344,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1003102
 name: NIST msp comment
 def: "Term for a comment field withing the NIST msp file format" [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000499 ! spectrum attribute
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -21420,7 +20394,6 @@ is_a: MS:1001456 ! analysis software
 id: MS:1003110
 name: SIM-XL score
 def: "SIM-XL identification search engine score" [PSI:MS]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002108 ! higher score better
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
@@ -21441,7 +20414,6 @@ is_a: MS:1000494 ! Thermo Scientific instrument model
 id: MS:1003113
 name: OpenMS:ConsensusID PEP
 def: "The OpenMS ConsesusID tool posterior error probability" [PSI:MS]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -21449,7 +20421,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1003114
 name: OpenMS:Best PSM Score
 def: "The score of the best PSM selected by the underlying identification tool" [PSI:MS]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002358 ! search engine specific peptide sequence-level identification statistic
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -21457,7 +20428,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1003115
 name: OpenMS:Target-decoy PSM q-value
 def: "The OpenMS Target-decoy q-values at PSM level" [PSI:MS]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -21465,7 +20435,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1003116
 name: OpenMS:Target-decoy peptide q-value
 def: "The OpenMS Target-decoy q-values at peptide sequence level" [PSI:MS]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002358 ! search engine specific peptide sequence-level identification statistic
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -21473,7 +20442,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1003117
 name: OpenMS:Target-decoy protein q-value
 def: "The OpenMS Target-decoy q-values at protein level" [PSI:MS]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -21488,7 +20456,6 @@ is_a: MS:1000752 ! TOPP software
 id: MS:1003119
 name: EPIFANY:Protein posterior probability
 def: "Protein Posterior probability calculated by EPIFANY protein inference algorithm" [PSI:MS]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -21496,7 +20463,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1003120
 name: OpenMS:LFQ intensity
 def: "The data type LFQ intensity produced by OpenMS." [PSI:MS]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -21504,7 +20470,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1003121
 name: OpenMS:LFQ spectral count
 def: "The data type LFQ spectral count produced by OpenMS." [PSI:MS]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
 
@@ -21530,7 +20495,6 @@ is_a: MS:1003123 ! Bruker Daltonics timsTOF series
 id: MS:1003125
 name: ProSight:spectral Q-value
 def: "ProSight spectrum-level Q-value." [PSI:MS]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002354 ! PSM-level q-value
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002109 ! lower score better
@@ -21540,7 +20504,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1003126
 name: ProSight:spectral P-score
 def: "ProSight spectrum-level P-score." [PSI:MS]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002109 ! lower score better
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
@@ -21549,7 +20512,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1003127
 name: ProSight:spectral E-value
 def: "ProSight spectrum-level E-value." [PSI:MS]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002353 ! PSM-level e-value
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002109 ! lower score better
@@ -21559,7 +20521,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1003128
 name: ProSight:spectral C-score
 def: "ProSight spectrum-level C-score." [PSI:MS]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002108 ! higher score better
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
@@ -21568,7 +20529,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1003129
 name: proteoform-level Q-value
 def: "Estimation of the Q-value for proteoforms." [PSI:MS]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002905 ! proteoform-level identification statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
 relationship: has_order MS:1002109 ! lower score better
@@ -21578,7 +20538,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1003130
 name: ProSight:proteoform Q-value
 def: "ProSight proteoform-level Q-value." [PSI:MS]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1003129 ! proteoform-level Q-value
 relationship: has_order MS:1002109 ! lower score better
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
@@ -21599,7 +20558,6 @@ is_a: MS:1003131 ! isoform-level identification attribute
 id: MS:1003133
 name: isoform-level Q-value
 def: "Estimation of the Q-value for isoforms." [PSI:MS]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1003132 ! isoform-level identification statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
@@ -21608,7 +20566,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1003134
 name: ProSight:isoform Q-value
 def: "ProSight isoform-level Q-value." [PSI:MS]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1003133 ! isoform-level Q-value
 relationship: has_order MS:1002109 ! lower score better
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
@@ -21617,7 +20574,6 @@ relationship: has_value_type xsd\:double ! The allowed value-type for this CV te
 id: MS:1003135
 name: ProSight:protein Q-value
 def: "ProSight protein-level Q-value." [PSI:MS]
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001869 ! protein-level q-value
 relationship: has_order MS:1002109 ! lower score better
 relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
@@ -21638,7 +20594,6 @@ is_a: MS:1001302 ! search engine specific input parameter
 id: MS:1003138
 name: ProSight:Run delta m mode
 def: "If true, runs delta m mode in ProSight." [PSI:MS]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1003136 ! ProSight input parameter
 is_a: MS:1003137 ! TDPortal input parameter
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
@@ -21647,7 +20602,6 @@ relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV t
 id: MS:1003139
 name: ProSight:Run Subsequence Search mode
 def: "If true, runs Subsequence Search mode in ProSight." [PSI:MS]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1003136 ! ProSight input parameter
 is_a: MS:1003137 ! TDPortal input parameter
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
@@ -21656,7 +20610,6 @@ relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV t
 id: MS:1003140
 name: ProSight:Run Annotated Proteoform Search mode
 def: "If true, runs Annotated Proteoform Search mode in ProSight." [PSI:MS]
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 is_a: MS:1003136 ! ProSight input parameter
 is_a: MS:1003137 ! TDPortal input parameter
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
@@ -21732,7 +20685,6 @@ relationship: has_regexp MS:1002505 ! regular expression for modification locali
 id: MS:1003151
 name: SHA-256
 def: "SHA-256 (member of Secure Hash Algorithm-2 family) is a cryptographic hash function designed by the National Security Agency (NSA) and published by the NIST as a U. S. government standard. It is also used to verify file integrity." [PSI:MS]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000561 ! data file checksum type
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -21746,7 +20698,6 @@ is_a: MS:1000603 ! Shimadzu Scientific Instruments instrument model
 id: MS:1003153
 name: raw ion mobility drift time array
 def: "Array of raw ion mobility values from a drift time device, reported in seconds (or milliseconds), corresponding to a spectrum of individual peaks encoded with an m/z array." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002893 ! ion mobility array
 relationship: has_units UO:0000028 ! millisecond
 relationship: has_units UO:0000010 ! second
@@ -21756,7 +20707,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1003154
 name: deconvoluted ion mobility array
 def: "Array of ion mobility values (K or K0) based on ion separation in gaseous phase due to different ion mobilities under an electric field based on ion size, m/z and shape, as an average property of an analyte post peak-detection, weighted charge state reduction, and/or adduct aggregation, corresponding to a spectrum of individual peaks encoded with an m/z array." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002893 ! ion mobility array
 relationship: has_units UO:0000028 ! millisecond
 relationship: has_units UO:0000010 ! second
@@ -21766,7 +20716,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1003155
 name: deconvoluted inverse reduced ion mobility array
 def: "Array of ion mobility values based on ion separation in gaseous phase due to different ion mobilities under an electric field based on ion size, m/z and shape, normalized for the local conditions and reported in volt-second per square centimeter, as an average property of an analyte post peak-detection, weighted charge state reduction, and/or adduct aggregation, corresponding to a spectrum of individual peaks encoded with an m/z array." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002893 ! ion mobility array
 relationship: has_units MS:1002814 ! volt-second per square centimeter
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
@@ -21775,7 +20724,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1003156
 name: deconvoluted ion mobility drift time array
 def: "Array of mean ion mobility values from a drift time device, reported in seconds (or milliseconds), as an average property of an analyte post peak-detection, weighted charge state reduction, and/or adduct aggregation, corresponding to a spectrum of individual peaks encoded with an m/z array." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1002893 ! ion mobility array
 relationship: has_units UO:0000028 ! millisecond
 relationship: has_units UO:0000010 ! second
@@ -21785,7 +20733,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1003157
 name: scanning quadrupole position lower bound m/z array
 def: "Array of m/z values representing the lower bound m/z of the quadrupole position at each point in the spectrum." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000513 ! binary data array
 relationship: has_units MS:1000040 ! m/z
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
@@ -21794,7 +20741,6 @@ relationship: has_value_type xsd\:float ! The allowed value-type for this CV ter
 id: MS:1003158
 name: scanning quadrupole position upper bound m/z array
 def: "Array of m/z values representing the upper bound m/z of the quadrupole position at each point in the spectrum." [PSI:MS]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000513 ! binary data array
 relationship: has_units MS:1000040 ! m/z
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
@@ -21849,7 +20795,6 @@ id: MS:1003166
 name: assigned intensity fraction
 def: "Fraction of intensity summed from all peaks that can be attributed to expected fragments of the analyte, divided by the intensity summed from all peaks in the spectrum" [PSI:PI]
 is_a: MS:1003078 ! interpreted spectrum attribute
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
@@ -21857,7 +20802,6 @@ id: MS:1003167
 name: MSn-1 isolation window precursor purity
 def: "The fraction of total intensities in the isolation window in the previous round of MS (i.e. the MSn-1 scan) that can be assigned to this identified analyte" [PSI:PI]
 is_a: MS:1003078 ! interpreted spectrum attribute
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
 [Term]
@@ -21865,7 +20809,6 @@ id: MS:1003168
 name: library spectrum comment
 def: "A free-text string providing additional information of the library spectrum not encoded otherwise, usually for human use and not parsed by software tools." [PSI:PI]
 is_a: MS:1003234 ! library spectrum attribute
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
@@ -21873,7 +20816,6 @@ id: MS:1003169
 name: proforma peptidoform sequence
 def: "Sequence string describing the amino acids and mass modifications of a peptidoform using the PSI ProForma notation" [PSI:PI]
 is_a: MS:1000889 ! peptidoform sequence
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
@@ -21899,8 +20841,6 @@ id: MS:1003173
 name: numeric attribute
 def: "An attribute that takes on a numeric value" [PSI:PI]
 is_a: MS:1000547 ! object attribute
-xref: value-type:xsd\:int "The allowed value-type for this CV term."
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
@@ -21909,8 +20849,6 @@ id: MS:1003174
 name: attribute maximum
 def: "The maximum value for this attribute" [PSI:PI]
 relationship: part_of MS:1003171 ! numeric attribute
-xref: value-type:xsd\:int "The allowed value-type for this CV term."
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
@@ -21919,8 +20857,6 @@ id: MS:1003175
 name: attribute minimum
 def: "The minimum value for this attribute" [PSI:PI]
 relationship: part_of MS:1003171 ! numeric attribute
-xref: value-type:xsd\:int "The allowed value-type for this CV term."
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
@@ -21929,8 +20865,6 @@ id: MS:1003176
 name: attribute mean
 def: "The arithmetic mean value for this attribute" [PSI:PI]
 relationship: part_of MS:1003171 ! numeric attribute
-xref: value-type:xsd\:int "The allowed value-type for this CV term."
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
@@ -21939,8 +20873,6 @@ id: MS:1003177
 name: attribute standard deviation
 def: "The standard deviation (exact value of population, or estimate from sample) of this attribute" [PSI:PI]
 relationship: part_of MS:1003171 ! numeric attribute
-xref: value-type:xsd\:int "The allowed value-type for this CV term."
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
@@ -21949,8 +20881,6 @@ id: MS:1003178
 name: attribute coefficient of variation
 def: "The coefficient of variation of this attribute, i.e. standard deviation divided by the mean" [PSI:PI]
 relationship: part_of MS:1003171 ! numeric attribute
-xref: value-type:xsd\:int "The allowed value-type for this CV term."
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
@@ -21959,8 +20889,6 @@ id: MS:1003179
 name: attribute summary value
 def: "The most appropriate summary value of the attribute, usually but not necessarily the mean" [PSI:PI]
 relationship: part_of MS:1003171 ! numeric attribute
-xref: value-type:xsd\:int "The allowed value-type for this CV term."
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
@@ -21969,8 +20897,6 @@ id: MS:1003180
 name: attribute median
 def: "The median of this attribute" [PSI:PI]
 relationship: part_of MS:1003171 ! numeric attribute
-xref: value-type:xsd\:int "The allowed value-type for this CV term."
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 
@@ -22010,7 +20936,6 @@ id: MS:1003186
 name: library format version
 def: "Version number of the [PSI] library format specification" [PSI:PI]
 is_a: MS:1003171 ! spectral library attribute
-xref: value-type:xsd:string "The allowed value-type for this CV term."
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
@@ -22018,7 +20943,6 @@ id: MS:1003187
 name: library identifier
 def: "Short identifier for the library for easy reference, preferably but not necessarily globally unique" [PSI:PI]
 is_a: MS:1003171 ! spectral library attribute
-xref: value-type:xsd:string "The allowed value-type for this CV term."
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
@@ -22026,7 +20950,6 @@ id: MS:1003188
 name: library name
 def: "A short name identifying the library to potential users. The same name may refer to multiple versions of the same continually updated library." [PSI:PI]
 is_a: MS:1003171 ! spectral library attribute
-xref: value-type:xsd:string "The allowed value-type for this CV term."
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
@@ -22034,7 +20957,6 @@ id: MS:1003189
 name: library description
 def: "Extended free-text description of the library" [PSI:PI]
 is_a: MS:1003171 ! spectral library attribute
-xref: value-type:xsd:string "The allowed value-type for this CV term."
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
@@ -22042,7 +20964,6 @@ id: MS:1003190
 name: library version
 def: "Version number of the library, usually refering to a certain release of a continually updated library " [PSI:PI]
 is_a: MS:1003171 ! spectral library attribute
-xref: value-type:xsd:string "The allowed value-type for this CV term."
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
@@ -22050,7 +20971,6 @@ id: MS:1003191
 name: library URI
 def: "URI or URL that uniquely identifies the library" [PSI:PI]
 is_a: MS:1003171 ! spectral library attribute
-xref: value-type:xsd:string "The allowed value-type for this CV term."
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
@@ -22088,7 +21008,6 @@ id: MS:1003197
 name: license URI
 def: "URI of the license controlling use of the library (e.g. https://creativecommons.org/publicdomain/zero/1.0/)" [PSI:PI]
 is_a: MS:1003171 ! spectral library attribute
-xref: value-type:xsd:string "The allowed value-type for this CV term."
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
@@ -22096,7 +21015,6 @@ id: MS:1003198
 name: copyright notice
 def: "Notice of statutorily prescribed form that informs users of the underlying claim to copyright ownership in a published work" [PSI:PI]
 is_a: MS:1003171 ! spectral library attribute
-xref: value-type:xsd:string "The allowed value-type for this CV term."
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
@@ -22104,7 +21022,6 @@ id: MS:1003199
 name: change log
 def: "Extended free-text description of the difference from the previous version" [PSI:PI]
 is_a: MS:1003171 ! spectral library attribute
-xref: value-type:xsd:string "The allowed value-type for this CV term."
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
@@ -22112,7 +21029,6 @@ id: MS:1003200
 name: software version
 def: "Version number of the software package used for library creation" [PSI:PI]
 is_a: MS:1003171 ! spectral library attribute
-xref: value-type:xsd:string "The allowed value-type for this CV term."
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
@@ -22133,7 +21049,6 @@ id: MS:1003203
 name: constituent spectrum file
 def: "Spectrum data file from which (at least) a subset of spectra were extracted from. Should use USI notation mzspec:PXDxxxx:msRunName if possible, or a URI if USI notation is not possible." [PSI:PI]
 is_a: MS:1003201 ! library provenance attribute
-xref: value-type:xsd:string "The allowed value-type for this CV term."
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
@@ -22141,7 +21056,6 @@ id: MS:1003204
 name: constituent identification file
 def: "Identification file where (at least) a subset of identifications were extracted from. Should use a URI if possible" [PSI:PI]
 is_a: MS:1003201 ! library provenance attribute
-xref: value-type:xsd:string "The allowed value-type for this CV term."
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
@@ -22149,7 +21063,6 @@ id: MS:1003205
 name: constituent library file
 def: "Source library URI which(at least) a subset of spectra were extracted from." [PSI:PI]
 is_a: MS:1003201 ! library provenance attribute
-xref: value-type:xsd:string "The allowed value-type for this CV term."
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
@@ -22157,7 +21070,6 @@ id: MS:1003206
 name: library creation log
 def: "String of logging information generated when the library was constructed from its constituent files. Multiple lines should be separated with escaped \n" [PSI:PI]
 is_a: MS:1003201 ! library provenance attribute
-xref: value-type:xsd:string "The allowed value-type for this CV term."
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
@@ -22441,7 +21353,6 @@ is_a: MS:1000008 ! ionization type
 id: MS:1003250
 name: count of identified peptidoforms
 def: "The number of peptidoforms that pass the threshold to be considered identified with sufficient confidence." [PSI:PI]
-xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002702 ! peptide sequence-level result list attribute
 relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
@@ -22449,7 +21360,6 @@ relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 id: MS:1003251
 name: count of identified spectra
 def: "The number of spectra that pass the threshold to be considered identified with sufficient confidence." [PSI:PI]
-xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002700 ! PSM-level result list attribute
 relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
@@ -23277,7 +22187,6 @@ id: PEFF:0000008
 name: DbName
 def: "PEFF keyword for the sequence database name." [PSI:PEFF]
 is_a: PEFF:0000002 ! PEFF file header section term
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
@@ -23285,7 +22194,6 @@ id: PEFF:0000009
 name: Prefix
 def: "PEFF keyword for the sequence database prefix." [PSI:PEFF]
 is_a: PEFF:0000002 ! PEFF file header section term
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
@@ -23293,7 +22201,6 @@ id: PEFF:0000010
 name: DbDescription
 def: "PEFF keyword for the sequence database short description." [PSI:PEFF]
 is_a: PEFF:0000002 ! PEFF file header section term
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
@@ -23301,7 +22208,6 @@ id: PEFF:0000011
 name: Decoy
 def: "PEFF keyword for the specifying whether the sequence database is a decoy database." [PSI:PEFF]
 is_a: PEFF:0000002 ! PEFF file header section term
-xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
 relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
 
 [Term]
@@ -23309,7 +22215,6 @@ id: PEFF:0000012
 name: DbSource
 def: "PEFF keyword for the source of the database file." [PSI:PEFF]
 is_a: PEFF:0000002 ! PEFF file header section term
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
@@ -23317,7 +22222,6 @@ id: PEFF:0000013
 name: DbVersion
 def: "PEFF keyword for the database version (release date) according to database provider." [PSI:PEFF]
 is_a: PEFF:0000002 ! PEFF file header section term
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
@@ -23333,7 +22237,6 @@ id: PEFF:0000015
 name: NumberOfEntries
 def: "PEFF keyword for the sumber of sequence entries in the database." [PSI:PEFF]
 is_a: PEFF:0000002 ! PEFF file header section term
-xref: value-type:xsd\:integer "The allowed value-type for this CV term."
 relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term
 
 [Term]
@@ -23341,7 +22244,6 @@ id: PEFF:0000016
 name: Conversion
 def: "PEFF keyword for the description of the conversion from original format to this current one." [PSI:PEFF]
 is_a: PEFF:0000002 ! PEFF file header section term
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
@@ -23349,7 +22251,6 @@ id: PEFF:0000017
 name: SequenceType
 def: "PEFF keyword for the molecular type of the sequences." [PSI:PEFF]
 is_a: PEFF:0000002 ! PEFF file header section term
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: has_regexp PEFF:1002002 ! regular expression for PEFF molecular sequence type
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -23358,7 +22259,6 @@ id: PEFF:0000018
 name: SpecificKey
 def: "PEFF keyword for database specific keywords not included in the current controlled vocabulary." [PSI:PEFF]
 is_a: PEFF:0000002 ! PEFF file header section term
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
@@ -23366,7 +22266,6 @@ id: PEFF:0000019
 name: SpecificValue
 def: "PEFF keyword for the specific values for a custom key." [PSI:PEFF]
 is_a: PEFF:0000002 ! PEFF file header section term
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
@@ -23374,7 +22273,6 @@ id: PEFF:0000020
 name: DatabaseDescription
 def: "PEFF keyword for the short description of the PEFF file." [PSI:PEFF]
 is_a: PEFF:0000002 ! PEFF file header section term
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
@@ -23382,7 +22280,6 @@ id: PEFF:0000021
 name: GeneralComment
 def: "PEFF keyword for a general comment." [PSI:PEFF]
 is_a: PEFF:0000002 ! PEFF file header section term
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
@@ -23390,7 +22287,6 @@ id: PEFF:0000022
 name: ProteoformDb
 def: "PEFF keyword that when set to 'true' indicates that the database contains complete proteoforms." [PSI:PEFF]
 is_a: PEFF:0000002 ! PEFF file header section term
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
@@ -23398,7 +22294,6 @@ id: PEFF:0000023
 name: OptionalTagDef
 def: "PEFF keyword for the short tag (abbreviation) and longer definition used to annotate a sequence annotation (such as variant or modification) in the OptionalTag location." [PSI:PEFF]
 is_a: PEFF:0000002 ! PEFF file header section term
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
@@ -23406,7 +22301,6 @@ id: PEFF:0000024
 name: HasAnnotationIdentifiers
 def: "PEFF keyword that when set to 'true' indicates that entries in the database have identifiers for each annotation." [PSI:PEFF]
 is_a: PEFF:0000002 ! PEFF file header section term
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
@@ -23415,7 +22309,6 @@ name: DbUniqueId
 def: "OBSOLETE Sequence database unique identifier." [PSI:PEFF]
 comment: This term was made obsolete because decided in Heidelberg 2018-04 that this is redundant.
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_obsolete: true
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -23424,7 +22317,6 @@ id: PEFF:0001002
 name: PName
 def: "PEFF keyword for the protein full name." [PSI:PEFF]
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
@@ -23432,7 +22324,6 @@ id: PEFF:0001003
 name: NcbiTaxId
 def: "PEFF keyword for the NCBI taxonomy identifier." [PSI:PEFF]
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-xref: value-type:xsd\:int "The allowed value-type for this CV term."
 relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
 [Term]
@@ -23440,7 +22331,6 @@ id: PEFF:0001004
 name: TaxName
 def: "PEFF keyword for the taxonomy name (latin or common name)." [PSI:PEFF]
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
@@ -23448,7 +22338,6 @@ id: PEFF:0001005
 name: GName
 def: "PEFF keyword for the gene name." [PSI:PEFF]
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
@@ -23456,7 +22345,6 @@ id: PEFF:0001006
 name: Length
 def: "PEFF keyword for the sequence length." [PSI:PEFF]
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-xref: value-type:xsd\:int "The allowed value-type for this CV term."
 relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
 [Term]
@@ -23464,7 +22352,6 @@ id: PEFF:0001007
 name: SV
 def: "PEFF keyword for the sequence version." [PSI:PEFF]
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
@@ -23472,7 +22359,6 @@ id: PEFF:0001008
 name: EV
 def: "PEFF keyword for the entry version." [PSI:PEFF]
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
@@ -23480,7 +22366,6 @@ id: PEFF:0001009
 name: PE
 def: "PEFF keyword for the Protein Evidence; A UniProtKB code 1-5." [PSI:PEFF]
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-xref: value-type:xsd\:int "The allowed value-type for this CV term."
 relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
 [Term]
@@ -23488,7 +22373,6 @@ id: PEFF:0001010
 name: Processed
 def: "PEFF keyword for information on how the full length original protein sequence can be processed into shorter components such as signal peptides and chains." [PSI:PEFF]
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: has_regexp PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -23498,7 +22382,6 @@ name: Variant
 def: "OBSOLETE Sequence variation (substitution, insertion, deletion)." [PSI:PEFF]
 comment: This term was made obsolete in favor of VariantSimple and VariantComplex.
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: has_regexp PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
 is_obsolete: true
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
@@ -23508,7 +22391,6 @@ id: PEFF:0001012
 name: ModResPsi
 def: "PEFF keyword for the modified residue with PSI-MOD identifier." [PSI:PEFF]
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: has_regexp PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -23517,7 +22399,6 @@ id: PEFF:0001013
 name: ModRes
 def: "PEFF keyword for the modified residue without aPSI-MOD or UniMod identifier." [PSI:PEFF]
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: has_regexp PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -23526,7 +22407,6 @@ id: PEFF:0001014
 name: AltAC
 def: "PEFF keyword for the Alternative Accession Code." [PSI:PEFF]
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
@@ -23534,7 +22414,6 @@ id: PEFF:0001015
 name: SeqStatus
 def: "PEFF keyword for the sequence status. Complete or Fragment." [PSI:PEFF]
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: has_regexp PEFF:1002003 ! regular expression for PEFF sequence status
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -23543,7 +22422,6 @@ id: PEFF:0001016
 name: CC
 def: "PEFF keyword for the entry associated comment." [PSI:PEFF]
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
@@ -23551,7 +22429,6 @@ id: PEFF:0001017
 name: KW
 def: "PEFF keyword for the entry associated keyword(s)." [PSI:PEFF]
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
@@ -23559,7 +22436,6 @@ id: PEFF:0001018
 name: GO
 def: "PEFF keyword for the Gene Ontology code." [PSI:PEFF]
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
@@ -23567,7 +22443,6 @@ id: PEFF:0001019
 name: XRef
 def: "PEFF keyword for the cross-reference to an external resource." [PSI:PEFF]
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
@@ -23575,7 +22450,6 @@ id: PEFF:0001020
 name: mature protein
 def: "Portion of a newly synthesized protein that contributes to a final structure after other components such as signal peptides are removed." [PSI:PEFF]
 is_a: PEFF:0001032 ! PEFF molecule processing keyword
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: has_regexp PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -23584,7 +22458,6 @@ id: PEFF:0001021
 name: signal peptide
 def: "Short peptide present at the N-terminus of a newly synthesized protein that is cleaved off and is not part of the final mature protein." [PSI:PEFF]
 is_a: PEFF:0001032 ! PEFF molecule processing keyword
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: has_regexp PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -23593,7 +22466,6 @@ id: PEFF:0001022
 name: transit peptide
 def: "Short peptide present at the N-terminus of a newly synthesized protein that helps the protein through the membrane of its destination organelle." [PSI:PEFF]
 is_a: PEFF:0001032 ! PEFF molecule processing keyword
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: has_regexp PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -23602,7 +22474,6 @@ id: PEFF:0001023
 name: Conflict
 def: "PEFF keyword for the sequence conflict; a UniProtKB term." [PSI:PEFF]
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: has_regexp PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -23611,7 +22482,6 @@ id: PEFF:0001024
 name: Crc64
 def: "PEFF keyword for the Sequence checksum in crc64." [PSI:PEFF]
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
@@ -23619,7 +22489,6 @@ id: PEFF:0001025
 name: Domain
 def: "PEFF keyword for the sequence range of a domain." [PSI:PEFF]
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
@@ -23627,7 +22496,6 @@ id: PEFF:0001026
 name: ID
 def: "PEFF keyword for the UniProtKB specific Protein identifier ID; a UniProtKB term." [PSI:PEFF]
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
@@ -23635,7 +22503,6 @@ id: PEFF:0001027
 name: ModResUnimod
 def: "PEFF keyword for the modified residue with UniMod identifier." [PSI:PEFF]
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: has_regexp PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -23644,7 +22511,6 @@ id: PEFF:0001028
 name: VariantSimple
 def: "PEFF keyword for the simple sequence variation of a single amino acid change. A change to a stop codon is permitted with a * symbol. More complex variations must be encoded with the VariantComplex term." [PSI:PEFF]
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: has_regexp PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -23653,7 +22519,6 @@ id: PEFF:0001029
 name: VariantComplex
 def: "PEFF keyword for a sequence variation that is more complex than a single amino acid change or change to a stop codon." [PSI:PEFF]
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: has_regexp PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -23662,7 +22527,6 @@ id: PEFF:0001030
 name: Proteoform
 def: "PEFF keyword for the proteoforms of this protein, constructed as a set of annotation identifiers." [PSI:PEFF]
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
@@ -23670,7 +22534,6 @@ id: PEFF:0001031
 name: DisulfideBond
 def: "PEFF keyword for the disulfide bonds in this protein, constructed as a sets of annotation identifiers of two half-cystine modifications." [PSI:PEFF]
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
@@ -23684,7 +22547,6 @@ id: PEFF:0001033
 name: Comment
 def: "PEFF keyword for the individual protein entry comment. It is discouraged to put parsable information here. This is only for free-text commentary." [PSI:PEFF]
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
 [Term]
@@ -23692,7 +22554,6 @@ id: PEFF:0001034
 name: propeptide
 def: "Short peptide that is cleaved off a newly synthesized protein and generally immediately degraded in the process of protein maturation, and is not a signal peptide or transit peptide." [PSI:PEFF]
 is_a: PEFF:0001032 ! PEFF molecule processing keyword
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: has_regexp PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 
@@ -23701,7 +22562,6 @@ id: PEFF:0001035
 name: initiator methionine
 def: "N-terminal methionine residue of a protein that can be co-translationally cleaved." [PSI:PEFF]
 is_a: PEFF:0001032 ! PEFF molecule processing keyword
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 relationship: has_regexp PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
 relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
 


### PR DESCRIPTION
Partially addresses #130 removing `xref: value-type` directives. The `xref: binary-data-type` directives remain as we do not have a alternative yet.