### PR TITLE
Remove colon escape from relationship, not syntactically necessary

### DIFF
--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -1,5 +1,5 @@
 format-version: 1.2
-data-version: 4.1.92
+data-version: 4.1.93
 date: 07:01:2022 11:44
 saved-by: Joshua Klein
 auto-generated-by: OBO-Edit 2.3.1

--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -195,14 +195,14 @@ id: MS:1000001
 name: sample number
 def: "A reference number relevant to the sample under study." [PSI:MS]
 is_a: MS:1000548 ! sample attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000002
 name: sample name
 def: "A reference string relevant to the sample under study." [PSI:MS]
 is_a: MS:1000548 ! sample attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000003
@@ -216,7 +216,7 @@ name: sample mass
 def: "Total mass of sample used." [PSI:MS]
 is_a: MS:1000548 ! sample attribute
 relationship: has_units UO:0000021 ! gram
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000005
@@ -224,7 +224,7 @@ name: sample volume
 def: "Total volume of solution used." [PSI:MS]
 is_a: MS:1000548 ! sample attribute
 relationship: has_units UO:0000098 ! milliliter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000006
@@ -232,7 +232,7 @@ name: sample concentration
 def: "Concentration of sample in picomol/ul, femtomol/ul or attomol/ul solution used." [PSI:MS]
 is_a: MS:1000548 ! sample attribute
 relationship: has_units UO:0000175 ! gram per liter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000007
@@ -265,7 +265,7 @@ id: MS:1000011
 name: mass resolution
 def: "Smallest mass difference between two equal magnitude peaks so that the valley between them is a specified fraction of the peak height." [PSI:MS]
 is_a: MS:1000503 ! scan attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000012
@@ -287,7 +287,7 @@ def: "Accuracy is the degree of conformity of a measured mass to its actual valu
 is_a: MS:1000480 ! mass analyzer attribute
 relationship: has_units MS:1000040 ! m/z
 relationship: has_units UO:0000169 ! parts per million
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000015
@@ -295,7 +295,7 @@ name: scan rate
 def: "Rate in Th/sec for scanning analyzers." [PSI:MS]
 is_a: MS:1000503 ! scan attribute
 relationship: has_units MS:1000807 ! Th/s
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000016
@@ -305,7 +305,7 @@ is_a: MS:1000503 ! scan attribute
 is_a: MS:1002345 ! PSM-level attribute
 relationship: has_units UO:0000010 ! second
 relationship: has_units UO:0000031 ! minute
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000017
@@ -346,7 +346,7 @@ name: TOF Total Path Length
 def: "The length of the field free drift space in a time of flight mass spectrometer." [PSI:MS]
 is_a: MS:1000480 ! mass analyzer attribute
 relationship: has_units UO:0000008 ! meter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000023
@@ -355,14 +355,14 @@ def: "OBSOLETE The total width (i.e. not half for plus-or-minus) of the gate app
 comment: This former purgatory term was made obsolete.
 relationship: has_units MS:1000040 ! m/z
 is_obsolete: true
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000024
 name: final MS exponent
 def: "Final MS level achieved when performing PFF with the ion trap (e.g. MS E10)." [PSI:MS]
 is_a: MS:1000480 ! mass analyzer attribute
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
+relationship: has_value_type xsd:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000025
@@ -372,7 +372,7 @@ synonym: "B" EXACT []
 synonym: "Magnetic Field" RELATED []
 is_a: MS:1000480 ! mass analyzer attribute
 relationship: has_units UO:0000228 ! tesla
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000026
@@ -391,7 +391,7 @@ id: MS:1000028
 name: detector resolution
 def: "The resolving power of the detector to detect the smallest difference between two ions so that the valley between them is a specified fraction of the peak height." [PSI:MS]
 is_a: MS:1000481 ! detector attribute
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000029
@@ -400,7 +400,7 @@ def: "The rate of signal sampling (measurement) with respect to time." [PSI:MS]
 synonym: "ADC Sampling Frequency" NARROW []
 is_a: MS:1000481 ! detector attribute
 relationship: has_units UO:0000106 ! hertz
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000030
@@ -420,7 +420,7 @@ id: MS:1000032
 name: customization
 def: "Free text description of a single customization made to the instrument; for several modifications, use several entries." [PSI:MS]
 is_a: MS:1000496 ! instrument attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000033
@@ -484,7 +484,7 @@ def: "Number of net charges, positive or negative, on an ion." [PSI:MS]
 synonym: "z" EXACT []
 is_a: MS:1000455 ! ion selection attribute
 is_a: MS:1000507 ! ion property
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
+relationship: has_value_type xsd:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000042
@@ -497,7 +497,7 @@ relationship: has_units MS:1000814 ! counts per second
 relationship: has_units MS:1000905 ! percent of base peak times 100
 relationship: has_units UO:0000269 ! absorbance unit
 relationship: part_of MS:1000231 ! peak
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000043
@@ -518,7 +518,7 @@ name: collision energy
 def: "Energy for an ion experiencing collision with a stationary gas particle resulting in dissociation of the ion." [PSI:MS]
 is_a: MS:1000510 ! precursor activation attribute
 relationship: has_units UO:0000266 ! electronvolt
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000046
@@ -569,7 +569,7 @@ id: MS:1000053
 name: sample batch
 def: "Sample batch lot identifier." [PSI:MS]
 is_a: MS:1000548 ! sample attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000054
@@ -1090,7 +1090,7 @@ id: MS:1000132
 name: percent of base peak
 def: "The magnitude of a peak or measurement element expressed in terms of the percentage of the magnitude of the base peak intensity." [PSI:MS]
 is_a: MS:1000043 ! intensity unit
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000133
@@ -1135,7 +1135,7 @@ name: normalized collision energy
 def: "Instrument setting, expressed in percent, for adjusting collisional energies of ions in an effort to provide equivalent excitation of all ions." [PSI:PI]
 is_a: MS:1000510 ! precursor activation attribute
 relationship: has_units UO:0000187 ! percent
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000139
@@ -1561,7 +1561,7 @@ def: "OBSOLETE An experimentally determined mass that is can be to determine a u
 comment: This child of the former purgatory term ion attribute was made obsolete.
 relationship: has_units UO:0000002 ! mass unit
 is_obsolete: true
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000208
@@ -1570,7 +1570,7 @@ def: "OBSOLETE The mass of an ion or molecule calculated using the average mass 
 comment: This child of the former purgatory term ion attribute was made obsolete.
 relationship: has_units UO:0000002 ! mass unit
 is_obsolete: true
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000209
@@ -1580,7 +1580,7 @@ synonym: "AE" EXACT []
 comment: This child of the former purgatory term ion attribute was made obsolete.
 relationship: has_units UO:0000266 ! electronvolt
 is_obsolete: true
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000210
@@ -1594,7 +1594,7 @@ id: MS:1000211
 name: OBSOLETE charge number
 def: "OBSOLETE The total charge on an ion divided by the electron charge e. OBSOLETED 2009-10-27 since this was viewed as a duplication of 00041 charge state." [PSI:MS]
 is_obsolete: true
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
+relationship: has_value_type xsd:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000212
@@ -1610,7 +1610,7 @@ def: "OBSOLETE The electron affinity of M is the minimum energy required for the
 comment: This child of the former purgatory term ion attribute was made obsolete.
 synonym: "EA" EXACT []
 is_obsolete: true
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000214
@@ -1626,7 +1626,7 @@ def: "OBSOLETE The calculated mass of an ion or molecule containing a single iso
 comment: This child of the former purgatory term ion attribute was made obsolete.
 relationship: has_units UO:0000002 ! mass unit
 is_obsolete: true
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000216
@@ -1648,7 +1648,7 @@ name: ionization efficiency
 def: "OBSOLETE The ratio of the number of ions formed to the number of electrons, molecules or photons used." [PSI:MS]
 comment: This term was made obsolete because it was replaced by ionization efficiency (MS:1000392).
 is_obsolete: true
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000219
@@ -1658,7 +1658,7 @@ synonym: "IE" EXACT []
 comment: This child of the former purgatory term ion attribute was made obsolete.
 relationship: has_units UO:0000266 ! electronvolt
 is_obsolete: true
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000220
@@ -1681,7 +1681,7 @@ def: "OBSOLETE The difference between the monoisotopic and nominal mass of a mol
 comment: This child of the former purgatory term ion attribute was made obsolete.
 relationship: has_units UO:0000002 ! mass unit
 is_obsolete: true
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000223
@@ -1689,7 +1689,7 @@ name: mass number
 def: "OBSOLETE The sum of the protons and neutrons in an atom, molecule or ion." [PSI:MS]
 comment: This child of the former purgatory term ion attribute was made obsolete.
 is_obsolete: true
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
+relationship: has_value_type xsd:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000224
@@ -1697,7 +1697,7 @@ name: molecular mass
 def: "Mass of a molecule measured in unified atomic mass units (u or Da)." [https://en.wikipedia.org/wiki/Molecular_mass]
 is_a: MS:1000861 ! molecular entity property
 relationship: has_units UO:0000002 ! mass unit
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000225
@@ -1706,7 +1706,7 @@ def: "OBSOLETE The mass of an ion or molecule calculated using the mass of the m
 comment: This child of the former purgatory term ion attribute was made obsolete.
 relationship: has_units UO:0000002 ! mass unit
 is_obsolete: true
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000226
@@ -1737,7 +1737,7 @@ def: "OBSOLETE The mass of an ion or molecule calculated using the mass of the m
 comment: This child of the former purgatory term ion attribute was made obsolete.
 relationship: has_units UO:0000002 ! mass unit
 is_obsolete: true
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000230
@@ -1766,7 +1766,7 @@ def: "OBSOLETE The proton affinity of a species M is defined as the negative of 
 synonym: "PA" EXACT [PSI:MS]
 comment: This child of the former purgatory term ion attribute was made obsolete.
 is_obsolete: true
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000234
@@ -1774,7 +1774,7 @@ name: mass resolving power
 def: "OBSOLETE In a mass spectrum, the observed mass divided by the difference between two masses that can be separated. The method by which delta m was obtained and the mass at which the measurement was made should be reported." [PSI:MS]
 comment: This term was made obsolete because it was replaced by mass resolving power (MS:1000800).
 is_obsolete: true
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000235
@@ -1788,7 +1788,7 @@ id: MS:1000236
 name: transmission
 def: "The ratio of the number of ions leaving a region of a mass spectrometer to the number entering that region." [PSI:MS]
 is_a: MS:1000496 ! instrument attribute
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000237
@@ -2154,7 +2154,7 @@ name: total ion current
 def: "The sum of all the separate ion currents carried by the ions of different m/z contributing to a complete mass spectrum or in a specified m/z range of a mass spectrum." [PSI:MS]
 synonym: "TIC" EXACT []
 is_a: MS:1003058 ! spectrum property
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000286
@@ -2287,7 +2287,7 @@ name: accelerating voltage
 def: "The electrical potential used to impart kinetic energy to ions in a mass spectrometer." [PSI:MS]
 is_a: MS:1000487 ! ion optics attribute
 relationship: has_units UO:0000218 ! volt
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000305
@@ -2315,7 +2315,7 @@ name: electric field strength
 def: "The magnitude of the force per unit charge at a given point in space." [PSI:MS]
 is_a: MS:1000487 ! ion optics attribute
 relationship: has_units UO:0000268 ! volt per meter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000309
@@ -2507,7 +2507,7 @@ id: MS:1000336
 name: neutral loss
 def: "The loss of an uncharged species during a rearrangement process. The value slot holds the molecular formula in Hill notation of the neutral loss molecule, see PMID: 21182243. This term must be used in conjunction with a child of the term MS:1002307 (fragmentation ion type)." [PSI:MS]
 is_a: MS:1001055 ! modification parameters
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000337
@@ -2885,7 +2885,7 @@ id: MS:1000392
 name: ionization efficiency
 def: "The ratio of the number of ions formed to the number of electrons, molecules or photons used." [PSI:MS]
 is_a: MS:1000482 ! source attribute
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000393
@@ -3005,7 +3005,7 @@ id: MS:1000412
 name: buffer gas
 def: "An inert gas used for collisional deactivation of internally excited ions." [PSI:MS]
 is_a: MS:1000510 ! precursor activation attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000413
@@ -3054,7 +3054,7 @@ id: MS:1000419
 name: collision gas
 def: "An inert gas used for collisional excitation. The term target gas is not recommended." [PSI:MS]
 is_a: MS:1000510 ! precursor activation attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000420
@@ -3499,7 +3499,7 @@ name: source potential
 def: "Potential difference at the MS source in volts." [PSI:MS]
 is_a: MS:1000482 ! source attribute
 relationship: has_units UO:0000218 ! volt
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000487
@@ -3590,7 +3590,7 @@ def: "The lower m/z bound of a mass spectrometer scan window." [PSI:MS]
 synonym: "mzRangeStop" RELATED []
 is_a: MS:1000549 ! selection window attribute
 relationship: has_units MS:1000040 ! m/z
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000501
@@ -3599,7 +3599,7 @@ def: "The upper m/z bound of a mass spectrometer scan window." [PSI:MS]
 synonym: "mzRangeStart" RELATED []
 is_a: MS:1000549 ! selection window attribute
 relationship: has_units MS:1000040 ! m/z
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000502
@@ -3609,7 +3609,7 @@ synonym: "Scan Duration" RELATED []
 is_a: MS:1000503 ! scan attribute
 relationship: has_units UO:0000010 ! second
 relationship: has_units UO:0000031 ! minute
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000503
@@ -3624,7 +3624,7 @@ name: base peak m/z
 def: "M/z value of the signal of highest intensity in the mass spectrum." [PSI:MS]
 is_a: MS:1003058 ! spectrum property
 relationship: has_units MS:1000040 ! m/z
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000505
@@ -3636,7 +3636,7 @@ relationship: has_units MS:1000132 ! percent of base peak
 relationship: has_units MS:1000814 ! counts per second
 relationship: has_units MS:1000905 ! percent of base peak times 100
 relationship: has_units UO:0000269 ! absorbance unit
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000506
@@ -3664,7 +3664,7 @@ name: activation energy
 def: "Activation Energy." [PSI:MS]
 is_a: MS:1000510 ! precursor activation attribute
 relationship: has_units UO:0000266 ! electronvolt
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000510
@@ -3677,14 +3677,14 @@ id: MS:1000511
 name: ms level
 def: "Stage number achieved in a multi stage mass spectrometry acquisition." [PSI:MS]
 is_a: MS:1000499 ! spectrum attribute
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
+relationship: has_value_type xsd:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000512
 name: filter string
 def: "A string unique to Thermo instrument describing instrument settings for the scan." [PSI:MS]
 is_a: MS:1000503 ! scan attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000513
@@ -3793,7 +3793,7 @@ def: "Highest m/z value observed in the m/z array." [PSI:MS]
 is_a: MS:1000808 ! chromatogram attribute
 is_a: MS:1003058 ! spectrum property
 relationship: has_units MS:1000040 ! m/z
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000528
@@ -3802,14 +3802,14 @@ def: "Lowest m/z value observed in the m/z array." [PSI:MS]
 is_a: MS:1000808 ! chromatogram attribute
 is_a: MS:1003058 ! spectrum property
 relationship: has_units MS:1000040 ! m/z
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000529
 name: instrument serial number
 def: "Serial Number of the instrument." [PSI:MS]
 is_a: MS:1000496 ! instrument attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000530
@@ -4073,14 +4073,14 @@ id: MS:1000568
 name: MD5
 def: "MD5 (Message-Digest algorithm 5) is a (now deprecated) cryptographic hash function with a 128-bit hash value used to check the integrity of files." [PSI:MS]
 is_a: MS:1000561 ! data file checksum type
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000569
 name: SHA-1
 def: "SHA-1 (Secure Hash Algorithm-1) is a cryptographic hash function designed by the National Security Agency (NSA). It is also used to verify file integrity. Since 2011 it has been deprecated by the NIST as a U. S. government standard." [PSI:MS]
 is_a: MS:1000561 ! data file checksum type
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000570
@@ -4200,35 +4200,35 @@ id: MS:1000586
 name: contact name
 def: "Name of the contact person or organization." [PSI:MS]
 is_a: MS:1000585 ! contact attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000587
 name: contact address
 def: "Postal address of the contact person or organization." [PSI:MS]
 is_a: MS:1000585 ! contact attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000588
 name: contact URL
 def: "Uniform Resource Locator related to the contact person or organization." [PSI:MS]
 is_a: MS:1000585 ! contact attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000589
 name: contact email
 def: "Email address of the contact person or organization." [PSI:MS]
 is_a: MS:1000585 ! contact attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000590
 name: contact affiliation
 def: "Home institution of the contact person." [PSI:MS]
 is_a: MS:1000585 ! contact attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000591
@@ -4397,7 +4397,7 @@ id: MS:1000616
 name: preset scan configuration
 def: "A user-defined scan configuration that specifies the instrumental settings in which a spectrum is acquired. An instrument may cycle through a list of preset scan configurations to acquire data. This is a more generic term for the Thermo \"scan event\", which is defined in the Thermo Xcalibur glossary as: a mass spectrometer scan that is defined by choosing the necessary scan parameter settings. Multiple scan events can be defined for each segment of time." [PSI:MS]
 is_a: MS:1000503 ! scan attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000617
@@ -4415,7 +4415,7 @@ def: "Highest wavelength observed in an EMR spectrum." [PSI:MS]
 is_a: MS:1003058 ! spectrum property
 is_a: MS:1000808 ! chromatogram attribute
 relationship: has_units UO:0000018 ! nanometer
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000619
@@ -4424,7 +4424,7 @@ def: "Lowest wavelength observed in an EMR spectrum." [PSI:MS]
 is_a: MS:1003058 ! spectrum property
 is_a: MS:1000808 ! chromatogram attribute
 relationship: has_units UO:0000018 ! nanometer
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000620
@@ -4496,7 +4496,7 @@ relationship: has_units MS:1000132 ! percent of base peak
 relationship: has_units MS:1000814 ! counts per second
 relationship: has_units MS:1000905 ! percent of base peak times 100
 relationship: has_units UO:0000269 ! absorbance unit
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000630
@@ -4514,7 +4514,7 @@ relationship: has_units MS:1000132 ! percent of base peak
 relationship: has_units MS:1000814 ! counts per second
 relationship: has_units MS:1000905 ! percent of base peak times 100
 relationship: has_units UO:0000269 ! absorbance unit
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000632
@@ -4527,7 +4527,7 @@ id: MS:1000633
 name: possible charge state
 def: "A possible charge state of the ion in a situation where the charge of an ion is known to be one of several possible values rather than a completely unknown value or determined to be a specific charge with reasonable certainty." [PSI:MS]
 is_a: MS:1000455 ! ion selection attribute
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
+relationship: has_value_type xsd:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000634
@@ -5274,7 +5274,7 @@ name: selected ion m/z
 def: "Mass-to-charge ratio of an selected ion." [PSI:MS]
 is_a: MS:1000455 ! ion selection attribute
 relationship: has_units MS:1000040 ! m/z
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000745
@@ -5293,7 +5293,7 @@ id: MS:1000747
 name: completion time
 def: "The time that a data processing action was finished." [PSI:MS]
 is_a: MS:1000630 ! data processing parameter
-relationship: has_value_type xsd\:dateTime ! The allowed value-type for this CV term
+relationship: has_value_type xsd:dateTime ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000748
@@ -5553,7 +5553,7 @@ xref: binary-data-type:MS\:1000522 "64-bit integer"
 xref: binary-data-type:MS\:1000523 "64-bit float"
 xref: binary-data-type:MS\:1001479 "null-terminated ASCII string"
 is_a: MS:1000513 ! binary data array
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000787
@@ -5565,7 +5565,7 @@ relationship: has_units MS:1000132 ! percent of base peak
 relationship: has_units MS:1000814 ! counts per second
 relationship: has_units MS:1000905 ! percent of base peak times 100
 relationship: has_units UO:0000269 ! absorbance unit
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000788
@@ -5577,7 +5577,7 @@ relationship: has_units MS:1000132 ! percent of base peak
 relationship: has_units MS:1000814 ! counts per second
 relationship: has_units MS:1000905 ! percent of base peak times 100
 relationship: has_units UO:0000269 ! absorbance unit
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000789
@@ -5613,7 +5613,7 @@ comment: This term was obsoleted in favour of using a target, lower, upper offse
 is_a: MS:1000792 ! isolation window attribute
 relationship: has_units MS:1000040 ! m/z
 is_obsolete: true
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000794
@@ -5623,7 +5623,7 @@ comment: This term was obsoleted in favour of using a target, lower, upper offse
 is_a: MS:1000792 ! isolation window attribute
 relationship: has_units MS:1000040 ! m/z
 is_obsolete: true
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000795
@@ -5638,7 +5638,7 @@ def: "Free-form text title describing a spectrum, usually a series of key value 
 comment: This is the preferred storage place for the spectrum TITLE from an MGF peak list.
 is_a: MS:1001405 ! spectrum identification result details
 is_a: MS:1000499 ! spectrum attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000797
@@ -5647,7 +5647,7 @@ def: "A list of scan numbers and or scan ranges associated with a peak list. If 
 comment: This is the preferred storage place for the spectrum SCANS attribute from an MGF peak list.
 is_a: MS:1001405 ! spectrum identification result details
 is_a: MS:1003058 ! spectrum property
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000798
@@ -5656,21 +5656,21 @@ def: "A list of raw scans and or scan ranges used to generate a peak list. If po
 comment: This is the preferred storage place for the spectrum RAWSCANS attribute from an MGF peak list.
 is_a: MS:1001405 ! spectrum identification result details
 is_a: MS:1003058 ! spectrum property
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000799
 name: custom unreleased software tool
 def: "A software tool that has not yet been released. The value should describe the software. Please do not use this term for publicly available software - contact the PSI-MS working group in order to have another CV term added." [PSI:MS]
 is_a: MS:1000531 ! software
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000800
 name: mass resolving power
 def: "The observed mass divided by the difference between two masses that can be separated: m/dm. The procedure by which dm was obtained and the mass at which the measurement was made should be reported." [PSI:MS]
 is_a: MS:1000503 ! scan attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000801
@@ -5692,7 +5692,7 @@ name: analyzer scan offset
 def: "Offset between two analyzers in a constant neutral loss or neutral gain scan. The value corresponds to the neutral loss or neutral gain value." [PSI:MS]
 is_a: MS:1000503 ! scan attribute
 relationship: has_units MS:1000040 ! m/z
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000804
@@ -5735,7 +5735,7 @@ name: chromatogram title
 def: "A free-form text title describing a chromatogram." [PSI:MS]
 comment: This is the preferred storage place for the spectrum title.
 is_a: MS:1000808 ! chromatogram attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000810
@@ -5854,7 +5854,7 @@ def: "The time of elution from all used chromatographic columns (one or more) in
 is_a: MS:1000503 ! scan attribute
 relationship: has_units UO:0000010 ! second
 relationship: has_units UO:0000031 ! minute
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000827
@@ -5862,7 +5862,7 @@ name: isolation window target m/z
 def: "The primary or reference m/z about which the isolation window is defined." [PSI:MS]
 is_a: MS:1000792 ! isolation window attribute
 relationship: has_units MS:1000040 ! m/z
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000828
@@ -5870,7 +5870,7 @@ name: isolation window lower offset
 def: "The extent of the isolation window in m/z below the isolation window target m/z. The lower and upper offsets may be asymmetric about the target m/z." [PSI:MS]
 is_a: MS:1000792 ! isolation window attribute
 relationship: has_units MS:1000040 ! m/z
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000829
@@ -5878,7 +5878,7 @@ name: isolation window upper offset
 def: "The extent of the isolation window in m/z above the isolation window target m/z. The lower and upper offsets may be asymmetric about the target m/z." [PSI:MS]
 is_a: MS:1000792 ! isolation window attribute
 relationship: has_units MS:1000040 ! m/z
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000831
@@ -5904,7 +5904,7 @@ id: MS:1000834
 name: matrix solution
 def: "Describes the chemical solution used as matrix." [PSI:MS]
 is_a: MS:1000832 ! MALDI matrix application
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000835
@@ -5912,7 +5912,7 @@ name: matrix solution concentration
 def: "Concentration of the chemical solution used as matrix." [PSI:MS]
 is_a: MS:1000832 ! MALDI matrix application
 relationship: has_units UO:0000175 ! gram per liter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000836
@@ -5965,7 +5965,7 @@ comment: This term was made obsolete because it was redundant with the Pato Onto
 is_a: MS:1000841 ! laser attribute
 relationship: has_units UO:0000018 ! nanometer
 is_obsolete: true
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000844
@@ -5973,7 +5973,7 @@ name: focus diameter x
 def: "Describes the diameter of the laser beam in x direction." [PSI:MS]
 is_a: MS:1000841 ! laser attribute
 relationship: has_units UO:0000017 ! micrometer
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000845
@@ -5981,7 +5981,7 @@ name: focus diameter y
 def: "Describes the diameter of the laser beam in y direction." [PSI:MS]
 is_a: MS:1000841 ! laser attribute
 relationship: has_units UO:0000017 ! micrometer
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000846
@@ -5989,7 +5989,7 @@ name: pulse energy
 def: "Describes output energy of the laser system. May be attenuated by filters or other means." [PSI:MS]
 is_a: MS:1000841 ! laser attribute
 relationship: has_units UO:0000112 ! joule
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000847
@@ -5997,7 +5997,7 @@ name: pulse duration
 def: "Describes how long the laser beam was emitted from the laser device." [PSI:MS]
 is_a: MS:1000841 ! laser attribute
 relationship: has_units UO:0000150 ! nanosecond
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000848
@@ -6005,7 +6005,7 @@ name: attenuation
 def: "Describes the reduction of the intensity of the laser beam energy." [PSI:MS]
 is_a: MS:1000841 ! laser attribute
 relationship: has_units UO:0000187 ! percent
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000849
@@ -6013,7 +6013,7 @@ name: impact angle
 def: "Describes the angle between the laser beam and the sample target." [PSI:MS]
 is_a: MS:1000841 ! laser attribute
 relationship: has_units UO:0000185 ! degree
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000850
@@ -6068,7 +6068,7 @@ id: MS:1000858
 name: fraction identifier
 def: "Identier string that describes the sample fraction. This identifier should contain the fraction number(s) or similar information." [PSI:MS]
 is_a: MS:1000857 ! run attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000859
@@ -6094,7 +6094,7 @@ name: isoelectric point
 def: "The pH of a solution at which a charged molecule does not migrate in an electric field." [PSI:MS]
 synonym: "pI" EXACT []
 is_a: MS:1000861 ! molecular entity property
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000863
@@ -6102,7 +6102,7 @@ name: predicted isoelectric point
 def: "The pH of a solution at which a charged molecule would not migrate in an electric field, as predicted by a software algorithm." [PSI:MS]
 synonym: "predicted pI" EXACT []
 is_a: MS:1000862 ! isoelectric point
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000864
@@ -6115,28 +6115,28 @@ id: MS:1000865
 name: empirical formula
 def: "A chemical formula which expresses the proportions of the elements present in a substance." [PSI:MS]
 is_a: MS:1000864 ! chemical formula
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000866
 name: molecular formula
 def: "A chemical compound formula expressing the number of atoms of each element present in a compound, without indicating how they are linked." [PSI:MS]
 is_a: MS:1000864 ! chemical formula
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000867
 name: structural formula
 def: "A chemical formula showing the number of atoms of each element in a molecule, their spatial arrangement, and their linkage to each other." [PSI:MS]
 is_a: MS:1000864 ! chemical formula
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000868
 name: SMILES formula
 def: "The simplified molecular input line entry specification or SMILES is a specification for unambiguously describing the structure of a chemical compound using a short ASCII string." [EDAM:2301]
 is_a: MS:1000864 ! chemical formula
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000869
@@ -6144,7 +6144,7 @@ name: collision gas pressure
 def: "The gas pressure of the collision gas used for collisional excitation." [PSI:MS]
 is_a: MS:1000510 ! precursor activation attribute
 relationship: has_units UO:0000110 ! pascal
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000870
@@ -6184,7 +6184,7 @@ name: declustering potential
 def: "Potential difference between the orifice and the skimmer in volts." [PSI:MS]
 is_a: MS:1000482 ! source attribute
 relationship: has_units UO:0000218 ! volt
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000876
@@ -6192,7 +6192,7 @@ name: cone voltage
 def: "Potential difference between the sampling cone/orifice in volts." [PSI:MS]
 is_a: MS:1000482 ! source attribute
 relationship: has_units UO:0000218 ! volt
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000877
@@ -6200,7 +6200,7 @@ name: tube lens voltage
 def: "Potential difference setting of the tube lens in volts." [PSI:MS]
 is_a: MS:1000482 ! source attribute
 relationship: has_units UO:0000218 ! volt
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000878
@@ -6213,7 +6213,7 @@ id: MS:1000879
 name: PubMed identifier
 def: "A unique identifier for a publication in the PubMed database (MIR:00000015)." [PSI:MS]
 is_a: MS:1000878 ! external reference identifier
-relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term
+relationship: has_value_type xsd:integer ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000880
@@ -6221,7 +6221,7 @@ name: interchannel delay
 def: "The duration of intervals between scanning, during which the instrument configuration is switched." [PSI:MS]
 is_a: MS:1000503 ! scan attribute
 relationship: has_units UO:0000010 ! second
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000881
@@ -6240,7 +6240,7 @@ id: MS:1000883
 name: protein short name
 def: "A short name or symbol of a protein (e.g., HSF 1 or HSF1_HUMAN)." [PSI:MS]
 is_a: MS:1000884 ! protein attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000884
@@ -6255,14 +6255,14 @@ name: protein accession
 def: "Identifier for a specific protein in a database." [PSI:MS]
 is_a: MS:1000884 ! protein attribute
 is_a: MS:1003046 ! peptide-to-protein mapping attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000886
 name: protein name
 def: "A long name describing the function of the protein." [PSI:MS]
 is_a: MS:1000884 ! protein attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000887
@@ -6275,7 +6275,7 @@ id: MS:1000888
 name: stripped peptide sequence
 def: "Sequence of letter symbols denoting the order of amino acids that compose the peptide, with any amino acid mass modifications that might be present having been stripped away." [PSI:MS]
 is_a: MS:1003050 ! peptidoform attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000889
@@ -6283,7 +6283,7 @@ name: peptidoform sequence
 def: "Sequence of letter symbols denoting the order of amino acid residues that compose the peptidoform including the encoding of any residue modifications that are present." [PSI:MS]
 comment: Make it more general as there are actually many other ways to display a modified peptide sequence.
 is_a: MS:1003050 ! peptidoform attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000890
@@ -6309,7 +6309,7 @@ id: MS:1000893
 name: peptidoform group label
 def: "An arbitrary string label used to mark a set of peptides that belong together in a set, whereby the members are differentiated by different isotopic labels. For example, the heavy and light forms of the same peptide will both be assigned the same peptide group label." [PSI:MS]
 is_a: MS:1003050 ! peptidoform attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000894
@@ -6318,7 +6318,7 @@ def: "A time interval from the start of chromatography when an analyte exits a c
 is_a: MS:1003050 ! peptidoform attribute
 relationship: has_units UO:0000010 ! second
 relationship: has_units UO:0000031 ! minute
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000895
@@ -6327,7 +6327,7 @@ def: "A time interval from the start of chromatography when an analyte exits an 
 is_a: MS:1000894 ! retention time
 relationship: has_units UO:0000010 ! second
 relationship: has_units UO:0000031 ! minute
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000896
@@ -6336,7 +6336,7 @@ def: "A time interval from the start of chromatography when an analyte exits a s
 is_a: MS:1000894 ! retention time
 relationship: has_units UO:0000010 ! second
 relationship: has_units UO:0000031 ! minute
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000897
@@ -6345,7 +6345,7 @@ def: "A time interval from the start of chromatography when an analyte exits a c
 is_a: MS:1000894 ! retention time
 relationship: has_units UO:0000010 ! second
 relationship: has_units UO:0000031 ! minute
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000898
@@ -6382,7 +6382,7 @@ id: MS:1000903
 name: product ion series ordinal
 def: "The ordinal of the fragment within a specified ion series. (e.g. 8 for a y8 ion)." [PSI:PI]
 is_a: MS:1001221 ! product ion attribute
-relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term
+relationship: has_value_type xsd:positiveInteger ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000904
@@ -6396,7 +6396,7 @@ id: MS:1000905
 name: percent of base peak times 100
 def: "The magnitude of a peak expressed in terms of the percentage of the magnitude of the base peak intensity multiplied by 100. The base peak is therefore 10000. This unit is common in normalized spectrum libraries." [PSI:MS]
 is_a: MS:1000043 ! intensity unit
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000906
@@ -6404,7 +6404,7 @@ name: peak intensity rank
 def: "Ordinal specifying the rank in intensity of a peak in a spectrum. Base peak is 1. The next most intense peak is 2, etc." [PSI:MS]
 is_a: MS:1000455 ! ion selection attribute
 relationship: part_of MS:1000231 ! peak
-relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term
+relationship: has_value_type xsd:positiveInteger ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000907
@@ -6412,7 +6412,7 @@ name: peak targeting suitability rank
 def: "Ordinal specifying the rank of a peak in a spectrum in terms of suitability for targeting. The most suitable peak is 1. The next most suitability peak is 2, etc. Suitability is algorithm and context dependant." [PSI:MS]
 is_a: MS:1000455 ! ion selection attribute
 relationship: part_of MS:1000231 ! peak
-relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term
+relationship: has_value_type xsd:positiveInteger ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000908
@@ -6471,7 +6471,7 @@ def: "The extent of the retention time window in time units below the target ret
 is_a: MS:1000915 ! retention time window attribute
 relationship: has_units UO:0000010 ! second
 relationship: has_units UO:0000031 ! minute
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000917
@@ -6480,7 +6480,7 @@ def: "The extent of the retention time window in time units above the target ret
 is_a: MS:1000915 ! retention time window attribute
 relationship: has_units UO:0000010 ! second
 relationship: has_units UO:0000031 ! minute
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000918
@@ -6538,7 +6538,7 @@ id: MS:1000926
 name: product interpretation rank
 def: "The integer rank given an interpretation of an observed product ion. For example, if y8 is selected as the most likely interpretation of a peak, then it is assigned a rank of 1." [PSI:MS]
 is_a: MS:1001221 ! product ion attribute
-relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term
+relationship: has_value_type xsd:positiveInteger ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000927
@@ -6546,7 +6546,7 @@ name: ion injection time
 def: "The length of time spent filling an ion trapping device." [PSI:MS]
 is_a: MS:1000503 ! scan attribute
 relationship: has_units UO:0000028 ! millisecond
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000928
@@ -6583,14 +6583,14 @@ id: MS:1000933
 name: protein modifications
 def: "Encoding of modifications of the protein sequence from the specified accession, written in PEFF notation." [PSI:MS]
 is_a: MS:1000884 ! protein attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000934
 name: gene name
 def: "Name of the gene from which the protein is translated." [PSI:MS]
 is_a: MS:1000884 ! protein attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1000935
@@ -6620,7 +6620,7 @@ relationship: part_of MS:0000000 ! Proteomics Standards Initiative Mass Spectrom
 id: MS:1001005
 name: SEQUEST:CleavesAt
 is_a: MS:1002096 ! SEQUEST input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001006
@@ -6633,14 +6633,14 @@ id: MS:1001007
 name: SEQUEST:OutputLines
 def: "Number of peptide results to show." [PSI:MS]
 is_a: MS:1002096 ! SEQUEST input parameter
-relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term
+relationship: has_value_type xsd:nonNegativeInteger ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001009
 name: SEQUEST:DescriptionLines
 def: "Number of full protein descriptions to show for top N peptides." [PSI:MS]
 is_a: MS:1002096 ! SEQUEST input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001010
@@ -6659,7 +6659,7 @@ id: MS:1001012
 name: database source
 def: "The organisation, project or laboratory from where the database is obtained (UniProt, NCBI, EBI, other)." [PSI:PI]
 is_a: MS:1001011 ! search database details
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001013
@@ -6679,14 +6679,14 @@ id: MS:1001015
 name: database original uri
 def: "URI, from where the search database was originally downloaded." [PSI:PI]
 is_a: MS:1001011 ! search database details
-relationship: has_value_type xsd\:anyURI ! The allowed value-type for this CV term
+relationship: has_value_type xsd:anyURI ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001016
 name: database version
 def: "Version of the search database. In mzIdentML use the attribute instead." [PSI:PI]
 is_a: MS:1001011 ! search database details
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001017
@@ -6694,7 +6694,7 @@ name: release date
 def: "Date and time at which a product was publicly released. For mzIdentML, use the database release date XML attribute instead of this term." [PSI:PI]
 is_a: MS:1001011 ! search database details
 is_a: MS:1003171 ! spectral library attribute
-relationship: has_value_type xsd\:dateTime
+relationship: has_value_type xsd:dateTime
 relationship: has_structured_representation_in_format MS:1002073 ! mzIdentML format
 
 [Term]
@@ -6744,13 +6744,13 @@ id: MS:1001025
 name: translation table
 def: "The translation table used to translate the nucleotides to amino acids." [PSI:PI]
 is_a: MS:1001011 ! search database details
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001026
 name: SEQUEST:NormalizeXCorrValues
 is_a: MS:1002096 ! SEQUEST input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001027
@@ -6763,14 +6763,14 @@ id: MS:1001028
 name: SEQUEST:SequenceHeaderFilter
 def: "String in the header of a sequence entry for that entry to be searched." [PSI:MS]
 is_a: MS:1002096 ! SEQUEST input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001029
 name: number of sequences searched
 def: "The number of sequences (proteins / nucleotides) from the database search after filtering." [PSI:PI]
 is_a: MS:1001011 ! search database details
-relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term
+relationship: has_value_type xsd:positiveInteger ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001030
@@ -6778,7 +6778,7 @@ name: number of peptide seqs compared to each spectrum
 def: "Number of peptide seqs compared to each spectrum." [PSI:PI]
 is_a: MS:1001011 ! search database details
 is_a: MS:1001405 ! spectrum identification result details
-relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term
+relationship: has_value_type xsd:nonNegativeInteger ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001031
@@ -6790,7 +6790,7 @@ is_a: MS:1001080 ! search type
 id: MS:1001032
 name: SEQUEST:SequencePartialFilter
 is_a: MS:1002096 ! SEQUEST input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001035
@@ -6804,21 +6804,21 @@ id: MS:1001036
 name: search time taken
 def: "The time taken to complete the search in seconds." [PSI:PI]
 is_a: MS:1001184 ! search statistics
-relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term
+relationship: has_value_type xsd:positiveInteger ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001037
 name: SEQUEST:ShowFragmentIons
 def: "Flag indicating that fragment ions should be shown." [PSI:MS]
 is_a: MS:1002096 ! SEQUEST input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001038
 name: SEQUEST:Consensus
 def: "Specify depth as value of the CVParam." [PSI:PI]
 is_a: MS:1001006 ! SEQUEST:ViewCV
-relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term
+relationship: has_value_type xsd:positiveInteger ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001040
@@ -6837,7 +6837,7 @@ id: MS:1001042
 name: SEQUEST:LimitTo
 def: "Specify \"number of dtas shown\" as value of the CVParam." [PSI:PI]
 is_a: MS:1002096 ! SEQUEST input parameter
-relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term
+relationship: has_value_type xsd:positiveInteger ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001044
@@ -6856,56 +6856,56 @@ id: MS:1001046
 name: SEQUEST:sort by dCn
 def: "Sort order of SEQUEST search results by the delta of the normalized correlation score." [PSI:PI]
 is_a: MS:1001041 ! SEQUEST:sortCV
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001047
 name: SEQUEST:sort by dM
 def: "Sort order of SEQUEST search results by the difference between a theoretically calculated and the corresponding experimentally measured molecular mass M." [PSI:PI]
 is_a: MS:1001041 ! SEQUEST:sortCV
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001048
 name: SEQUEST:sort by Ions
 def: "Sort order of SEQUEST search results given by the ions." [PSI:PI]
 is_a: MS:1001041 ! SEQUEST:sortCV
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001049
 name: SEQUEST:sort by MH+
 def: "Sort order of SEQUEST search results given by the mass of the protonated ion." [PSI:PI]
 is_a: MS:1001041 ! SEQUEST:sortCV
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001050
 name: SEQUEST:sort by P
 def: "Sort order of SEQUEST search results given by the probability." [PSI:PI]
 is_a: MS:1001041 ! SEQUEST:sortCV
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001051
 name: multiple enzyme combination rules
 def: "OBSOLETE: use attribute independent in mzIdentML instead. Description of multiple enzyme digestion protocol, if any." [PSI:PI]
 is_obsolete: true
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001052
 name: SEQUEST:sort by PreviousAminoAcid
 def: "Sort order of SEQUEST search results given by the previous amino acid." [PSI:PI]
 is_a: MS:1001041 ! SEQUEST:sortCV
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001053
 name: SEQUEST:sort by Ref
 def: "Sort order of SEQUEST search results given by the reference." [PSI:PI]
 is_a: MS:1001041 ! SEQUEST:sortCV
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001055
@@ -6937,7 +6937,7 @@ id: MS:1001059
 name: SEQUEST:sort by RSp
 def: "Sort order of SEQUEST search results given by the result 'Sp' of 'Rank/Sp' in the out file (peptide)." [PSI:PI]
 is_a: MS:1001041 ! SEQUEST:sortCV
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001060
@@ -6979,35 +6979,35 @@ id: MS:1001068
 name: SEQUEST:sort by Sp
 def: "Sort order of SEQUEST search results by the Sp score." [PSI:PI]
 is_a: MS:1001041 ! SEQUEST:sortCV
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001069
 name: SEQUEST:sort by TIC
 def: "Sort order of SEQUEST search results given by the total ion current." [PSI:PI]
 is_a: MS:1001041 ! SEQUEST:sortCV
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001070
 name: SEQUEST:sort by Scan
 def: "Sort order of SEQUEST search results given by the scan number." [PSI:PI]
 is_a: MS:1001041 ! SEQUEST:sortCV
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001071
 name: SEQUEST:sort by Sequence
 def: "Sort order of SEQUEST search results given by the sequence." [PSI:PI]
 is_a: MS:1001041 ! SEQUEST:sortCV
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001072
 name: SEQUEST:sort by Sf
 def: "Sort order of SEQUEST search results given by the SEQUEST result 'Sf'." [PSI:PI]
 is_a: MS:1001041 ! SEQUEST:sortCV
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001073
@@ -7062,7 +7062,7 @@ id: MS:1001086
 name: SEQUEST:sort by XCorr
 def: "Sort order of SEQUEST search results by the correlation score." [PSI:PI]
 is_a: MS:1001041 ! SEQUEST:sortCV
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001087
@@ -7076,7 +7076,7 @@ name: protein description
 def: "The protein description line from the sequence entry in the source database FASTA file." [PSI:PI]
 is_a: MS:1001085 ! protein-level identification attribute
 is_a: MS:1001342 ! database sequence details
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001089
@@ -7085,7 +7085,7 @@ def: "The taxonomy of the resultant molecule from the search." [PSI:PI]
 is_a: MS:1001085 ! protein-level identification attribute
 is_a: MS:1001342 ! database sequence details
 is_a: MS:1001512 ! Sequence database filters
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001090
@@ -7116,55 +7116,55 @@ id: MS:1001093
 name: sequence coverage
 def: "The percent coverage for the protein based upon the matched peptide sequences (can be calculated)." [PSI:PI]
 is_a: MS:1001085 ! protein-level identification attribute
-relationship: has_value_type xsd\:decimal ! The allowed value-type for this CV term
+relationship: has_value_type xsd:decimal ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001094
 name: SEQUEST:sort by z
 def: "Sort order of SEQUEST search results given by the charge." [PSI:PI]
 is_a: MS:1001041 ! SEQUEST:sortCV
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001095
 name: SEQUEST:ProcessAll
 is_a: MS:1001087 ! SEQUEST:ProcessCV
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001096
 name: SEQUEST:TopPercentMostIntense
 def: "Specify \"percentage\" as value of the CVParam." [PSI:PI]
 is_a: MS:1001087 ! SEQUEST:ProcessCV
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001097
 name: distinct peptide sequences
 def: "This counts distinct sequences hitting the protein without regard to a minimal confidence threshold." [PSI:PI]
 is_a: MS:1001085 ! protein-level identification attribute
-relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term
+relationship: has_value_type xsd:nonNegativeInteger ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001098
 name: confident distinct peptide sequences
 def: "This counts the number of distinct peptide sequences. Multiple charge states and multiple modification states do NOT count as multiple sequences. The definition of 'confident' must be qualified elsewhere." [PSI:PI]
 is_a: MS:1001085 ! protein-level identification attribute
-relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term
+relationship: has_value_type xsd:nonNegativeInteger ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001099
 name: confident peptide qualification
 def: "The point of this entry is to define what is meant by confident for the term Confident distinct peptide sequence and/or Confident peptides. Example 1 - metric=Paragon:Confidence value=95 sense=greater than Example 2 - metric=Mascot:Eval value=0.05 sense=less than." [PSI:PI]
 is_a: MS:1001085 ! protein-level identification attribute
-relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term
+relationship: has_value_type xsd:nonNegativeInteger ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001100
 name: confident peptide sequence number
 def: "This counts the number of peptide sequences without regard to whether they are distinct. Multiple charges states and multiple modification states DO count as multiple peptides. The definition of 'confident' must be qualified elsewhere." [PSI:PI]
 is_a: MS:1001085 ! protein-level identification attribute
-relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term
+relationship: has_value_type xsd:nonNegativeInteger ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001101
@@ -7176,13 +7176,13 @@ is_a: MS:1001085 ! protein-level identification attribute
 id: MS:1001102
 name: SEQUEST:Chromatogram
 is_a: MS:1001006 ! SEQUEST:ViewCV
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001103
 name: SEQUEST:InfoAndLog
 is_a: MS:1001006 ! SEQUEST:ViewCV
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001104
@@ -7201,7 +7201,7 @@ id: MS:1001106
 name: SEQUEST:TopNumber
 def: "Specify \"number\" as value of the CVParam." [PSI:PI]
 is_a: MS:1001087 ! SEQUEST:ProcessCV
-relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term
+relationship: has_value_type xsd:positiveInteger ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001107
@@ -7220,7 +7220,7 @@ id: MS:1001109
 name: SEQUEST:CullTo
 def: "Specify cull string as value of the CVParam." [PSI:PI]
 is_a: MS:1001087 ! SEQUEST:ProcessCV
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001110
@@ -7232,7 +7232,7 @@ is_a: MS:1002096 ! SEQUEST input parameter
 id: MS:1001111
 name: SEQUEST:Full
 is_a: MS:1001110 ! SEQUEST:modeCV
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001112
@@ -7240,7 +7240,7 @@ name: n-terminal flanking residue
 def: "Residue preceding the first amino acid in the peptide sequence as it occurs in the protein. Use 'N-term' to denote if the peptide starts at the N terminus of the protein." [PSI:PI]
 is_a: MS:1003046 ! peptide-to-protein mapping attribute
 is_a: MS:1001105 ! peptide sequence-level identification attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001113
@@ -7248,7 +7248,7 @@ name: c-terminal flanking residue
 def: "Residue following the last amino acid in the peptide sequence as it occurs in the protein. Use 'C-term' to denote if the peptide ends at the C terminus of the protein." [PSI:PI]
 is_a: MS:1003046 ! peptide-to-protein mapping attribute
 is_a: MS:1001105 ! peptide sequence-level identification attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001114
@@ -7259,7 +7259,7 @@ is_a: MS:1001105 ! peptide sequence-level identification attribute
 relationship: has_units UO:0000010 ! second
 relationship: has_units UO:0000031 ! minute
 is_obsolete: true
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001115
@@ -7280,7 +7280,7 @@ name: theoretical mass
 def: "The theoretical neutral mass of the molecule (e.g. the peptide sequence and its modifications) not including its charge carrier." [PSI:PI]
 is_a: MS:1001105 ! peptide sequence-level identification attribute
 relationship: has_units UO:0000221 ! dalton
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001118
@@ -7298,14 +7298,14 @@ is_a: MS:1002473 ! ion series considered in search
 id: MS:1001120
 name: SEQUEST:FormatAndLinks
 is_a: MS:1001110 ! SEQUEST:modeCV
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001121
 name: number of matched peaks
 def: "The number of peaks that were matched as qualified by the ion series considered field. If a peak matches multiple ions then only 1 would be added the count." [PSI:PI]
 is_a: MS:1001105 ! peptide sequence-level identification attribute
-relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term
+relationship: has_value_type xsd:nonNegativeInteger ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001122
@@ -7318,14 +7318,14 @@ id: MS:1001123
 name: number of peaks used
 def: "The number of peaks from the original peak list that are used to calculate the scores for a particular search engine. All ions that have the opportunity to match or be counted even if they don't." [PSI:PI]
 is_a: MS:1001105 ! peptide sequence-level identification attribute
-relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term
+relationship: has_value_type xsd:nonNegativeInteger ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001124
 name: number of peaks submitted
 def: "The number of peaks from the original peaks listed that were submitted to the search engine." [PSI:PI]
 is_a: MS:1001105 ! peptide sequence-level identification attribute
-relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term
+relationship: has_value_type xsd:nonNegativeInteger ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001125
@@ -7333,13 +7333,13 @@ name: manual validation
 def: "Result of quality estimation: decision of a manual validation." [PSI:PI]
 is_a: MS:1001092 ! peptide sequence-level identification statistic
 is_a: MS:1001116 ! single protein identification statistic
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001126
 name: SEQUEST:Fast
 is_a: MS:1001110 ! SEQUEST:modeCV
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001127
@@ -7366,42 +7366,42 @@ def: "OBSOLETE Peptide raw area." [PSI:PI]
 comment: This term was made obsolete because it is replaced by 'MS1 feature area' (MS:1001844).
 is_a: MS:1002737 ! peptide-level quantification datatype
 is_obsolete: true
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001131
 name: error on peptide area
 def: "Error on peptide area." [PSI:PI]
 is_a: MS:1002737 ! peptide-level quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001132
 name: peptide ratio
 def: "Peptide ratio." [PSI:PI]
 is_a: MS:1002737 ! peptide-level quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001133
 name: error on peptide ratio
 def: "Error on peptide ratio." [PSI:PI]
 is_a: MS:1002737 ! peptide-level quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001134
 name: protein ratio
 def: "Protein ratio." [PSI:PI]
 is_a: MS:1002738 ! protein-level quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001135
 name: error on protein ratio
 def: "Error on protein ratio." [PSI:PI]
 is_a: MS:1002738 ! protein-level quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001136
@@ -7410,21 +7410,21 @@ def: "OBSOLETE P-value (protein diff from 1 randomly)." [PSI:PI]
 comment: This term was made obsolete because it is replaced by 't-test p-value' (MS:1001855).
 is_a: MS:1002738 ! protein-level quantification datatype
 is_obsolete: true
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001137
 name: absolute quantity
 def: "Absolute quantity in terms of real concentration or molecule copy number in sample." [PSI:PI]
 is_a: MS:1001805 ! quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001138
 name: error on absolute quantity
 def: "Error on absolute quantity." [PSI:PI]
 is_a: MS:1001805 ! quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001139
@@ -7446,7 +7446,7 @@ id: MS:1001141
 name: intensity of precursor ion
 def: "The intensity of the precursor ion." [PSI:PI]
 is_a: MS:1001805 ! quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001142
@@ -7524,7 +7524,7 @@ id: MS:1001154
 name: SEQUEST:probability
 def: "The SEQUEST result 'Probability'." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001155
@@ -7532,62 +7532,62 @@ name: SEQUEST:xcorr
 def: "The SEQUEST result 'XCorr'." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002108 ! higher score better
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001156
 name: SEQUEST:deltacn
 def: "The SEQUEST result 'DeltaCn'." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001157
 name: SEQUEST:sp
 def: "The SEQUEST result 'Sp' (protein)." [PSI:PI]
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001158
 name: SEQUEST:Uniq
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001159
 name: SEQUEST:expectation value
 def: "The SEQUEST result 'Expectation value'." [PSI:PI]
 is_a: MS:1001153 ! search engine specific score
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001160
 name: SEQUEST:sf
 def: "The SEQUEST result 'Sf'." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001161
 name: SEQUEST:matched ions
 def: "The SEQUEST result 'Matched Ions'." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term
+relationship: has_value_type xsd:integer ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001162
 name: SEQUEST:total ions
 def: "The SEQUEST result 'Total Ions'." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term
+relationship: has_value_type xsd:integer ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001163
 name: SEQUEST:consensus score
 def: "The SEQUEST result 'Consensus Score'." [PSI:PI]
 is_a: MS:1001153 ! search engine specific score
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001164
@@ -7595,7 +7595,7 @@ name: Paragon:unused protscore
 def: "The Paragon result 'Unused ProtScore'." [PSI:PI]
 is_a: MS:1002363 ! search engine specific score for proteins
 is_a: MS:1002368 ! search engine specific score for protein groups
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001165
@@ -7603,70 +7603,70 @@ name: Paragon:total protscore
 def: "The Paragon result 'Total ProtScore'." [PSI:PI]
 is_a: MS:1002363 ! search engine specific score for proteins
 is_a: MS:1002368 ! search engine specific score for protein groups
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001166
 name: Paragon:score
 def: "The Paragon result 'Score'." [PSI:PI]
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001167
 name: Paragon:confidence
 def: "The Paragon result 'Confidence'." [PSI:PI]
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001168
 name: Paragon:expression error factor
 def: "The Paragon result 'Expression Error Factor'." [PSI:PI]
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001169
 name: Paragon:expression change p-value
 def: "The Paragon result 'Expression change P-value'." [PSI:PI]
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001170
 name: Paragon:contrib
 def: "The Paragon result 'Contrib'." [PSI:PI]
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001171
 name: Mascot:score
 def: "The Mascot result 'Score'." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001172
 name: Mascot:expectation value
 def: "The Mascot result 'expectation value'." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001173
 name: Mascot:matched ions
 def: "The Mascot result 'Matched ions'." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term
+relationship: has_value_type xsd:nonNegativeInteger ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001174
 name: Mascot:total ions
 def: "The Mascot result 'Total ions'." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term
+relationship: has_value_type xsd:nonNegativeInteger ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001175
@@ -7685,7 +7685,7 @@ id: MS:1001177
 name: number of molecular hypothesis considered
 def: "Number of Molecular Hypothesis Considered - This is the number of molecules (e.g. peptides for proteomics) considered for a particular search." [PSI:PI]
 is_a: MS:1001184 ! search statistics
-relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term
+relationship: has_value_type xsd:nonNegativeInteger ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001178
@@ -7726,7 +7726,7 @@ comment: This term was made obsolete because now is split into peptide and prote
 is_a: MS:1001092 ! peptide sequence-level identification statistic
 is_a: MS:1001198 ! protein identification confidence metric
 is_obsolete: true
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001192
@@ -7734,7 +7734,7 @@ name: Expect value
 def: "Result of quality estimation: Expect value." [PSI:PI]
 is_a: MS:1001092 ! peptide sequence-level identification statistic
 is_a: MS:1001116 ! single protein identification statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001193
@@ -7742,14 +7742,14 @@ name: confidence score
 def: "Result of quality estimation: confidence score." [PSI:PI]
 is_a: MS:1001092 ! peptide sequence-level identification statistic
 is_a: MS:1001116 ! single protein identification statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001194
 name: quality estimation with decoy database
 def: "Quality estimation by decoy database." [PSI:PI]
 is_a: MS:1001060 ! quality estimation method details
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001195
@@ -7794,7 +7794,7 @@ def: "Maximum value of molecular weight filter." [PSI:PI]
 is_a: MS:1001512 ! Sequence database filters
 relationship: has_units UO:0000221 ! dalton
 relationship: has_units UO:0000222 ! kilodalton
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001202
@@ -7803,21 +7803,21 @@ def: "Minimum value of molecular weight filter." [PSI:PI]
 is_a: MS:1001512 ! Sequence database filters
 relationship: has_units UO:0000221 ! dalton
 relationship: has_units UO:0000222 ! kilodalton
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001203
 name: DB PI filter maximum
 def: "Maximum value of isoelectric point filter." [PSI:PI]
 is_a: MS:1001512 ! Sequence database filters
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001204
 name: DB PI filter minimum
 def: "Minimum value of isoelectric point filter." [PSI:PI]
 is_a: MS:1001512 ! Sequence database filters
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001207
@@ -7868,35 +7868,35 @@ name: protein-level global FDR
 def: "Estimation of the global false discovery rate of proteins." [PSI:PI]
 is_a: MS:1002705 ! protein-level result list statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001215
 name: SEQUEST:PeptideSp
 def: "The SEQUEST result 'Sp' in out file (peptide)." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001217
 name: SEQUEST:PeptideRankSp
 def: "The SEQUEST result 'Sp' of 'Rank/Sp' in out file (peptide). Also called 'rsp'." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term
+relationship: has_value_type xsd:integer ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001218
 name: SEQUEST:PeptideNumber
 def: "The SEQUEST result '#' in out file (peptide)." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term
+relationship: has_value_type xsd:integer ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001219
 name: SEQUEST:PeptideIdnumber
 def: "The SEQUEST result 'Id#' in out file (peptide)." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term
+relationship: has_value_type xsd:integer ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001220
@@ -8081,7 +8081,7 @@ name: local FDR
 def: "Result of quality estimation: the local FDR at the current position of a sorted list." [PSI:PI]
 is_a: MS:1001092 ! peptide sequence-level identification statistic
 is_a: MS:1001116 ! single protein identification statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001251
@@ -8179,21 +8179,21 @@ id: MS:1001268
 name: programmer
 def: "Programmer role." [PSI:PI]
 is_a: MS:1001266 ! role type
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001269
 name: instrument vendor
 def: "Instrument vendor role." [PSI:PI]
 is_a: MS:1001266 ! role type
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001270
 name: lab personnel
 def: "Lab personnel role." [PSI:PI]
 is_a: MS:1001266 ! role type
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001271
@@ -8236,7 +8236,7 @@ id: MS:1001283
 name: decoy DB accession regexp
 def: "Specify the regular expression for decoy accession numbers." [PSI:PI]
 is_a: MS:1001450 ! decoy DB details
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001284
@@ -8357,7 +8357,7 @@ id: MS:1001301
 name: protein rank
 def: "The rank of the protein in a list sorted by the search engine." [PSI:PI]
 is_a: MS:1001085 ! protein-level identification attribute
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
+relationship: has_value_type xsd:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001302
@@ -8464,70 +8464,70 @@ id: MS:1001316
 name: Mascot:SigThreshold
 def: "Significance threshold below which the p-value of a peptide match must lie to be considered statistically significant (default 0.05)." [PSI:PI]
 is_a: MS:1002095 ! Mascot input parameter
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001317
 name: Mascot:MaxProteinHits
 def: "The number of protein hits to display in the report. If 'Auto', all protein hits that have a protein score exceeding the average peptide identity threshold are reported. Otherwise an integer at least 1." [PSI:PI]
 is_a: MS:1002095 ! Mascot input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001318
 name: Mascot:ProteinScoringMethod
 def: "Mascot protein scoring method; either 'Standard' or 'MudPIT'." [PSI:PI]
 is_a: MS:1002095 ! Mascot input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001319
 name: Mascot:MinMSMSThreshold
 def: "Mascot peptide match ion score threshold. If between 0 and 1, then peptide matches whose expect value exceeds the thresholds are suppressed; if at least 1, then peptide matches whose ion score is below the threshold are suppressed." [PSI:PI]
 is_a: MS:1002095 ! Mascot input parameter
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001320
 name: Mascot:ShowHomologousProteinsWithSamePeptides
 def: "If true, show (sequence or spectrum) same-set proteins. Otherwise they are suppressed." [PSI:PI]
 is_a: MS:1002095 ! Mascot input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001321
 name: Mascot:ShowHomologousProteinsWithSubsetOfPeptides
 def: "If true, show (sequence or spectrum) sub-set and subsumable proteins. Otherwise they are suppressed." [PSI:PI]
 is_a: MS:1002095 ! Mascot input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001322
 name: Mascot:RequireBoldRed
 def: "Only used in Peptide Summary and Select Summary reports. If true, a peptide match must be 'bold red' to be included in the report; bold red means the peptide is a top ranking match in a query and appears for the first time (in linear order) in the list of protein hits." [PSI:PI]
 is_a: MS:1002095 ! Mascot input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001323
 name: Mascot:UseUnigeneClustering
 def: "If true, then the search results are against a nucleic acid database and Unigene clustering is enabled. Otherwise UniGene clustering is not in use." [PSI:PI]
 is_a: MS:1002095 ! Mascot input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001324
 name: Mascot:IncludeErrorTolerantMatches
 def: "If true, then the search results are error tolerant and peptide matches from the second pass are included in search results. Otherwise no error tolerant peptide matches are included." [http://www.matrixscience.com/help/error_tolerant_help.html]
 is_a: MS:1002095 ! Mascot input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001325
 name: Mascot:ShowDecoyMatches
 def: "If true, then the search results are against an automatically generated decoy database and the reported peptide matches and protein hits come from the decoy database. Otherwise peptide matches and protein hits come from the original database." [PSI:PI]
 is_a: MS:1002095 ! Mascot input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001326
@@ -8541,28 +8541,28 @@ id: MS:1001328
 name: OMSSA:evalue
 def: "OMSSA E-value." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001329
 name: OMSSA:pvalue
 def: "OMSSA p-value." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001330
 name: X\!Tandem:expect
 def: "The X!Tandem expectation value." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001331
 name: X\!Tandem:hyperscore
 def: "The X!Tandem hyperscore." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001332
@@ -8725,7 +8725,7 @@ id: MS:1001358
 name: msmsEval quality
 def: "This term reports the quality of the spectrum assigned by msmsEval." [PSI:PI]
 is_a: MS:1001357 ! spectrum quality descriptions
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001359
@@ -8738,7 +8738,7 @@ id: MS:1001360
 name: alternate single letter codes
 def: "List of standard residue one letter codes which are used to replace a non-standard." [PSI:PI]
 is_a: MS:1001359 ! ambiguous residues
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001361
@@ -8746,14 +8746,14 @@ name: alternate mass
 def: "List of masses a non-standard letter code is replaced with." [PSI:PI]
 is_a: MS:1001359 ! ambiguous residues
 relationship: has_units UO:0000221 ! dalton
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001362
 name: number of unmatched peaks
 def: "The number of unmatched peaks." [PSI:PI]
 is_a: MS:1002345 ! PSM-level attribute
-relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term
+relationship: has_value_type xsd:nonNegativeInteger ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001363
@@ -8767,7 +8767,7 @@ name: peptide sequence-level global FDR
 def: "Estimation of the global false discovery rate for distinct peptides once redundant identifications of the same peptide have been removed (id est multiple PSMs have been collapsed to one entry)." [PSI:PI]
 is_a: MS:1002703 ! peptide sequence-level result list statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001365
@@ -8804,166 +8804,166 @@ id: MS:1001370
 name: Mascot:homology threshold
 def: "The Mascot result 'homology threshold'." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001371
 name: Mascot:identity threshold
 def: "The Mascot result 'identity threshold'." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001372
 name: SEQUEST:Sequences
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term
+relationship: has_value_type xsd:positiveInteger ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001373
 name: SEQUEST:TIC
 def: "SEQUEST total ion current." [PSI:PI]
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001374
 name: SEQUEST:Sum
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001375
 name: Phenyx:Instrument Type
 def: "The instrument type parameter value in Phenyx." [PSI:PI]
 is_a: MS:1002097 ! Phenyx input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001376
 name: Phenyx:Scoring Model
 def: "The selected scoring model in Phenyx." [PSI:PI]
 is_a: MS:1002097 ! Phenyx input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001377
 name: Phenyx:Default Parent Charge
 def: "The default parent charge value in Phenyx." [PSI:PI]
 is_a: MS:1002097 ! Phenyx input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001378
 name: Phenyx:Trust Parent Charge
 def: "The parameter in Phenyx that specifies if the experimental charge state is to be considered as correct." [PSI:PI]
 is_a: MS:1002097 ! Phenyx input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001379
 name: Phenyx:Turbo
 def: "The turbo mode parameter in Phenyx." [PSI:PI]
 is_a: MS:1002097 ! Phenyx input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001380
 name: Phenyx:Turbo:ErrorTol
 def: "The maximal allowed fragment m/z error filter considered in the turbo mode of Phenyx." [PSI:PI]
 is_a: MS:1002097 ! Phenyx input parameter
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001381
 name: Phenyx:Turbo:Coverage
 def: "The minimal peptide sequence coverage value, expressed in percent, considered in the turbo mode of Phenyx." [PSI:PI]
 is_a: MS:1002097 ! Phenyx input parameter
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001382
 name: Phenyx:Turbo:Series
 def: "The list of ion series considered in the turbo mode of Phenyx." [PSI:PI]
 is_a: MS:1002097 ! Phenyx input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001383
 name: Phenyx:MinPepLength
 def: "The minimal number of residues for a peptide to be considered for a valid identification in Phenyx." [PSI:PI]
 is_a: MS:1002097 ! Phenyx input parameter
-relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term
+relationship: has_value_type xsd:positiveInteger ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001384
 name: Phenyx:MinPepzscore
 def: "The minimal peptide z-score for a peptide to be considered for a valid identification in Phenyx." [PSI:PI]
 is_a: MS:1002097 ! Phenyx input parameter
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001385
 name: Phenyx:MaxPepPvalue
 def: "The maximal peptide p-value for a peptide to be considered for a valid identification in Phenyx." [PSI:PI]
 is_a: MS:1002097 ! Phenyx input parameter
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001386
 name: Phenyx:AC Score
 def: "The minimal protein score required for a protein database entry to be displayed in the list of identified proteins in Phenyx." [PSI:PI]
 is_a: MS:1002097 ! Phenyx input parameter
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001387
 name: Phenyx:Conflict Resolution
 def: "The parameter in Phenyx that specifies if the conflict resolution algorithm is to be used." [PSI:PI]
 is_a: MS:1002097 ! Phenyx input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001388
 name: Phenyx:AC
 def: "The primary sequence database identifier of a protein in Phenyx." [PSI:PI]
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001389
 name: Phenyx:ID
 def: "A secondary sequence database identifier of a protein in Phenyx." [PSI:PI]
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001390
 name: Phenyx:Score
 def: "The protein score of a protein match in Phenyx." [PSI:PI]
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001391
 name: Phenyx:Peptides1
 def: "First number of phenyx result \"#Peptides\"." [PSI:PI]
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term
+relationship: has_value_type xsd:positiveInteger ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001392
 name: Phenyx:Peptides2
 def: "Second number of phenyx result \"#Peptides\"." [PSI:PI]
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term
+relationship: has_value_type xsd:positiveInteger ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001393
 name: Phenyx:Auto
 def: "The value of the automatic peptide acceptance filter in Phenyx." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001394
@@ -8971,14 +8971,14 @@ name: Phenyx:User
 def: "The value of the user-defined peptide acceptance filter in Phenyx." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001395
 name: Phenyx:Pepzscore
 def: "The z-score value of a peptide sequence match in Phenyx." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001396
@@ -8986,14 +8986,14 @@ name: Phenyx:PepPvalue
 def: "The p-value of a peptide sequence match in Phenyx." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1002358 ! search engine specific peptide sequence-level identification statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001397
 name: Phenyx:NumberOfMC
 def: "The number of missed cleavages of a peptide sequence in Phenyx." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term
+relationship: has_value_type xsd:positiveInteger ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001398
@@ -9001,7 +9001,7 @@ name: Phenyx:Modif
 def: "The expression of the nature and position(s) of modified residue(s) on a matched peptide sequence in Phenyx." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001399
@@ -9056,7 +9056,7 @@ id: MS:1001410
 name: translation start codons
 def: "The translation start codons used to translate the nucleotides to amino acids." [PSI:PI]
 is_a: MS:1001011 ! search database details
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001411
@@ -9072,7 +9072,7 @@ relationship: has_units UO:0000166 ! parts per notation unit
 relationship: has_units UO:0000169 ! parts per million
 relationship: has_units UO:0000187 ! percent
 relationship: has_units UO:0000221 ! dalton
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001413
@@ -9082,7 +9082,7 @@ relationship: has_units UO:0000166 ! parts per notation unit
 relationship: has_units UO:0000169 ! parts per million
 relationship: has_units UO:0000187 ! percent
 relationship: has_units UO:0000221 ! dalton
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001414
@@ -9091,7 +9091,7 @@ def: "OBSOLETE: replaced by MS:1000797 (peak list scans): This term can hold the
 is_a: MS:1001405 ! spectrum identification result details
 is_obsolete: true
 replaced_by: MS:1000797
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001415
@@ -9100,7 +9100,7 @@ def: "OBSOLETE: replaced by MS:1000798 (peak list raw scans): This term can hold
 is_a: MS:1001405 ! spectrum identification result details
 is_obsolete: true
 replaced_by: MS:1000798
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001416
@@ -9109,35 +9109,35 @@ def: "OBSOLETE: replaced by MS:1000796 (spectrum title): Holds the spectrum titl
 is_a: MS:1001405 ! spectrum identification result details
 is_obsolete: true
 replaced_by: MS:1000796
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001417
 name: SpectraST:dot
 def: "SpectraST dot product of two spectra, measuring spectral similarity." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001418
 name: SpectraST:dot_bias
 def: "SpectraST measure of how much of the dot product is dominated by a few peaks." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001419
 name: SpectraST:discriminant score F
 def: "SpectraST spectrum score." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001420
 name: SpectraST:delta
 def: "SpectraST normalised difference between dot product of top hit and runner-up." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001421
@@ -9156,188 +9156,188 @@ id: MS:1001423
 name: translation table description
 def: "A URL that describes the translation table used to translate the nucleotides to amino acids." [PSI:PI]
 is_a: MS:1001011 ! search database details
-relationship: has_value_type xsd\:anyURI ! The allowed value-type for this CV term
+relationship: has_value_type xsd:anyURI ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001424
 name: ProteinExtractor:Methodname
 def: "Name of the used method in the ProteinExtractor algorithm." [PSI:PI]
 is_a: MS:1002098 ! ProteinExtractor input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001425
 name: ProteinExtractor:GenerateNonRedundant
 def: "Flag indicating if a non redundant scoring should be generated." [PSI:PI]
 is_a: MS:1002098 ! ProteinExtractor input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001426
 name: ProteinExtractor:IncludeIdentified
 def: "Flag indicating if identified proteins should be included." [PSI:PI]
 is_a: MS:1002098 ! ProteinExtractor input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001427
 name: ProteinExtractor:MaxNumberOfProteins
 def: "The maximum number of proteins to consider." [PSI:PI]
 is_a: MS:1002098 ! ProteinExtractor input parameter
-relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term
+relationship: has_value_type xsd:positiveInteger ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001428
 name: ProteinExtractor:MaxProteinMass
 def: "The maximum considered mass for a protein." [PSI:PI]
 is_a: MS:1002098 ! ProteinExtractor input parameter
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001429
 name: ProteinExtractor:MinNumberOfPeptides
 def: "The minimum number of proteins to consider." [PSI:PI]
 is_a: MS:1002098 ! ProteinExtractor input parameter
-relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term
+relationship: has_value_type xsd:positiveInteger ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001430
 name: ProteinExtractor:UseMascot
 def: "Flag indicating to include Mascot scoring for calculation of the ProteinExtractor meta score." [PSI:PI]
 is_a: MS:1002098 ! ProteinExtractor input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001431
 name: ProteinExtractor:MascotPeptideScoreThreshold
 def: "Only peptides with scores higher than that threshold are taken into account in Mascot scoring for calculation of the ProteinExtractor meta score." [DOI:10.4172/jpb.1000056]
 is_a: MS:1002098 ! ProteinExtractor input parameter
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001432
 name: ProteinExtractor:MascotUniqueScore
 def: "In the final result each protein must have at least one peptide above this Mascot score threshold in ProteinExtractor meta score calculation." [DOI:10.4172/jpb.1000056]
 is_a: MS:1002098 ! ProteinExtractor input parameter
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001433
 name: ProteinExtractor:MascotUseIdentityScore
 is_a: MS:1002098 ! ProteinExtractor input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001434
 name: ProteinExtractor:MascotWeighting
 def: "Influence of Mascot search engine in the process of merging the search engine specific protein lists into the global protein list of ProteinExtractor." [DOI:10.4172/jpb.1000056]
 is_a: MS:1002098 ! ProteinExtractor input parameter
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001435
 name: ProteinExtractor:UseSequest
 def: "Flag indicating to include SEQUEST scoring for calculation of the ProteinExtractor meta score." [PSI:PI]
 is_a: MS:1002098 ! ProteinExtractor input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001436
 name: ProteinExtractor:SequestPeptideScoreThreshold
 def: "Only peptides with scores higher than that threshold are taken into account in SEQUEST scoring for calculation of the ProteinExtractor meta score." [DOI:10.4172/jpb.1000056]
 is_a: MS:1002098 ! ProteinExtractor input parameter
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001437
 name: ProteinExtractor:SequestUniqueScore
 def: "In the final result each protein must have at least one peptide above this SEQUEST score threshold in ProteinExtractor meta score calculation." [DOI:10.4172/jpb.1000056]
 is_a: MS:1002098 ! ProteinExtractor input parameter
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001438
 name: ProteinExtractor:SequestWeighting
 def: "Influence of SEQUEST search engine in the process of merging the search engine specific protein lists into the global protein list of ProteinExtractor." [DOI:10.4172/jpb.1000056]
 is_a: MS:1002098 ! ProteinExtractor input parameter
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001439
 name: ProteinExtractor:UseProteinSolver
 def: "Flag indicating to include ProteinSolver scoring for calculation of the ProteinExtractor meta score." [PSI:PI]
 is_a: MS:1002098 ! ProteinExtractor input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001440
 name: ProteinExtractor:ProteinSolverPeptideScoreThreshold
 def: "Only peptides with scores higher than that threshold are taken into account in ProteinSolver scoring for calculation of the ProteinExtractor meta score." [DOI:10.4172/jpb.1000056]
 is_a: MS:1002098 ! ProteinExtractor input parameter
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001441
 name: ProteinExtractor:ProteinSolverUniqueScore
 def: "In the final result each protein must have at least one peptide above this ProteinSolver score threshold in ProteinExtractor meta score calculation." [DOI:10.4172/jpb.1000056]
 is_a: MS:1002098 ! ProteinExtractor input parameter
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001442
 name: ProteinExtractor:ProteinSolverWeighting
 def: "Influence of ProteinSolver search engine in the process of merging the search engine specific protein lists into the global protein list of ProteinExtractor." [DOI:10.4172/jpb.1000056]
 is_a: MS:1002098 ! ProteinExtractor input parameter
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001443
 name: ProteinExtractor:UsePhenyx
 def: "Flag indicating to include Phenyx scoring for calculation of the ProteinExtractor meta score." [PSI:PI]
 is_a: MS:1002098 ! ProteinExtractor input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001444
 name: ProteinExtractor:PhenyxPeptideScoreThreshold
 def: "Only peptides with scores higher than that threshold are taken into account in Phenyx scoring for calculation of the ProteinExtractor meta score." [DOI:10.4172/jpb.1000056]
 is_a: MS:1002098 ! ProteinExtractor input parameter
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001445
 name: ProteinExtractor:PhenyxUniqueScore
 def: "In the final result each protein must have at least one peptide above this Phenyx score threshold in ProteinExtractor meta score calculation." [DOI:10.4172/jpb.1000056]
 is_a: MS:1002098 ! ProteinExtractor input parameter
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001446
 name: ProteinExtractor:PhenyxWeighting
 def: "Influence of Phenyx search engine in the process of merging the search engine specific protein lists into the global protein list of ProteinExtractor." [DOI:10.4172/jpb.1000056]
 is_a: MS:1002098 ! ProteinExtractor input parameter
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001447
 name: prot:FDR threshold
 def: "False-discovery rate threshold for proteins." [PSI:PI]
 is_a: MS:1002485 ! protein-level statistical threshold
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001448
 name: pep:FDR threshold
 def: "False-discovery rate threshold for peptides." [PSI:PI]
 is_a: MS:1002484 ! peptide-level statistical threshold
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001449
 name: OMSSA e-value threshold
 def: "Threshold for OMSSA e-value for quality estimation." [PSI:PI]
 is_a: MS:1002099 ! OMSSA input parameter
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001450
@@ -9350,7 +9350,7 @@ id: MS:1001451
 name: decoy DB generation algorithm
 def: "Name of algorithm used for decoy generation." [PSI:PI]
 is_a: MS:1001450 ! decoy DB details
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001452
@@ -9442,28 +9442,28 @@ id: MS:1001467
 name: taxonomy: NCBI TaxID
 def: "This term is used if a NCBI TaxID is specified, e.g. 9606 for Homo sapiens." [PSI:PI]
 is_a: MS:1001089 ! molecule taxonomy
-relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term
+relationship: has_value_type xsd:positiveInteger ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001468
 name: taxonomy: common name
 def: "This term is used if a common name is specified, e.g. human. Recommend using MS:1001467 (taxonomy: NCBI TaxID) where possible." [PSI:PI]
 is_a: MS:1001089 ! molecule taxonomy
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001469
 name: taxonomy: scientific name
 def: "This term is used if a scientific name is specified, e.g. Homo sapiens. Recommend using MS:1001467 (taxonomy: NCBI TaxID) where possible." [PSI:PI]
 is_a: MS:1001089 ! molecule taxonomy
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001470
 name: taxonomy: Swiss-Prot ID
 def: "This term is used if a swiss prot taxonomy id is specified, e.g. Human. Recommend using MS:1001467 (taxonomy: NCBI TaxID) where possible." [PSI:PI]
 is_a: MS:1001089 ! molecule taxonomy
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001471
@@ -9601,21 +9601,21 @@ id: MS:1001491
 name: percolator:Q value
 def: "Percolator:Q value." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001492
 name: percolator:score
 def: "Percolator:score." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001493
 name: percolator:PEP
 def: "Posterior error probability." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001494
@@ -9628,91 +9628,91 @@ id: MS:1001495
 name: ProteinScape:SearchResultId
 def: "The SearchResultId of this peptide as SearchResult in the ProteinScape database." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term
+relationship: has_value_type xsd:positiveInteger ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001496
 name: ProteinScape:SearchEventId
 def: "The SearchEventId of the SearchEvent in the ProteinScape database." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term
+relationship: has_value_type xsd:positiveInteger ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001497
 name: ProteinScape:ProfoundProbability
 def: "The Profound probability score stored by ProteinScape." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001498
 name: Profound:z value
 def: "The Profound z value." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001499
 name: Profound:Cluster
 def: "The Profound cluster score." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001500
 name: Profound:ClusterRank
 def: "The Profound cluster rank." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term
+relationship: has_value_type xsd:positiveInteger ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001501
 name: MSFit:Mowse score
 def: "The MSFit Mowse score." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001502
 name: Sonar:Score
 def: "The Sonar score." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001503
 name: ProteinScape:PFFSolverExp
 def: "The ProteinSolver exp value stored by ProteinScape." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001504
 name: ProteinScape:PFFSolverScore
 def: "The ProteinSolver score stored by ProteinScape." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001505
 name: ProteinScape:IntensityCoverage
 def: "The intensity coverage of the identified peaks in the spectrum calculated by ProteinScape." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001506
 name: ProteinScape:SequestMetaScore
 def: "The SEQUEST meta score calculated by ProteinScape from the original SEQUEST scores." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001507
 name: ProteinExtractor:Score
 def: "The score calculated by ProteinExtractor." [PSI:PI]
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001508
@@ -9749,14 +9749,14 @@ id: MS:1001513
 name: DB sequence filter pattern
 def: "DB sequence filter pattern." [PSI:MS]
 is_a: MS:1001512 ! Sequence database filters
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001514
 name: DB accession filter string
 def: "DB accession filter string." [PSI:MS]
 is_a: MS:1001512 ! Sequence database filters
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001515
@@ -9818,7 +9818,7 @@ name: fragment neutral loss
 def: "This term can describe a neutral loss m/z value that is lost from an ion." [PSI:PI]
 is_a: MS:1001471 ! peptide modification details
 relationship: has_units UO:0000221 ! dalton
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001525
@@ -9826,7 +9826,7 @@ name: precursor neutral loss
 def: "This term can describe a neutral loss m/z value that is lost from an ion." [PSI:PI]
 is_a: MS:1001471 ! peptide modification details
 relationship: has_units UO:0000221 ! dalton
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001526
@@ -10084,42 +10084,42 @@ id: MS:1001568
 name: Scaffold:Peptide Probability
 def: "Scaffold peptide probability score." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001569
 name: IdentityE Score
 def: "Waters IdentityE peptide score." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001570
 name: ProteinLynx:Log Likelihood
 def: "ProteinLynx log likelihood score." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001571
 name: ProteinLynx:Ladder Score
 def: "Waters ProteinLynx Ladder score." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001572
 name: SpectrumMill:Score
 def: "Spectrum mill peptide score." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001573
 name: SpectrumMill:SPI
 def: "SpectrumMill SPI score (%)." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001574
@@ -10132,42 +10132,42 @@ id: MS:1001575
 name: Scaffold: Minimum Peptide Count
 def: "Minimum number of peptides a protein must have to be accepted." [PSI:PI]
 is_a: MS:1002106 ! Scaffold input parameter
-relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term
+relationship: has_value_type xsd:positiveInteger ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001576
 name: Scaffold: Minimum Protein Probability
 def: "Minimum protein probability a protein must have to be accepted." [PSI:PI]
 is_a: MS:1002106 ! Scaffold input parameter
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001577
 name: Scaffold: Minimum Peptide Probability
 def: "Minimum probability a peptide must have to be accepted for protein scoring." [PSI:PI]
 is_a: MS:1002106 ! Scaffold input parameter
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001578
 name: minimum number of enzymatic termini
 def: "Minimum number of enzymatic termini a peptide must have to be accepted." [PSI:PI]
 is_a: MS:1002094 ! common search engine input parameter
-relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term
+relationship: has_value_type xsd:nonNegativeInteger ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001579
 name: Scaffold:Protein Probability
 def: "Scaffold protein probability score." [PSI:PI]
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001580
 name: SpectrumMill:Discriminant Score
 def: "Discriminant score from Agilent SpectrumMill software." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001581
@@ -10176,7 +10176,7 @@ def: "The DC potential applied to the asymmetric waveform in FAIMS that compensa
 synonym: "FAIMS CV" EXACT []
 is_a: MS:1002892 ! ion mobility attribute
 relationship: has_units UO:0000218 ! volt
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001582
@@ -10243,14 +10243,14 @@ id: MS:1001591
 name: anchor protein
 def: "A representative protein selected from a set of sequence same-set or spectrum same-set proteins." [PSI:MS]
 is_a: MS:1001101 ! protein group or subset relationship
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001592
 name: family member protein
 def: "A protein with significant homology to another protein, but some distinguishing peptide matches." [PSI:MS]
 is_a: MS:1001101 ! protein group or subset relationship
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001593
@@ -10263,49 +10263,49 @@ id: MS:1001594
 name: sequence same-set protein
 def: "A protein which is indistinguishable or equivalent to another protein, having matches to an identical set of peptide sequences." [PSI:MS]
 is_a: MS:1001101 ! protein group or subset relationship
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001595
 name: spectrum same-set protein
 def: "A protein which is indistinguishable or equivalent to another protein, having matches to a set of peptide sequences that cannot be distinguished using the evidence in the mass spectra." [PSI:MS]
 is_a: MS:1001101 ! protein group or subset relationship
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001596
 name: sequence sub-set protein
 def: "A protein with a sub-set of the peptide sequence matches for another protein, and no distinguishing peptide matches." [PSI:MS]
 is_a: MS:1001101 ! protein group or subset relationship
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001597
 name: spectrum sub-set protein
 def: "A protein with a sub-set of the matched spectra for another protein, where the matches cannot be distinguished using the evidence in the mass spectra, and no distinguishing peptide matches." [PSI:MS]
 is_a: MS:1001101 ! protein group or subset relationship
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001598
 name: sequence subsumable protein
 def: "A sequence same-set or sequence sub-set protein where the matches are distributed across two or more proteins." [PSI:MS]
 is_a: MS:1001101 ! protein group or subset relationship
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001599
 name: spectrum subsumable protein
 def: "A spectrum same-set or spectrum sub-set protein where the matches are distributed across two or more proteins." [PSI:MS]
 is_a: MS:1001101 ! protein group or subset relationship
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001600
 name: protein inference confidence category
 def: "Confidence category of inferred protein (conclusive, non conclusive, ambiguous group or indistinguishable)." [PSI:MS]
 is_a: MS:1001101 ! protein group or subset relationship
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001601
@@ -10314,7 +10314,7 @@ def: "OBSOLETE Name and location of the .raw file or files." [PSI:MS]
 comment: This term was made obsolete because it's recommended to use one of the 'mass spectrometer file format' terms (MS:1000560) instead.
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001602
@@ -10323,7 +10323,7 @@ def: "OBSOLETE Path and name of the .srf (SEQUEST Result Format) file." [PSI:MS]
 comment: This term was made obsolete. Use attribute in mzIdentML / mzQuantML instead.
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001603
@@ -10332,7 +10332,7 @@ def: "OBSOLETE Ionization source (electro-, nano-, thermospray, electron impact,
 comment: This term was made obsolete because it's recommended to use one of the 'inlet type' (MS:1000007) or 'ionization type' (MS:1000008) terms instead.
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001604
@@ -10341,14 +10341,14 @@ def: "OBSOLETE Fragmentation method used (CID, MPD, ECD, PQD, ETD, HCD, Any)." [
 comment: This term was made obsolete because it's recommended to use one of the 'ionization type' terms (MS:1000008) instead.
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001605
 name: ProteomeDiscoverer:Spectrum Selector:Lower RT Limit
 def: "Lower retention-time limit." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001606
@@ -10357,28 +10357,28 @@ def: "OBSOLETE Type of mass spectrometer used (ITMS, FTMS, TOFMS, SQMS, TQMS, Se
 comment: This term was made obsolete because it's recommended to use mass analyzer type (MS:1000443) instead.
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001607
 name: ProteomeDiscoverer:Max Precursor Mass
 def: "Maximum mass limit of a singly charged precursor ion." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001608
 name: ProteomeDiscoverer:Min Precursor Mass
 def: "Minimum mass limit of a singly charged precursor ion." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001609
 name: ProteomeDiscoverer:Spectrum Selector:Minimum Peak Count
 def: "Minimum number of peaks in a tandem mass spectrum that is allowed to pass the filter and to be subjected to further processing in the workflow." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
+relationship: has_value_type xsd:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001610
@@ -10387,7 +10387,7 @@ def: "OBSOLETE Level of the mass spectrum (MS2 ... MS10)." [PSI:MS]
 comment: This term was made obsolete because it's recommended to use MS1 spectrum (MS:1000579) or MSn spectrum (MS:1000580) instead.
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001611
@@ -10396,21 +10396,21 @@ def: "OBSOLETE Polarity mode (positive or negative)." [PSI:MS]
 comment: This term was made obsolete because it's recommended to use scan polarity (MS:1000465) instead.
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001612
 name: ProteomeDiscoverer:Spectrum Selector:Precursor Selection
 def: "Determines which precursor mass to use for a given MSn scan. This option applies only to higher-order MSn scans (n >= 3)." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001613
 name: ProteomeDiscoverer:SN Threshold
 def: "Signal-to-Noise ratio below which peaks are removed." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001614
@@ -10419,119 +10419,119 @@ def: "OBSOLETE Scan type for the precursor ion (full, Single Ion Monitoring (SIM
 comment: This term was made obsolete because it's recommended to use MS1 spectrum (MS:1000579), MSn spectrum (MS:1000580), CRM spectrum (MS:1000581), SIM spectrum (MS:1000582) or SRM spectrum (MS:1000583) instead.
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001615
 name: ProteomeDiscoverer:Spectrum Selector:Total Intensity Threshold
 def: "Used to filter out tandem mass spectra that have a total intensity current(sum of the intensities of all peaks in a spectrum) below the specified value." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001616
 name: ProteomeDiscoverer:Spectrum Selector:Unrecognized Activation Type Replacements
 def: "Specifies the fragmentation method to use in the search algorithm if it is not included in the scan header." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001617
 name: ProteomeDiscoverer:Spectrum Selector:Unrecognized Charge Replacements
 def: "Specifies the charge state of the precursor ions, if it is not defined in the scan header." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
+relationship: has_value_type xsd:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001618
 name: ProteomeDiscoverer:Spectrum Selector:Unrecognized Mass Analyzer Replacements
 def: "Specifies the mass spectrometer to use to produce the spectra, if it is not included in the scan header." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001619
 name: ProteomeDiscoverer:Spectrum Selector:Unrecognized MS Order Replacements
 def: "Specifies the MS scan order used to produce the product spectra, if it is not included in the scan header." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001620
 name: ProteomeDiscoverer:Spectrum Selector:Unrecognized Polarity Replacements
 def: "Specifies the polarity of the ions monitored if it is not included in the scan header." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001621
 name: ProteomeDiscoverer:Spectrum Selector:Upper RT Limit
 def: "Upper retention-time limit." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001622
 name: ProteomeDiscoverer:Non-Fragment Filter:Mass Window Offset
 def: "Specifies the size of the mass-to-charge ratio (m/z) window in daltons used to remove precursors." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001623
 name: ProteomeDiscoverer:Non-Fragment Filter:Maximum Neutral Loss Mass
 def: "Maximum allowed mass of a neutral loss." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001624
 name: ProteomeDiscoverer:Non-Fragment Filter:Remove Charge Reduced Precursor
 def: "Determines whether the charge-reduced precursor peaks found in an ETD or ECD spectrum are removed." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001625
 name: ProteomeDiscoverer:Non-Fragment Filter:Remove Neutral Loss Peaks
 def: "Determines whether neutral loss peaks are removed from ETD and ECD spectra." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001626
 name: ProteomeDiscoverer:Non-Fragment Filter:Remove Only Known Masses
 def: "Determines whether overtone peaks are removed from LTQ FT or LTQ FT Ultra ECD spectra." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001627
 name: ProteomeDiscoverer:Non-Fragment Filter:Remove Precursor Overtones
 def: "Determines whether precursor overtone peaks in the spectrum are removed from the input spectrum." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001628
 name: ProteomeDiscoverer:Non-Fragment Filter:Remove Precursor Peak
 def: "Determines whether precursor artifact peaks from the MS2 input spectra are removed." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001629
 name: ProteomeDiscoverer:Spectrum Grouper:Allow Mass Analyzer Mismatch
 def: "Determines whether the fragment spectrum for scans with the same precursor mass is grouped, regardless of mass analyzer and activation type." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001630
 name: ProteomeDiscoverer:Spectrum Grouper:Allow MS Order Mismatch
 def: "Determines whether spectra from different MS order scans can be grouped together." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001631
@@ -10540,21 +10540,21 @@ def: "OBSOLETE Chromatographic window where precursors to be grouped must reside
 comment: This term was made obsolete because it's recommended to use retention time window width (MS:1001907) instead.
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001632
 name: ProteomeDiscoverer:Spectrum Grouper:Precursor Mass Criterion
 def: "Groups spectra measured within the given mass and retention-time tolerances into a single spectrum for analysis." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001633
 name: ProteomeDiscoverer:Xtract:Highest Charge
 def: "Highest charge state that is allowed for the deconvolution of multiply charged data." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
+relationship: has_value_type xsd:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001634
@@ -10563,14 +10563,14 @@ def: "OBSOLETE Highest mass-to-charge (mz) value for spectral peaks in the measu
 comment: This term was made obsolete because it's recommended to use scan window upper limit (MS:1000500) instead.
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001635
 name: ProteomeDiscoverer:Xtract:Lowest Charge
 def: "Lowest charge state that is allowed for the deconvolution of multiply charged data." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
+relationship: has_value_type xsd:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001636
@@ -10579,70 +10579,70 @@ def: "OBSOLETE Lowest mass-to-charge (mz) value for spectral peaks in the measur
 comment: This term was made obsolete because it's recommended to use scan window lower limit (MS:1000501) instead.
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001637
 name: ProteomeDiscoverer:Xtract:Monoisotopic Mass Only
 def: "Determines whether the isotopic pattern, i.e. all isotopes of a mass are removed from the spectrum." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001638
 name: ProteomeDiscoverer:Xtract:Overlapping Remainder
 def: "Fraction of the more abundant peak that an overlapping multiplet must exceed in order to be processed (deconvoluted)." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001639
 name: ProteomeDiscoverer:Xtract:Required Fitting Accuracy
 def: "Accuracy required for a pattern fit to be considered valid." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001640
 name: ProteomeDiscoverer:Xtract:Resolution At 400
 def: "Resolution at mass 400." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001641
 name: ProteomeDiscoverer:Lowest Charge State
 def: "Minimum charge state below which peptides are filtered out." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
+relationship: has_value_type xsd:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001642
 name: ProteomeDiscoverer:Highest Charge State
 def: "Maximum charge above which peptides are filtered out." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
+relationship: has_value_type xsd:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001643
 name: ProteomeDiscoverer:Spectrum Score Filter:Let Pass Above Scores
 def: "Determines whether spectra with scores above the threshold score are retained rather than filtered out." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001644
 name: ProteomeDiscoverer:Dynamic Modification
 def: "Determine dynamic post-translational modifications (PTMs)." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001645
 name: ProteomeDiscoverer:Static Modification
 def: "Static Modification to all occurrences of a named amino acid." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001646
@@ -10651,42 +10651,42 @@ def: "OBSOLETE Determines whether the Proteome Discoverer application searches a
 comment: This term was made obsolete because it's recommended to use quality estimation with decoy database (MS:1001194) instead.
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001647
 name: ProteomeDiscoverer:Mascot:Error tolerant Search
 def: "Determines whether to search error-tolerant." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001648
 name: ProteomeDiscoverer:Mascot:Max MGF File Size
 def: "Maximum size of the .mgf (Mascot Generic Format) file in MByte." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
+relationship: has_value_type xsd:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001649
 name: ProteomeDiscoverer:Mascot:Mascot Server URL
 def: "URL (Uniform resource Locator) of the Mascot server." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001650
 name: ProteomeDiscoverer:Mascot:Number of attempts to submit the search
 def: "Number of attempts to submit the Mascot search." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
+relationship: has_value_type xsd:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001651
 name: ProteomeDiscoverer:Mascot:X Static Modification
 def: "Number of attempts to submit the Mascot search." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001652
@@ -10695,14 +10695,14 @@ def: "OBSOLETE Name of the user submitting the Mascot search." [PSI:MS]
 comment: This term was made obsolete because it's recommended to use researcher (MS:1001271) instead.
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001653
 name: ProteomeDiscoverer:Mascot:Time interval between attempts to submit a search
 def: "Time interval between attempts to submit a search in seconds." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001654
@@ -10711,7 +10711,7 @@ def: "OBSOLETE Specifies the enzyme reagent used for protein digestion." [PSI:MS
 comment: This term was made obsolete because it's recommended to use cleavage agent name (MS:1001045) instead.
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001655
@@ -10720,28 +10720,28 @@ def: "OBSOLETE Mass tolerance used for matching fragment peaks in Da or mmu." [P
 comment: This term was made obsolete because it's recommended to use search tolerance minus value (MS:1001413) or search tolerance plus value (MS:1001412) instead.
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001656
 name: Mascot:Instrument
 def: "Type of instrument used to acquire the data in the raw file." [PSI:MS]
 is_a: MS:1002095 ! Mascot input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001657
 name: ProteomeDiscoverer:Maximum Missed Cleavage Sites
 def: "Maximum number of missed cleavage sites to consider during the digest." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
+relationship: has_value_type xsd:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001658
 name: ProteomeDiscoverer:Mascot:Peptide CutOff Score
 def: "Minimum score in the IonScore column that each peptide must exceed in order to be reported." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001659
@@ -10750,14 +10750,14 @@ def: "OBSOLETE Mass window for which precursor ions are considered to be the sam
 comment: This term was made obsolete because it's recommended to use search tolerance minus value (MS:1001413) or search tolerance plus value (MS:1001412) instead.
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001660
 name: ProteomeDiscoverer:Mascot:Protein CutOff Score
 def: "Minimum protein score in the IonScore column that each protein must exceed in order to be reported." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001661
@@ -10766,28 +10766,28 @@ def: "OBSOLETE Database to use in the search (configured on the Mascot server)."
 comment: This term was made obsolete because it's recommended to use database name (MS:1001013) instead.
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001662
 name: ProteomeDiscoverer:Mascot:Protein Relevance Factor
 def: "Specifies a factor that is used in calculating a threshold that determines whether a protein appears in the results report." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001663
 name: ProteomeDiscoverer:Target FDR Relaxed
 def: "Specifies the relaxed target false discovery rate (FDR, 0.0 - 1.0) for peptide hits with moderate confidence." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001664
 name: ProteomeDiscoverer:Target FDR Strict
 def: "Specifies the strict target false discovery rate (FDR, 0.0 - 1.0) for peptide hits with high confidence." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001665
@@ -10796,7 +10796,7 @@ def: "OBSOLETE Limits searches to entries from a particular species or group of 
 comment: This term was made obsolete because it's recommended to use taxonomy: scientific name (MS:1001469) instead.
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001666
@@ -10805,7 +10805,7 @@ def: "OBSOLETE Use average mass for the precursor." [PSI:MS]
 comment: This term was made obsolete because it's recommended to use parent mass type average (MS:1001212) instead.
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001667
@@ -10814,105 +10814,105 @@ def: "OBSOLETE Determines whether to use MudPIT or normal scoring." [PSI:MS]
 comment: This term was made obsolete because it's recommended to use Mascot:ProteinScoringMethod (MS:1001318) instead.
 is_a: MS:1002095 ! Mascot input parameter
 is_obsolete: true
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001668
 name: ProteomeDiscoverer:Absolute XCorr Threshold
 def: "Minimum cross-correlation threshold that determines whether peptides in an .srf file are imported." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001669
 name: ProteomeDiscoverer:SEQUEST:Calculate Probability Score
 def: "Determines whether to calculate a probability score for every peptide match." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001670
 name: ProteomeDiscoverer:SEQUEST:CTerminal Modification
 def: "Dynamic C-terminal modification that is used during the search." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001671
 name: ProteomeDiscoverer:SEQUEST:Fragment Ion Cutoff Percentage
 def: "Percentage of the theoretical ions that must be found in order for a peptide to be scored and retained." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001672
 name: ProteomeDiscoverer:SEQUEST:Max Identical Modifications Per Peptide
 def: "Maximum number of identical modifications that a single peptide can have." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
+relationship: has_value_type xsd:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001673
 name: ProteomeDiscoverer:Max Modifications Per Peptide
 def: "Maximum number of different modifications that a peptide can have, e.g. because of steric hindrance." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
+relationship: has_value_type xsd:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001674
 name: ProteomeDiscoverer:SEQUEST:Maximum Peptides Considered
 def: "Maximum number of peptides that are searched and scored per spectrum." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
+relationship: has_value_type xsd:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001675
 name: ProteomeDiscoverer:Maximum Peptides Output
 def: "Maximum number of peptide matches reported per spectrum." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
+relationship: has_value_type xsd:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001676
 name: ProteomeDiscoverer:Maximum Protein References Per Peptide
 def: "Maximum number of proteins that a single identified peptide can be associated with during protein assembly." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
+relationship: has_value_type xsd:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001677
 name: ProteomeDiscoverer:SEQUEST:NTerminal Modification
 def: "Dynamic N-terminal modification that is used during the search." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001678
 name: ProteomeDiscoverer:Peptide CTerminus
 def: "Static modification for the C terminal of the peptide used during the search." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001679
 name: ProteomeDiscoverer:Peptide NTerminus
 def: "Static modification for the N terminal of the peptide used during the search." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001680
 name: ProteomeDiscoverer:SEQUEST:Peptide Relevance Factor
 def: "Specifies a factor to apply to the protein score." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001681
 name: ProteomeDiscoverer:Protein Relevance Threshold
 def: "Specifies a peptide threshold that determines whether the protein that it is a part of is scored and retained in the report." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001682
@@ -10921,133 +10921,133 @@ def: "OBSOLETE Determines whether the Proteome Discoverer application searches a
 comment: This term was made obsolete because it's recommended to use quality estimation with decoy database (MS:1001194) instead.
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001683
 name: ProteomeDiscoverer:SEQUEST:Use Average Fragment Masses
 def: "Use average masses for the fragments." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001684
 name: ProteomeDiscoverer:Use Neutral Loss a Ions
 def: "Determines whether a ions with neutral loss are used for spectrum matching." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001685
 name: ProteomeDiscoverer:Use Neutral Loss b Ions
 def: "Determines whether b ions with neutral loss are used for spectrum matching." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001686
 name: ProteomeDiscoverer:Use Neutral Loss y Ions
 def: "Determines whether y ions with neutral loss are used for spectrum matching." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001687
 name: ProteomeDiscoverer:Use Neutral Loss z Ions
 def: "Determines whether z ions with neutral loss are used for spectrum matching." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001688
 name: ProteomeDiscoverer:SEQUEST:Weight of a Ions
 def: "Uses a ions for spectrum matching with this relative factor." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001689
 name: ProteomeDiscoverer:SEQUEST:Weight of b Ions
 def: "Uses b ions for spectrum matching with this relative factor." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001690
 name: ProteomeDiscoverer:SEQUEST:Weight of c Ions
 def: "Uses c ions for spectrum matching with this relative factor." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001691
 name: ProteomeDiscoverer:SEQUEST:Weight of d Ions
 def: "Uses c ions for spectrum matching with this relative factor." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001692
 name: ProteomeDiscoverer:SEQUEST:Weight of v Ions
 def: "Uses c ions for spectrum matching with this relative factor." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001693
 name: ProteomeDiscoverer:SEQUEST:Weight of w Ions
 def: "Uses c ions for spectrum matching with this relative factor." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001694
 name: ProteomeDiscoverer:SEQUEST:Weight of x Ions
 def: "Uses x ions for spectrum matching with this relative factor." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001695
 name: ProteomeDiscoverer:SEQUEST:Weight of y Ions
 def: "Uses y ions for spectrum matching with this relative factor." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001696
 name: ProteomeDiscoverer:SEQUEST:Weight of z Ions
 def: "Uses z ions for spectrum matching with this relative factor." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001697
 name: ProteomeDiscoverer:ZCore:Protein Score Cutoff
 def: "Sets a minimum protein score that each protein must exceed in order to be reported." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001698
 name: ProteomeDiscoverer:Reporter Ions Quantizer:Integration Method
 def: "Specifies which peak to select if more than one peak is found inside the integration window." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001699
 name: ProteomeDiscoverer:Reporter Ions Quantizer:Integration Window Tolerance
 def: "Specifies the mass-to-charge window that enables one to look for the reporter peaks." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001700
 name: ProteomeDiscoverer:Reporter Ions Quantizer:Quantitation Method
 def: "Quantitation method for isobarically labeled quantitation." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001701
@@ -11056,133 +11056,133 @@ def: "OBSOLETE Format of the exported spectra (dta, mgf or mzData)." [PSI:MS]
 comment: This term was made obsolete because it's recommended to use one of the 'mass spectrometer file format' terms (MS:1000560) instead.
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001702
 name: ProteomeDiscoverer:Spectrum Exporter:File name
 def: "Name of the output file that contains the exported data." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001703
 name: ProteomeDiscoverer:Search Modifications Only For Identified Proteins
 def: "Influences the modifications search." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001704
 name: ProteomeDiscoverer:SEQUEST:Std High Confidence XCorr Charge1
 def: "Standard high confidence XCorr parameter for charge = 1." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001705
 name: ProteomeDiscoverer:SEQUEST:Std High Confidence XCorr Charge2
 def: "Standard high confidence XCorr parameter for charge = 2." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001706
 name: ProteomeDiscoverer:SEQUEST:Std High Confidence XCorr Charge3
 def: "Standard high confidence XCorr parameter for charge = 3." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001707
 name: ProteomeDiscoverer:SEQUEST:Std High Confidence XCorr Charge4
 def: "Standard high confidence XCorr parameter for charge >= 4." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001708
 name: ProteomeDiscoverer:SEQUEST:Std Medium Confidence XCorr Charge1
 def: "Standard medium confidence XCorr parameter for charge = 1." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001709
 name: ProteomeDiscoverer:SEQUEST:Std Medium Confidence XCorr Charge2
 def: "Standard medium confidence XCorr parameter for charge = 2." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001710
 name: ProteomeDiscoverer:SEQUEST:Std Medium Confidence XCorr Charge3
 def: "Standard medium confidence XCorr parameter for charge = 3." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001711
 name: ProteomeDiscoverer:SEQUEST:Std Medium Confidence XCorr Charge4
 def: "Standard medium confidence XCorr parameter for charge >= 4." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001712
 name: ProteomeDiscoverer:SEQUEST:FT High Confidence XCorr Charge1
 def: "FT high confidence XCorr parameter for charge = 1." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001713
 name: ProteomeDiscoverer:SEQUEST:FT High Confidence XCorr Charge2
 def: "FT high confidence XCorr parameter for charge = 2." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001714
 name: ProteomeDiscoverer:SEQUEST:FT High Confidence XCorr Charge3
 def: "FT high confidence XCorr parameter for charge = 3." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001715
 name: ProteomeDiscoverer:SEQUEST:FT High Confidence XCorr Charge4
 def: "FT high confidence XCorr parameter for charge >= 4." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001716
 name: ProteomeDiscoverer:SEQUEST:FT Medium Confidence XCorr Charge1
 def: "FT medium confidence XCorr parameter for charge = 1." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001717
 name: ProteomeDiscoverer:SEQUEST:FT Medium Confidence XCorr Charge2
 def: "FT medium confidence XCorr parameter for charge = 2." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001718
 name: ProteomeDiscoverer:SEQUEST:FT Medium Confidence XCorr Charge3
 def: "FT medium confidence XCorr parameter for charge = 3." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001719
 name: ProteomeDiscoverer:SEQUEST:FT Medium Confidence XCorr Charge4
 def: "FT medium confidence XCorr parameter for charge >= 4." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001720
@@ -11191,7 +11191,7 @@ def: "OBSOLETE ProteomeDiscoverer's 1st dynamic post-translational modification 
 comment: This term was made obsolete because it's recommended to use ProteomeDiscoverer:Dynamic Modification (MS:1001644) instead.
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001721
@@ -11200,7 +11200,7 @@ def: "OBSOLETE ProteomeDiscoverer's 2nd dynamic post-translational modification 
 comment: This term was made obsolete because it's recommended to use ProteomeDiscoverer:Dynamic Modification (MS:1001644) instead.
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001722
@@ -11209,7 +11209,7 @@ def: "OBSOLETE ProteomeDiscoverer's 3rd dynamic post-translational modification 
 comment: This term was made obsolete because it's recommended to use ProteomeDiscoverer:Dynamic Modification (MS:1001644) instead.
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001723
@@ -11218,77 +11218,77 @@ def: "OBSOLETE ProteomeDiscoverer's 4th dynamic post-translational modification 
 comment: This term was made obsolete because it's recommended to use ProteomeDiscoverer:Dynamic Modification (MS:1001644) instead.
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001724
 name: ProteomeDiscoverer:Static Modification for X
 def: "Static Modification for X." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001725
 name: ProteomeDiscoverer:Initial minimal peptide probability
 def: "Minimal initial peptide probability to contribute to analysis." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001726
 name: ProteomeDiscoverer:Minimal peptide probability
 def: "Minimum adjusted peptide probability contributing to protein probability." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001727
 name: ProteomeDiscoverer:Minimal peptide weight
 def: "Minimum peptide weight contributing to protein probability." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001728
 name: ProteomeDiscoverer:Number of input1 spectra
 def: "Number of spectra from 1+ precursor ions." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
+relationship: has_value_type xsd:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001729
 name: ProteomeDiscoverer:Number of input2 spectra
 def: "Number of spectra from 2+ precursor ions." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
+relationship: has_value_type xsd:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001730
 name: ProteomeDiscoverer:Number of input3 spectra
 def: "Number of spectra from 3+ precursor ions." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
+relationship: has_value_type xsd:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001731
 name: ProteomeDiscoverer:Number of input4 spectra
 def: "Number of spectra from 4+ precursor ions." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
+relationship: has_value_type xsd:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001732
 name: ProteomeDiscoverer:Number of input5 spectra
 def: "Number of spectra from 5+ precursor ions." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
+relationship: has_value_type xsd:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001733
 name: ProteomeDiscoverer:Number of predicted correct proteins
 def: "Total number of predicted correct protein ids (sum of probabilities)." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001734
@@ -11297,7 +11297,7 @@ def: "OBSOLETE Sample organism (used for annotation purposes)." [PSI:MS]
 comment: This term was made obsolete because it's recommended to use taxonomy: scientific name (MS:1001469) instead.
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001735
@@ -11306,14 +11306,14 @@ def: "OBSOLETE Full path database name." [PSI:MS]
 comment: This term was made obsolete. Use attribute in mzIdentML / mzQuantML instead.
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001736
 name: ProteomeDiscoverer:Residue substitution list
 def: "Residues considered equivalent when comparing peptides." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001737
@@ -11322,7 +11322,7 @@ def: "OBSOLETE File type (if not pepXML)." [PSI:MS]
 comment: This term was made obsolete because it's recommended to use mass spectrometer file format (MS:1000560) instead.
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001738
@@ -11331,7 +11331,7 @@ def: "OBSOLETE Input pepXML files." [PSI:MS]
 comment: This term was made obsolete because it's recommended to use pepXML file (MS:1001421) instead.
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001739
@@ -11340,21 +11340,21 @@ def: "OBSOLETE Input pepXML files (old)." [PSI:MS]
 comment: This term was made obsolete because it's recommended to use pepXML file (MS:1001421) instead.
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001740
 name: ProteomeDiscoverer:WinCyg reference database
 def: "Windows full path for database." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001741
 name: ProteomeDiscoverer:WinCyg source files
 def: "Windows pepXML file names." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001742
@@ -11367,126 +11367,126 @@ id: MS:1001743
 name: ProteomeDiscoverer:Mascot:Weight of A Ions
 def: "Determines if to use A ions for spectrum matching." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001744
 name: ProteomeDiscoverer:Mascot:Weight of B Ions
 def: "Determines if to use B ions for spectrum matching." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001745
 name: ProteomeDiscoverer:Mascot:Weight of C Ions
 def: "Determines if to use C ions for spectrum matching." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001746
 name: ProteomeDiscoverer:Mascot:Weight of D Ions
 def: "Determines if to use D ions for spectrum matching." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001747
 name: ProteomeDiscoverer:Mascot:Weight of V Ions
 def: "Determines if to use V ions for spectrum matching." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001748
 name: ProteomeDiscoverer:Mascot:Weight of W Ions
 def: "Determines if to use W ions for spectrum matching." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001749
 name: ProteomeDiscoverer:Mascot:Weight of X Ions
 def: "Determines if to use X ions for spectrum matching." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001750
 name: ProteomeDiscoverer:Mascot:Weight of Y Ions
 def: "Determines if to use Y ions for spectrum matching." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001751
 name: ProteomeDiscoverer:Mascot:Weight of Z Ions
 def: "Determines if to use z ions for spectrum matching." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001752
 name: ProteomeDiscoverer:Spectrum Selector:Use New Precursor Reevaluation
 def: "Determines if to use precursor reevaluation." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001753
 name: ProteomeDiscoverer:Spectrum Selector:SN Threshold FTonly
 def: "Signal-to-Noise ratio below which peaks are removed (in FT mode only)." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001754
 name: ProteomeDiscoverer:Mascot:Please Do not Touch this
 def: "Unknown Mascot parameter which ProteomeDiscoverer uses for mascot searches." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001755
 name: contact phone number
 def: "Phone number of the contact person or organization." [PSI:MS]
 is_a: MS:1000585 ! contact attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001756
 name: contact fax number
 def: "Fax number for the contact person or organization." [PSI:MS]
 is_a: MS:1000585 ! contact attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001757
 name: contact toll-free phone number
 def: "Toll-free phone number of the contact person or organization." [PSI:MS]
 is_a: MS:1000585 ! contact attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001758
 name: Mascot:SigThresholdType
 def: "Significance threshold type used in Mascot reporting (either 'identity' or 'homology')." [PSI:MS]
 is_a: MS:1002095 ! Mascot input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001759
 name: Mascot:ProteinGrouping
 def: "Strategy used by Mascot to group proteins with same peptide matches (one of 'none', 'Occam's razor' or 'family clustering')." [PSI:MS]
 is_a: MS:1002095 ! Mascot input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001760
 name: Percolator:features
 def: "List of Percolator features that were used in processing the peptide matches. Typical Percolator features are 'retentionTime', 'dM', 'mScore', 'lgDScore', 'mrCalc', 'charge' and 'dMppm'." [PSI:MS]
 is_a: MS:1002107 ! Percolator input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001761
@@ -11685,7 +11685,7 @@ id: MS:1001793
 name: Mascot:PreferredTaxonomy
 def: "NCBI TaxID taxonomy ID to prefer when two or more proteins match the same set of peptides or when protein entry in database represents multiple sequences." [PSI:MS]
 is_a: MS:1002095 ! Mascot input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001795
@@ -11779,7 +11779,7 @@ id: MS:1001808
 name: technical replicate
 def: "The study variable is 'technical replicate'. The string value denotes the category of technical replicate, e.g. 'run generated from same sample'." [PSI:MS]
 is_a: MS:1001807 ! study variable attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001809
@@ -11816,21 +11816,21 @@ id: MS:1001814
 name: generic experimental condition
 def: "The experimental condition is given in the value of this term." [PSI:MS]
 is_a: MS:1001807 ! study variable attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001815
 name: time series, time point X
 def: "The experimental design followed a time series design. The time point of this run is given in the value of this term." [PSI:MS]
 is_a: MS:1001807 ! study variable attribute
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
+relationship: has_value_type xsd:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001816
 name: dilution series, concentration X
 def: "The experimental design followed a dilution series design. The concentration of this run is given in the value of this term." [PSI:MS]
 is_a: MS:1001807 ! study variable attribute
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001817
@@ -11909,7 +11909,7 @@ id: MS:1001829
 name: SRM transition ID
 def: "Identifier for an SRM transition in an external document describing additional information about the transition." [PSI:MS]
 is_a: MS:1001828 ! feature attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001830
@@ -11929,7 +11929,7 @@ id: MS:1001832
 name: quantitation software comment or customizations
 def: "Quantitation software comment or any customizations to the default setup of the software." [PSI:PI]
 is_a: MS:1001129 ! quantification information
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001833
@@ -11978,35 +11978,35 @@ id: MS:1001840
 name: LC-MS feature intensity
 def: "Maximum peak intensity of the LC-MS feature." [PSI:PI]
 is_a: MS:1002735 ! feature-level quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001841
 name: LC-MS feature volume
 def: "Real (intensity times area) volume of the LC-MS feature." [PSI:PI]
 is_a: MS:1002735 ! feature-level quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001842
 name: sequence-level spectral count
 def: "The number of MS2 spectra identified for a raw peptide sequence without PTMs and charge state in spectral counting." [PSI:PI]
 is_a: MS:1002737 ! peptide-level quantification datatype
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
+relationship: has_value_type xsd:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001843
 name: MS1 feature maximum intensity
 def: "Maximum intensity of MS1 feature." [PSI:PI]
 is_a: MS:1002735 ! feature-level quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001844
 name: MS1 feature area
 def: "Area of MS1 feature." [PSI:PI]
 is_a: MS:1002735 ! feature-level quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001845
@@ -12015,21 +12015,21 @@ def: "OBSOLETE Area of MS1 peak (e.g. SILAC, 15N)." [PSI:PI]
 comment: This term was made obsolete because it was a duplication of MS:1001844.
 is_a: MS:1001805 ! quantification datatype
 is_obsolete: true
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001846
 name: isotopic pattern area
 def: "Area of all peaks belonging to the isotopic pattern of light or heavy peak (e.g. 15N)." [PSI:PI]
 is_a: MS:1001805 ! quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001847
 name: reporter ion intensity
 def: "Intensity of MS2 reporter ion (e.g. iTraq)." [PSI:PI]
 is_a: MS:1001805 ! quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001848
@@ -12044,84 +12044,84 @@ def: "OBSOLETE Peptide quantification value calculated as sum of MatchedFeature 
 comment: This term was made obsolete because the concept MatchedFeature was dropped.
 is_a: MS:1002735 ! feature-level quantification datatype
 is_obsolete: true
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001850
 name: normalized peptide value
 def: "Normalized peptide value." [PSI:PI]
 is_a: MS:1002737 ! peptide-level quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001851
 name: protein value: sum of peptide values
 def: "Protein quantification value calculated as sum of peptide values." [PSI:PI]
 is_a: MS:1002738 ! protein-level quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001852
 name: normalized protein value
 def: "Normalized protein value." [PSI:PI]
 is_a: MS:1002738 ! protein-level quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001853
 name: max fold change
 def: "Global datatype: Maximum of all pair-wise fold changes of group means (e.g. Progenesis)." [PSI:PI]
 is_a: MS:1001805 ! quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001854
 name: ANOVA p-value
 def: "Global datatype: p-value of ANOVA of group means (e.g. Progenesis)." [PSI:PI]
 is_a: MS:1002072 ! p-value
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001855
 name: t-test p-value
 def: "P-value of t-Test of two groups." [PSI:PI]
 is_a: MS:1002072 ! p-value
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001856
 name: reporter ion raw value
 def: "Intensity (or area) of MS2 reporter ion (e.g. iTraq)." [PSI:PI]
 is_a: MS:1001805 ! quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001857
 name: reporter ion normalized value
 def: "Normalized value of MS2 reporter ion (e.g. iTraq)." [PSI:PI]
 is_a: MS:1001805 ! quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001858
 name: XIC area
 def: "Area of the extracted ion chromatogram (e.g. of a transition in SRM)." [PSI:PI]
 is_a: MS:1001805 ! quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001859
 name: normalized XIC area
 def: "Normalized area of the extracted ion chromatogram (e.g. of a transition in SRM)." [PSI:PI]
 is_a: MS:1001805 ! quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001860
 name: protein value: mean of peptide ratios
 def: "Protein quantification value calculated as mean of peptide ratios." [PSI:PI]
 is_a: MS:1002738 ! protein-level quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001861
@@ -12171,7 +12171,7 @@ name: distinct peptide-level q-value
 def: "Estimation of the q-value for distinct peptides once redundant identifications of the same peptide have been removed (id est multiple PSMs, possibly with different mass modifications, mapping to the same sequence have been collapsed to one entry)." [PSI:PI]
 is_a: MS:1002484 ! peptide-level statistical threshold
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001869
@@ -12179,7 +12179,7 @@ name: protein-level q-value
 def: "Estimation of the q-value for proteins." [PSI:PI]
 is_a: MS:1001116 ! single protein identification statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001870
@@ -12187,7 +12187,7 @@ name: peptide sequence-level p-value
 def: "Estimation of the p-value for distinct peptides once redundant identifications of the same peptide have been removed (id est multiple PSMs have been collapsed to one entry)." [PSI:PI]
 is_a: MS:1001092 ! peptide sequence-level identification statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001871
@@ -12195,7 +12195,7 @@ name: protein-level p-value
 def: "Estimation of the p-value for proteins." [PSI:PI]
 is_a: MS:1001116 ! single protein identification statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001872
@@ -12203,7 +12203,7 @@ name: peptide sequence-level e-value
 def: "Estimation of the e-value for distinct peptides once redundant identifications of the same peptide have been removed (id est multiple PSMs have been collapsed to one entry)." [PSI:PI]
 is_a: MS:1001092 ! peptide sequence-level identification statistic
 relationship: has_domain MS:1002306 ! value greater than zero
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001873
@@ -12211,7 +12211,7 @@ name: protein-level e-value
 def: "Estimation of the e-value for proteins." [PSI:PI]
 is_a: MS:1001116 ! single protein identification statistic
 relationship: has_domain MS:1002306 ! value greater than zero
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001874
@@ -12221,14 +12221,14 @@ comment: This term was made obsolete because it was split into the more specific
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1001153 ! search engine specific score
 is_obsolete: true
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001875
 name: modification motif
 def: "The regular expression describing the sequence motif for a modification." [PSI:PI]
 is_a: MS:1001056 ! modification specificity rule
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001876
@@ -12257,7 +12257,7 @@ name: offset voltage
 def: "The potential difference between two adjacent interface voltages affecting in-source collision induced dissociation." [PSI:MS]
 is_a: MS:1000482 ! source attribute
 relationship: has_units UO:0000218 ! volt
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001880
@@ -12282,14 +12282,14 @@ id: MS:1001883
 name: coefficient of variation
 def: "Variation of a set of signal measurements calculated as the standard deviation relative to the mean." [PSI:MS]
 is_a: MS:1001882 ! transition validation attribute
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001884
 name: signal-to-noise ratio
 def: "Unitless number providing the ratio of the total measured intensity of a signal relative to the estimated noise level for that signal." [PSI:MS]
 is_a: MS:1001882 ! transition validation attribute
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001885
@@ -12297,7 +12297,7 @@ name: command-line parameters
 def: "Parameters string passed to a command-line interface software application, omitting the executable name." [PSI:MS]
 is_a: MS:1000630 ! data processing parameter
 is_a: MS:1003201 ! library provenance attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001886
@@ -12329,119 +12329,119 @@ id: MS:1001890
 name: Progenesis:protein normalised abundance
 def: "The data type normalised abundance for proteins produced by Progenesis LC-MS." [PSI:MS]
 is_a: MS:1002738 ! protein-level quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001891
 name: Progenesis:peptide normalised abundance
 def: "The data type normalised abundance for peptides produced by Progenesis LC-MS." [PSI:MS]
 is_a: MS:1002737 ! peptide-level quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001892
 name: Progenesis:protein raw abundance
 def: "The data type raw abundance for proteins produced by Progenesis LC-MS." [PSI:MS]
 is_a: MS:1002738 ! protein-level quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001893
 name: Progenesis:peptide raw abundance
 def: "The data type raw abundance for peptide produced by Progenesis LC-MS." [PSI:MS]
 is_a: MS:1002737 ! peptide-level quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001894
 name: Progenesis:confidence score
 def: "The data type confidence score produced by Progenesis LC-MS." [PSI:MS]
 is_a: MS:1001805 ! quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001895
 name: Progenesis:peptide count
 def: "The data type peptide count produced by Progenesis LC-MS." [PSI:MS]
 is_a: MS:1002737 ! peptide-level quantification datatype
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
+relationship: has_value_type xsd:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001896
 name: Progenesis:feature intensity
 def: "The data type feature intensity produced by Progenesis LC-MS." [PSI:MS]
 is_a: MS:1002735 ! feature-level quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001897
 name: MaxQuant:peptide counts (unique)
 def: "The data type peptide counts (unique) produced by MaxQuant." [PSI:MS]
 is_a: MS:1002737 ! peptide-level quantification datatype
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
+relationship: has_value_type xsd:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001898
 name: MaxQuant:peptide counts (all)
 def: "The data type peptide counts (all) produced by MaxQuant." [PSI:MS]
 is_a: MS:1002737 ! peptide-level quantification datatype
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
+relationship: has_value_type xsd:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001899
 name: MaxQuant:peptide counts (razor+unique)
 def: "The data type peptide counts (razor+unique) produced by MaxQuant." [PSI:MS]
 is_a: MS:1002737 ! peptide-level quantification datatype
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
+relationship: has_value_type xsd:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001900
 name: MaxQuant:sequence length
 def: "The data type sequence length produced by MaxQuant." [PSI:MS]
 is_a: MS:1002737 ! peptide-level quantification datatype
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
+relationship: has_value_type xsd:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001901
 name: MaxQuant:PEP
 def: "The data type PEP (posterior error probability) produced by MaxQuant." [PSI:MS]
 is_a: MS:1001805 ! quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001902
 name: MaxQuant:LFQ intensity
 def: "The data type LFQ intensity produced by MaxQuant." [PSI:MS]
 is_a: MS:1001805 ! quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001903
 name: MaxQuant:feature intensity
 def: "The data type feature intensity produced by MaxQuant." [PSI:MS]
 is_a: MS:1002735 ! feature-level quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001904
 name: MaxQuant:MS/MS count
 def: "The data type MS2 count produced by MaxQuant." [PSI:MS]
 is_a: MS:1001805 ! quantification datatype
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
+relationship: has_value_type xsd:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001905
 name: emPAI value
 def: "The emPAI value of protein abundance, produced from the emPAI algorithm." [PSI:MS]
 is_a: MS:1002738 ! protein-level quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001906
 name: APEX value
 def: "The APEX value of protein abundance, produced from the APEX software." [PSI:MS]
 is_a: MS:1002738 ! protein-level quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001907
@@ -12450,7 +12450,7 @@ def: "The full width of a retention time window for a chromatographic peak." [PS
 is_a: MS:1000915 ! retention time window attribute
 relationship: has_units UO:0000010 ! second
 relationship: has_units UO:0000031 ! minute
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001908
@@ -12490,7 +12490,7 @@ name: S-lens voltage
 def: "Potential difference setting of the Thermo Scientific S-lens stacked-ring ion guide in volts." [PSI:MS]
 is_a: MS:1000482 ! source attribute
 relationship: has_units UO:0000218 ! volt
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001914
@@ -12533,14 +12533,14 @@ id: MS:1001919
 name: ProteomeXchange accession number
 def: "Main identifier of a ProteomeXchange dataset." [PSI:PI]
 is_a: MS:1000878 ! external reference identifier
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001921
 name: ProteomeXchange accession number version number
 def: "Version number of a ProteomeXchange accession number." [PSI:PI]
 is_a: MS:1000878 ! external reference identifier
-relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term
+relationship: has_value_type xsd:nonNegativeInteger ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001922
@@ -12549,63 +12549,63 @@ def: "DOI unique identifier of a publication." [PSI:PI, http://dx.doi.org]
 synonym: "doi" EXACT []
 is_a: MS:1000878 ! external reference identifier
 relationship: has_regexp MS:1002480 ! (10[.][0-9]\{4,\}(?:[.][0-9]+)*/(?:(?![\"&\'<>])[^ \t\\r\n\\v\\f])+)
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001923
 name: external reference keyword
 def: "Free text attribute that can enrich the information about an entity." [PSI:PI]
 is_a: MS:1002840 ! external reference data
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001924
 name: journal article keyword
 def: "Keyword present in a scientific publication." [PSI:PI]
 is_a: MS:1001923 ! external reference keyword
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001925
 name: submitter keyword
 def: "Keyword assigned by the data submitter." [PSI:PI]
 is_a: MS:1001923 ! external reference keyword
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001926
 name: curator keyword
 def: "Keyword assigned by a data curator." [PSI:PI]
 is_a: MS:1001923 ! external reference keyword
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001927
 name: Tranche file hash
 def: "Hash assigned by the Tranche resource to an individual file." [PSI:PI]
 is_a: MS:1000878 ! external reference identifier
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001928
 name: Tranche project hash
 def: "Hash assigned by the Tranche resource to a whole project." [PSI:PI]
 is_a: MS:1000878 ! external reference identifier
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001929
 name: PRIDE experiment URI
 def: "URI that allows the access to one experiment in the PRIDE database." [PSI:PI]
 is_a: MS:1000878 ! external reference identifier
-relationship: has_value_type xsd\:anyURI ! The allowed value-type for this CV term
+relationship: has_value_type xsd:anyURI ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001930
 name: PRIDE project URI
 def: "URI that allows the access to one project in the PRIDE database." [PSI:PI]
 is_a: MS:1000878 ! external reference identifier
-relationship: has_value_type xsd\:anyURI ! The allowed value-type for this CV term
+relationship: has_value_type xsd:anyURI ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001931
@@ -12618,14 +12618,14 @@ id: MS:1001932
 name: source interface model
 def: "The source interface model." [PSI:MS]
 relationship: part_of MS:1001931 ! source interface
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001933
 name: source sprayer
 def: "The source sprayer." [PSI:MS]
 relationship: part_of MS:1000458 ! source
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001934
@@ -12638,14 +12638,14 @@ id: MS:1001935
 name: source sprayer manufacturer
 def: "The source sprayer manufacturer." [PSI:MS]
 relationship: part_of MS:1001933 ! source sprayer
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001936
 name: source sprayer model
 def: "The source sprayer model." [PSI:MS]
 relationship: part_of MS:1001933 ! source sprayer
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001937
@@ -12696,7 +12696,7 @@ def: "Potential difference between Q2 and Q3 in a triple quadrupole instrument i
 is_a: MS:1000510 ! precursor activation attribute
 relationship: has_units UO:0000218 ! volt
 synonym: "CXP" EXACT []
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001945
@@ -12739,35 +12739,35 @@ id: MS:1001950
 name: PEAKS:peptideScore
 def: "The PEAKS peptide '-10lgP Score'." [PSI:MS]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001951
 name: PEAKS:proteinScore
 def: "The PEAKS protein '-10lgP Score'." [PSI:MS]
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001952
 name: ZCore:probScore
 def: "The ZCore probability score." [PSI:MS]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001953
 name: source interface manufacturer
 def: "The source interface manufacturer." [PSI:MS]
 relationship: part_of MS:1001931 ! source interface
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001954
 name: acquisition parameter
 def: "Parameters used in the mass spectrometry acquisition." [PSI:MS]
 relationship: part_of MS:1001458 ! spectrum generation information
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001955
@@ -12810,35 +12810,35 @@ id: MS:1001961
 name: peptide spectrum match scoring algorithm
 def: "Algorithm used to score the match between a spectrum and a peptide ion." [PSI:MS]
 relationship: part_of MS:1001458 ! spectrum generation information
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001962
 name: Mascot:C13 counts
 def: "C13 peaks to use in peak detection." [PSI:MS]
 is_a: MS:1002095 ! Mascot input parameter
-relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term
+relationship: has_value_type xsd:nonNegativeInteger ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001963
 name: ProteinExtractor:Weighting
 def: "Weighting factor for protein list compilation by ProteinExtractor." [PSI:MS]
 is_a: MS:1002098 ! ProteinExtractor input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001964
 name: ProteinScape:second round Mascot
 def: "Flag indicating a second round search with Mascot." [PSI:MS]
 is_a: MS:1002100 ! ProteinScape input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001965
 name: ProteinScape:second round Phenyx
 def: "Flag indicating a second round search with Phenyx." [PSI:MS]
 is_a: MS:1002100 ! ProteinScape input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001966
@@ -12854,7 +12854,7 @@ is_a: MS:1002222 ! SRM transition attribute
 relationship: has_units UO:0000028 ! millisecond
 comment: This term was made obsolete because it was replaced by ion mobility drift time (MS:1002476).
 is_obsolete: true
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001968
@@ -12868,7 +12868,7 @@ name: phosphoRS score
 def: "phosphoRS score for PTM site location at the PSM-level." [DOI:10.1021/pr200611n, PMID:22073976]
 is_a: MS:1001968 ! PTM localization PSM-level statistic
 relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001970
@@ -12876,7 +12876,7 @@ name: phosphoRS sequence probability
 def: "Probability that the respective isoform is correct." [DOI:10.1021/pr200611n, PMID:22073976]
 is_a: MS:1001968 ! PTM localization PSM-level statistic
 relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001971
@@ -12884,14 +12884,14 @@ name: phosphoRS site probability
 def: "Estimate of the probability that the respective site is truly phosphorylated." [DOI:10.1021/pr200611n, PMID:22073976]
 is_a: MS:1001968 ! PTM localization PSM-level statistic
 relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001972
 name: PTM scoring algorithm version
 def: "Version of the post-translational modification scoring algorithm." [PSI:MS]
 is_a: MS:1001471 ! peptide modification details
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001973
@@ -12906,7 +12906,7 @@ def: "Score specific to DeBunker." [PSI:MS]
 is_a: MS:1001968 ! PTM localization PSM-level statistic
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001975
@@ -12917,7 +12917,7 @@ is_a: MS:1001405 ! spectrum identification result details
 relationship: has_units UO:0000166 ! parts per notation unit
 relationship: has_units UO:0000187 ! percent
 relationship: has_units UO:0000221 ! dalton
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001976
@@ -12928,7 +12928,7 @@ is_a: MS:1001405 ! spectrum identification result details
 relationship: has_units UO:0000166 ! parts per notation unit
 relationship: has_units UO:0000187 ! percent
 relationship: has_units UO:0000221 ! dalton
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001977
@@ -12942,7 +12942,7 @@ name: MSQuant:PTM-score
 def: "The PTM score from MSQuant software." [DOI:10.1021/pr900721e, PMID:19888749]
 is_a: MS:1001968 ! PTM localization PSM-level statistic
 relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001979
@@ -12950,7 +12950,7 @@ name: MaxQuant:PTM Score
 def: "The PTM score from MaxQuant software." [PSI:MS]
 is_a: MS:1001968 ! PTM localization PSM-level statistic
 relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001980
@@ -12958,14 +12958,14 @@ name: MaxQuant:Phospho (STY) Probabilities
 def: "The Phospho (STY) Probabilities from MaxQuant software." [PSI:MS]
 is_a: MS:1001968 ! PTM localization PSM-level statistic
 relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001981
 name: MaxQuant:Phospho (STY) Score Diffs
 def: "The Phospho (STY) Score Diffs from MaxQuant software." [PSI:MS]
 is_a: MS:1001968 ! PTM localization PSM-level statistic
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001982
@@ -12973,7 +12973,7 @@ name: MaxQuant:P-site localization probability
 def: "The P-site localization probability value from MaxQuant software." [PSI:MS]
 is_a: MS:1001968 ! PTM localization PSM-level statistic
 relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001983
@@ -12981,7 +12981,7 @@ name: MaxQuant:PTM Delta Score
 def: "The PTM Delta Score value from MaxQuant software (Difference between highest scoring site and second highest)." [PSI:MS]
 is_a: MS:1001968 ! PTM localization PSM-level statistic
 relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001984
@@ -12995,7 +12995,7 @@ name: Ascore
 def: "A-score for PTM site location at the PSM-level." [DOI:10.1038/nbt1240, PMID:16964243]
 is_a: MS:1001968 ! PTM localization PSM-level statistic
 relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001986
@@ -13003,7 +13003,7 @@ name: H-Score
 def: "H-Score for peptide phosphorylation site location." [DOI:10.1021/pr1006813, PMID:20836569]
 is_a: MS:1001968 ! PTM localization PSM-level statistic
 relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1001987
@@ -13095,28 +13095,28 @@ id: MS:1002001
 name: MS1 label-based raw feature quantitation
 def: "MS1 label-based raw feature quantitation." [PSI:PI]
 is_a: MS:1002018 ! MS1 label-based analysis
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002002
 name: MS1 label-based peptide level quantitation
 def: "MS1 label-based peptide level quantitation." [PSI:PI]
 is_a: MS:1002018 ! MS1 label-based analysis
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002003
 name: MS1 label-based protein level quantitation
 def: "MS1 label-based protein level quantitation." [PSI:PI]
 is_a: MS:1002018 ! MS1 label-based analysis
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002004
 name: MS1 label-based proteingroup level quantitation
 def: "MS1 label-based proteingroup level quantitation." [PSI:PI]
 is_a: MS:1002018 ! MS1 label-based analysis
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002005
@@ -13170,7 +13170,7 @@ name: Mascot:PTM site assignment confidence
 def: "Relative probability that PTM site assignment is correct, derived from the Mascot score difference between matches to the same spectrum (Mascot Delta Score)." [http://www.matrixscience.com/help/pt_mods_help.html#SITE]
 is_a: MS:1001968 ! PTM localization PSM-level statistic
 relationship: has_units UO:0000187 ! percent
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002013
@@ -13178,7 +13178,7 @@ name: collision energy ramp start
 def: "Collision energy at the start of the collision energy ramp." [PSI:PI]
 is_a: MS:1000045 ! collision energy
 relationship: has_units UO:0000266 ! electronvolt
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002014
@@ -13186,28 +13186,28 @@ name: collision energy ramp end
 def: "Collision energy at the end of the collision energy ramp." [PSI:PI]
 is_a: MS:1000045 ! collision energy
 relationship: has_units UO:0000266 ! electronvolt
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002015
 name: spectral count peptide level quantitation
 def: "Spectral count peptide level quantitation." [PSI:PI]
 is_a: MS:1001836 ! spectral counting quantitation analysis
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002016
 name: spectral count protein level quantitation
 def: "Spectral count protein level quantitation." [PSI:PI]
 is_a: MS:1001836 ! spectral counting quantitation analysis
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002017
 name: spectral count proteingroup level quantitation
 def: "Spectral count proteingroup level quantitation." [PSI:PI]
 is_a: MS:1001836 ! spectral counting quantitation analysis
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002018
@@ -13220,28 +13220,28 @@ id: MS:1002019
 name: label-free raw feature quantitation
 def: "Label-free raw feature quantitation." [PSI:PI]
 is_a: MS:1001834 ! LC-MS label-free quantitation analysis
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002020
 name: label-free peptide level quantitation
 def: "Label-free peptide level quantitation." [PSI:PI]
 is_a: MS:1001834 ! LC-MS label-free quantitation analysis
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002021
 name: label-free protein level quantitation
 def: "Label-free protein level quantitation." [PSI:PI]
 is_a: MS:1001834 ! LC-MS label-free quantitation analysis
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002022
 name: label-free proteingroup level quantitation
 def: "Label-free proteingroup level quantitation." [PSI:PI]
 is_a: MS:1001834 ! LC-MS label-free quantitation analysis
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002023
@@ -13254,63 +13254,63 @@ id: MS:1002024
 name: MS2 tag-based feature level quantitation
 def: "MS2 tag-based feature level quantitation." [PSI:PI]
 is_a: MS:1002023 ! MS2 tag-based analysis
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002025
 name: MS2 tag-based peptide level quantitation
 def: "MS2 tag-based peptide level quantitation." [PSI:PI]
 is_a: MS:1002023 ! MS2 tag-based analysis
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002026
 name: MS2 tag-based protein level quantitation
 def: "MS2 tag-based protein level quantitation." [PSI:PI]
 is_a: MS:1002023 ! MS2 tag-based analysis
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002027
 name: MS2 tag-based proteingroup level quantitation
 def: "MS2 tag-based proteingroup level quantitation." [PSI:PI]
 is_a: MS:1002023 ! MS2 tag-based analysis
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002028
 name: nucleic acid base modification
 def: "Nucleic acid base modification (substitution, insertion or deletion)." [PSI:PI]
 is_a: MS:1001471 ! peptide modification details
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002029
 name: original nucleic acid sequence
 def: "Specification of the original nucleic acid sequence, prior to a modification. The value slot should hold the DNA or RNA sequence." [PSI:PI]
 is_a: MS:1001471 ! peptide modification details
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002030
 name: modified nucleic acid sequence
 def: "Specification of the modified nucleic acid sequence. The value slot should hold the DNA or RNA sequence." [PSI:PI]
 is_a: MS:1001471 ! peptide modification details
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002031
 name: PASSEL transition group browser URI
 def: "URI to retrieve transition group data for a PASSEL (PeptideAtlas SRM Experiment Library) experiment." [PSI:PI]
 is_a: MS:1000878 ! external reference identifier
-relationship: has_value_type xsd\:anyURI ! The allowed value-type for this CV term
+relationship: has_value_type xsd:anyURI ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002032
 name: PeptideAtlas dataset URI
 def: "URI that allows access to a PeptideAtlas dataset." [PSI:PI]
 is_a: MS:1000878 ! external reference identifier
-relationship: has_value_type xsd\:anyURI ! The allowed value-type for this CV term
+relationship: has_value_type xsd:anyURI ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002033
@@ -13364,7 +13364,7 @@ is_a: MS:1000482 ! source attribute
 is_a: MS:1002039 ! inlet attribute
 relationship: has_units UO:0000012 ! kelvin
 relationship: has_units UO:0000027 ! degree Celsius
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002041
@@ -13373,7 +13373,7 @@ def: "The temperature of the source of a mass spectrometer." [PSI:MS]
 is_a: MS:1000482 ! source attribute
 relationship: has_units UO:0000012 ! kelvin
 relationship: has_units UO:0000027 ! degree Celsius
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002042
@@ -13382,7 +13382,7 @@ def: "The duration of a complete cycle of modulation in a comprehensive two-dime
 is_a: MS:1000857 ! run attribute
 relationship: has_units UO:0000010 ! second
 relationship: has_units UO:0000031 ! minute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002043
@@ -13395,21 +13395,21 @@ id: MS:1002044
 name: ProteinProspector:score
 def: "The ProteinProspector result 'Score'." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002045
 name: ProteinProspector:expectation value
 def: "The ProteinProspector result 'Expectation value'." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002046
 name: native source path
 def: "The original source path used for directory-based sources." [PSI:MS]
 is_a: MS:1001458 ! spectrum generation information
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002047
@@ -13429,21 +13429,21 @@ id: MS:1002049
 name: MS-GF:RawScore
 def: "MS-GF raw score." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
+relationship: has_value_type xsd:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002050
 name: MS-GF:DeNovoScore
 def: "MS-GF de novo score." [PSI:PI]
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
+relationship: has_value_type xsd:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002051
 name: MS-GF:Energy
 def: "MS-GF energy score." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term
+relationship: has_value_type xsd:nonNegativeInteger ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002052
@@ -13452,7 +13452,7 @@ def: "MS-GF spectral E-value." [PSI:PI]
 is_a: MS:1002353 ! PSM-level e-value
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002109 ! lower score better
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002053
@@ -13461,7 +13461,7 @@ def: "MS-GF E-value." [PSI:PI]
 is_a: MS:1002353 ! PSM-level e-value
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002109 ! lower score better
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002054
@@ -13469,21 +13469,21 @@ name: MS-GF:QValue
 def: "MS-GF Q-value." [PSI:PI]
 is_a: MS:1002354 ! PSM-level q-value
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002055
 name: MS-GF:PepQValue
 def: "MS-GF peptide-level Q-value." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002056
 name: MS-GF:PEP
 def: "MS-GF posterior error probability." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002057
@@ -13533,28 +13533,28 @@ id: MS:1002064
 name: peptide consensus RT
 def: "Peptide consensus retention time." [PSI:PI]
 is_a: MS:1002737 ! peptide-level quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002065
 name: peptide consensus m/z
 def: "Peptide consensus mass/charge ratio." [PSI:PI]
 is_a: MS:1002737 ! peptide-level quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002066
 name: ratio calculation method
 def: "Method used to calculate the ratio." [PSI:PI]
 is_a: MS:1001805 ! quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002067
 name: protein value: median of peptide ratios
 def: "Protein quantification value calculated as median of peptide ratios." [PSI:PI]
 is_a: MS:1002738 ! protein-level quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002068
@@ -13567,21 +13567,21 @@ id: MS:1002069
 name: metabolic labelling purity
 def: "Metabolic labelling: Description of labelling purity. Usually the purity of feeding material (e.g. 95%), or the inclusion rate derived from isotopic peak pattern shape." [PSI:PI]
 is_a: MS:1001055 ! modification parameters
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002070
 name: t-test
 def: "Perform a t-test (two groups). Specify in string value, whether paired / unpaired, variance equal / different, one- / two-sided version is performed." [PSI:PI]
 is_a: MS:1001861 ! quantification data processing
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002071
 name: ANOVA-test
 def: "Perform an ANOVA-test (more than two groups). Specify in string value, which version is performed." [PSI:PI]
 is_a: MS:1001861 ! quantification data processing
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002072
@@ -13589,7 +13589,7 @@ name: p-value
 def: "P-value as result of one of the processing steps described. Specify in the description, which processing step it was." [PSI:PI]
 is_a: MS:1001805 ! quantification datatype
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002073
@@ -13628,7 +13628,7 @@ def: "OBSOLETE ProteomeDiscoverer's 1st static post-translational modification (
 comment: This term was made obsolete because it's recommended to use ProteomeDiscoverer:Static Modification (MS:1001645) instead.
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002079
@@ -13637,7 +13637,7 @@ def: "OBSOLETE ProteomeDiscoverer's 2nd static post-translational modification (
 comment: This term was made obsolete because it's recommended to use ProteomeDiscoverer:Static Modification (MS:1001645) instead.
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002080
@@ -13645,7 +13645,7 @@ name: ProteomeDiscoverer:Spectrum Selector:Precursor Clipping Range Before
 def: "Precursor clipping range before." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_units UO:0000221 ! dalton
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002081
@@ -13653,7 +13653,7 @@ name: ProteomeDiscoverer:Spectrum Selector:Precursor Clipping Range After
 def: "Precursor clipping range after." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 relationship: has_units UO:0000221 ! dalton
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002082
@@ -13662,7 +13662,7 @@ def: "The time of elution from the first chromatographic column in the chromatog
 is_a: MS:1000503 ! scan attribute
 relationship: has_units UO:0000010 ! second
 relationship: has_units UO:0000031 ! minute
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002083
@@ -13671,7 +13671,7 @@ def: "The time of elution from the second chromatographic column in the chromato
 is_a: MS:1000503 ! scan attribute
 relationship: has_units UO:0000010 ! second
 relationship: has_units UO:0000031 ! minute
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002084
@@ -13708,28 +13708,28 @@ id: MS:1002089
 name: ProteomeDiscoverer:Peptide Without Protein XCorr Threshold
 def: "XCorr threshold for storing peptides that do not belong to a protein." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002090
 name: Calculate Probability Scores
 def: "Flag indicating that a probability score for the assessment that a reported peptide match is a random occurrence is calculated." [PSI:MS]
 is_a: MS:1002094 ! common search engine input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002091
 name: ProteomeDiscoverer:Maximum Delta Cn
 def: "Delta Cn threshold for filtering out PSM's." [PSI:MS]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002092
 name: Percolator:Validation based on
 def: "Algorithm (e.g. q-value or PEP) used for calculation of the validation score using Percolator." [PSI:MS]
 is_a: MS:1002107 ! Percolator input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002093
@@ -13925,7 +13925,7 @@ comment: This term was made obsolete because it was split into the more specific
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1001153 ! search engine specific score
 is_obsolete: true
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002126
@@ -14095,7 +14095,7 @@ id: MS:1002153
 name: protein level PSM counts
 def: "The number of spectra identified for this protein in spectral counting." [PSI:PI]
 is_a: MS:1002738 ! protein-level quantification datatype
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
+relationship: has_value_type xsd:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002154
@@ -14457,35 +14457,35 @@ id: MS:1002213
 name: PAnalyzer:conclusive protein
 def: "A protein identified by at least one unique (distinct, discrete) peptide (peptides are considered different only if they can be distinguished by evidence in mass spectrum)." [PSI:PI]
 is_a: MS:1001600 ! protein inference confidence category
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002214
 name: PAnalyzer:indistinguishable protein
 def: "A member of a group of proteins sharing all peptides that are exclusive to the group (peptides are considered different only if they can be distinguished by evidence in mass spectrum)." [PSI:PI]
 is_a: MS:1001600 ! protein inference confidence category
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002215
 name: PAnalyzer:non-conclusive protein
 def: "A protein sharing all its matched peptides with either conclusive or indistinguishable proteins (peptides are considered different only if they can be distinguished by evidence in mass spectrum)." [PSI:PI]
 is_a: MS:1001600 ! protein inference confidence category
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002216
 name: PAnalyzer:ambiguous group member
 def: "A protein sharing at least one peptide not matched to either conclusive or indistinguishable proteins (peptides are considered different only if they can be distinguished by evidence in mass spectrum)." [PSI:PI]
 is_a: MS:1001600 ! protein inference confidence category
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002217
 name: decoy peptide
 def: "A putative identified peptide issued from a decoy sequence database." [PSI:PI]
 is_a: MS:1001105 ! peptide sequence-level identification attribute
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002218
@@ -14493,7 +14493,7 @@ name: percent collision energy ramp start
 def: "Collision energy at the start of the collision energy ramp in percent, normalized to the mass of the ion." [PSI:PI]
 is_a: MS:1000138 ! normalized collision energy
 relationship: has_units UO:0000187 ! percent
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002219
@@ -14501,7 +14501,7 @@ name: percent collision energy ramp end
 def: "Collision energy at the end of the collision energy ramp in percent, normalized to the mass of the ion." [PSI:PI]
 is_a: MS:1000138 ! normalized collision energy
 relationship: has_units UO:0000187 ! percent
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002220
@@ -14528,14 +14528,14 @@ id: MS:1002223
 name: precursor ion detection probability
 def: "Probability of detecting precursor when parent protein is present." [PSI:PI]
 is_a: MS:1002222 ! SRM transition attribute
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002224
 name: product ion detection probability
 def: "Probability of detecting product ion when precursor ion is present." [PSI:PI]
 is_a: MS:1002222 ! SRM transition attribute
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002225
@@ -14562,28 +14562,28 @@ id: MS:1002227
 name: number of product ion observations
 def: "The number of times the specific product ion has been observed in a series of SRM experiments." [PSI:PI]
 is_a: MS:1002222 ! SRM transition attribute
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
+relationship: has_value_type xsd:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002228
 name: number of precursor ion observations
 def: "The number of times the specific precursor ion has been observed in a series of SRM experiments." [PSI:PI]
 is_a: MS:1002222 ! SRM transition attribute
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
+relationship: has_value_type xsd:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002229
 name: ProteomeDiscoverer:Mascot:Significance Middle
 def: "Calculated relaxed significance when performing a decoy search for high-confidence peptides." [PSI:PI]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002230
 name: ProteomeDiscoverer:Mascot:Significance High
 def: "Calculated relaxed significance when performing a decoy search for medium-confidence peptides." [PSI:PI]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002231
@@ -14603,7 +14603,7 @@ id: MS:1002233
 name: ProteomeDiscoverer:SEQUEST:Low resolution spectra contained
 def: "Flag indicating if low-resolution spectra are taken into consideration." [PSI:PI]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002234
@@ -14612,21 +14612,21 @@ def: "Mass-to-charge ratio of a precursor ion selected for fragmentation." [PSI:
 synonym: "selected ion m/z" RELATED []
 is_a: MS:1000455 ! ion selection attribute
 relationship: has_units MS:1000040 ! m/z
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002235
 name: ProteoGrouper:PDH score
 def: "A score assigned to a single protein accession (modelled as ProteinDetectionHypothesis in mzIdentML), based on summed peptide level scores." [PSI:PI]
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002236
 name: ProteoGrouper:PAG score
 def: "A score assigned to a protein group (modelled as ProteinAmbiguityGroup in mzIdentML), based on all summed peptide level scores that have been assigned to the group as unique or razor peptides." [PSI:PI]
 is_a: MS:1002368 ! search engine specific score for protein groups
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002237
@@ -14699,21 +14699,21 @@ id: MS:1002248
 name: SEQUEST:spscore
 def: "The SEQUEST result 'SpScore'." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002249
 name: SEQUEST:sprank
 def: "The SEQUEST result 'SpRank'." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
+relationship: has_value_type xsd:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002250
 name: SEQUEST:deltacnstar
 def: "The SEQUEST result 'DeltaCnStar'." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002251
@@ -14727,63 +14727,63 @@ name: Comet:xcorr
 def: "The Comet result 'XCorr'." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002108 ! higher score better
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002253
 name: Comet:deltacn
 def: "The Comet result 'DeltaCn'." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002254
 name: Comet:deltacnstar
 def: "The Comet result 'DeltaCnStar'." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002255
 name: Comet:spscore
 def: "The Comet result 'SpScore'." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002256
 name: Comet:sprank
 def: "The Comet result 'SpRank'." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002257
 name: Comet:expectation value
 def: "The Comet result 'Expectation value'." [PSI:PI]
 is_a: MS:1001153 ! search engine specific score
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002258
 name: Comet:matched ions
 def: "The Comet result 'Matched Ions'." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
+relationship: has_value_type xsd:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002259
 name: Comet:total ions
 def: "The Comet result 'Total Ions'." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
+relationship: has_value_type xsd:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002260
 name: PSM:FDR threshold
 def: "False-discovery rate threshold for peptide-spectrum matches." [PSI:PI]
 is_a: MS:1002483 ! PSM-level statistical threshold
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002261
@@ -14797,7 +14797,7 @@ name: Byonic:Score
 def: "The Byonic score is the primary indicator of PSM correctness. The Byonic score reflects the absolute quality of the peptide-spectrum match, not the relative quality compared to other candidate peptides. Byonic scores range from 0 to about 1000, with 300 a good score, 400 a very good score, and PSMs with scores over 500 almost sure to be correct." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002108 ! higher score better
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002263
@@ -14805,7 +14805,7 @@ name: Byonic:Delta Score
 def: "The drop in Byonic score from the top-scoring peptide to the next peptide with distinct sequence. In this computation, the same peptide with different modifications is not considered distinct." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002108 ! higher score better
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002264
@@ -14813,7 +14813,7 @@ name: Byonic:DeltaMod Score
 def: "The drop in Byonic score from the top-scoring peptide to the next peptide different in any way, including placement of modifications. DeltaMod gives an indication of whether modifications are confidently localized; DeltaMod over 10.0 means that there is high likelihood that all modification placements are correct." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002108 ! higher score better
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002265
@@ -14821,7 +14821,7 @@ name: Byonic:PEP
 def: "Byonic posterior error probability." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002109 ! lower score better
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002266
@@ -14829,7 +14829,7 @@ name: Byonic:Peptide LogProb
 def: "The log p-value of the PSM. This is the log of the probability that the PSM with such a score and delta would arise by chance in a search of this size (the size of the protein database, as expanded by the modification rules). A log p-value of -3.0 should happen by chance on only one of a thousand spectra. Caveat: it is very hard to compute a p-value that works for all searches and all spectra, so read Byonic p-values with a certain amount of skepticism." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002109 ! lower score better
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002267
@@ -14838,7 +14838,7 @@ def: "The log p-value of the protein." [PSI:PI]
 is_a: MS:1002363 ! search engine specific score for proteins
 is_a: MS:1002363 ! search engine specific score for proteins
 relationship: has_order MS:1002109 ! lower score better
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002268
@@ -14847,7 +14847,7 @@ def: "Best (most negative) log p-value of an individual PSM." [PSI:PI]
 is_a: MS:1001116 ! single protein identification statistic
 is_a: MS:1001153 ! search engine specific score
 relationship: has_order MS:1002109 ! lower score better
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002269
@@ -14855,7 +14855,7 @@ name: Byonic:Best Score
 def: "Best (largest) Byonic score of a PSM." [PSI:PI]
 is_a: MS:1002363 ! search engine specific score for proteins
 relationship: has_order MS:1002108 ! higher score better
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002270
@@ -14881,7 +14881,7 @@ name: detector potential
 def: "Detector potential difference in volts." [PSI:MS]
 is_a: MS:1000481 ! detector attribute
 relationship: has_units UO:0000218 ! volt
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002274
@@ -15065,7 +15065,7 @@ id: MS:1002303
 name: Bruker Container nativeID format
 def: "Native identifier (UUID)." [PSI:MS]
 is_a: MS:1000767 ! native spectrum identifier format
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002304
@@ -15103,7 +15103,7 @@ name: Byonic: Peptide AbsLogProb
 def: "The absolute value of the log-base10 of the Byonic posterior error probability (PEP) of the PSM." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002108 ! higher score better
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002310
@@ -15111,7 +15111,7 @@ name: Byonic: Protein AbsLogProb
 def: "The absolute value of the log-base10 of the Byonic posterior error probability (PEP) of the protein." [PSI:PI]
 is_a: MS:1002363 ! search engine specific score for proteins
 relationship: has_order MS:1002108 ! higher score better
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002311
@@ -15119,7 +15119,7 @@ name: Byonic: Peptide AbsLogProb2D
 def: "The absolute value of the log-base10 Byonic two-dimensional posterior error probability (PEP) of the PSM. The two-dimensional PEP takes into account protein ranking information as well as PSM information." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002108 ! higher score better
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002312
@@ -15150,98 +15150,98 @@ id: MS:1002316
 name: ProteomeDiscoverer:Amanda:high confidence threshold
 def: "Strict confidence probability score." [PSI:PI]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
+relationship: has_value_type xsd:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002317
 name: ProteomeDiscoverer:Amanda:middle confidence threshold
 def: "Relaxed confidence probability score." [PSI:PI]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
+relationship: has_value_type xsd:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002318
 name: ProteomeDiscoverer:automatic workload
 def: "Flag indicating automatic estimation of the workload level." [PSI:PI]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002319
 name: Amanda:AmandaScore
 def: "The Amanda score of the scoring function for a PSM." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002320
 name: ProteomeDiscoverer:max differential modifications
 def: "Maximum dynamic modifications per PSM." [PSI:PI]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
+relationship: has_value_type xsd:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002321
 name: ProteomeDiscoverer:max equal modifications
 def: "Maximum equal modifications per PSM." [PSI:PI]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
+relationship: has_value_type xsd:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002322
 name: ProteomeDiscoverer:min peptide length
 def: "Minimum peptide length." [PSI:PI]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
+relationship: has_value_type xsd:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002323
 name: ProteomeDiscoverer:max peptide length
 def: "Maximum peptide length." [PSI:PI]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
+relationship: has_value_type xsd:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002324
 name: ProteomeDiscoverer:max number neutral loss
 def: "Maximum number of same neutral losses." [PSI:PI]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
+relationship: has_value_type xsd:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002325
 name: ProteomeDiscoverer:max number neutral loss modifications
 def: "Max number of same neutral losses of modifications." [PSI:PI]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
+relationship: has_value_type xsd:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002326
 name: ProteomeDiscoverer:use flanking ions
 def: "Flag for usage of flanking ions." [PSI:PI]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002327
 name: ProteomeDiscoverer:max number of same modifs
 def: "The maximum number of possible equal modifications per PSM." [PSI:PI]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
+relationship: has_value_type xsd:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002328
 name: ProteomeDiscoverer:perform deisotoping
 def: "Defines whether a simple deisotoping shall be performed." [PSI:PI]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002329
 name: ProteomeDiscoverer:ion settings
 def: "Specifies the fragment ions and neutral losses that are calculated." [PSI:PI]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002330
@@ -15250,7 +15250,7 @@ def: "OBSOLETE ProteomeDiscoverer's 3rd static post-translational modification (
 comment: This term was made obsolete because it's recommended to use ProteomeDiscoverer:Static Modification (MS:1001645) instead.
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002331
@@ -15259,7 +15259,7 @@ def: "OBSOLETE ProteomeDiscoverer's 5th dynamic post-translational modification 
 comment: This term was made obsolete because it's recommended to use ProteomeDiscoverer:Dynamic Modification (MS:1001644) instead.
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 is_obsolete: true
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002332
@@ -15303,28 +15303,28 @@ name: Andromeda:score
 def: "The probability based score of the Andromeda search engine." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002108 ! higher score better
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002339
 name: site:global FDR
 def: "Estimation of global false discovery rate of peptides with a post-translational modification." [PSI:PI]
 is_a: MS:1001405 ! spectrum identification result details
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002340
 name: ProteomeXchange project tag
 def: "Tag that can be added to a ProteomeXchange dataset, to enable the grouping of datasets. One tag can be used for indicating that a given dataset is part of a bigger project, like e.g. the Human Proteome Project." [PSI:PI]
 is_a: MS:1000878 ! external reference identifier
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002341
 name: second-pass peptide identification
 def: "A putative identified peptide found in a second-pass search of protein sequences selected from a first-pass search." [PSI:PI]
 is_a: MS:1001105 ! peptide sequence-level identification attribute
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002342
@@ -15383,7 +15383,7 @@ name: PSM-level global FDR
 def: "Estimation of the global false discovery rate of peptide spectrum matches." [PSI:PI]
 is_a: MS:1002701 ! PSM-level result list statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002351
@@ -15391,7 +15391,7 @@ name: PSM-level local FDR
 def: "Estimation of the local false discovery rate of peptide spectrum matches." [PSI:PI]
 is_a: MS:1002347 ! PSM-level identification statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002352
@@ -15399,7 +15399,7 @@ name: PSM-level p-value
 def: "Estimation of the p-value for peptide spectrum matches." [PSI:PI]
 is_a: MS:1002347 ! PSM-level identification statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002353
@@ -15407,7 +15407,7 @@ name: PSM-level e-value
 def: "Estimation of the e-value for peptide spectrum matches." [PSI:PI]
 is_a: MS:1002347 ! PSM-level identification statistic
 relationship: has_domain MS:1002306 ! value greater than zero
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002354
@@ -15415,7 +15415,7 @@ name: PSM-level q-value
 def: "Estimation of the q-value for peptide spectrum matches." [PSI:PI]
 is_a: MS:1002347 ! PSM-level identification statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002355
@@ -15424,7 +15424,7 @@ def: "mzidLibrary FDRScore for peptide spectrum matches." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1002363 ! search engine specific score for proteins
 relationship: has_domain MS:1002349 ! value greater than zero but less than or equal to 1
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002356
@@ -15433,7 +15433,7 @@ def: "mzidLibrary Combined FDRScore for peptide spectrum matches specifically ob
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1002363 ! search engine specific score for proteins
 relationship: has_domain MS:1002349 ! value greater than zero but less than or equal to 1
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002357
@@ -15441,7 +15441,7 @@ name: PSM-level probability
 def: "Probability that the reported peptide ion is truly responsible for some or all of the components of the specified mass spectrum." [PSI:PI]
 is_a: MS:1002347 ! PSM-level identification statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002358
@@ -15455,7 +15455,7 @@ name: peptide sequence-level local FDR
 def: "Estimation of the local false discovery rate for distinct peptides once redundant identifications of the same peptide have been removed (id est multiple PSMs have been collapsed to one entry)." [PSI:PI]
 is_a: MS:1001092 ! peptide sequence-level identification statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002360
@@ -15464,7 +15464,7 @@ def: "MzidLibrary FDRScore for distinct peptides once redundant identifications 
 is_a: MS:1002358 ! search engine specific peptide sequence-level identification statistic
 is_a: MS:1002363 ! search engine specific score for proteins
 relationship: has_domain MS:1002349 ! value greater than zero but less than or equal to one
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002361
@@ -15473,7 +15473,7 @@ def: "Combined FDRScore for peptides once redundant identifications of the same 
 is_a: MS:1002358 ! search engine specific peptide sequence-level identification statistic
 is_a: MS:1002363 ! search engine specific score for proteins
 relationship: has_domain MS:1002349 ! value greater than zero but less than or equal to one
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002362
@@ -15481,7 +15481,7 @@ name: peptide sequence-level probability
 def: "Probability that the reported distinct peptide sequence (irrespective of mass modifications) has been correctly identified via the referenced PSMs." [PSI:PI]
 is_a: MS:1001092 ! peptide sequence-level identification statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002363
@@ -15494,7 +15494,7 @@ id: MS:1002364
 name: protein-level local FDR
 def: "Estimation of the local false discovery rate of proteins." [PSI:PI]
 is_a: MS:1001116 ! single protein identification statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002365
@@ -15502,7 +15502,7 @@ name: FDRScore for proteins
 def: "MzidLibrary FDRScore for proteins specifically obtained for distinct combinations of single, pairs or triplets of search engines making a given PSM, used for integrating results from these distinct pools." [PSI:PI]
 is_a: MS:1002363 ! search engine specific score for proteins
 relationship: has_domain MS:1002349 ! value greater than zero but less than or equal to one
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002366
@@ -15510,7 +15510,7 @@ name: combined FDRScore for proteins
 def: "MzidLibrary Combined FDRScore for proteins." [PSI:PI]
 is_a: MS:1002363 ! search engine specific score for proteins
 relationship: has_domain MS:1002349 ! value greater than zero but less than or equal to one
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002367
@@ -15518,7 +15518,7 @@ name: probability for proteins
 def: "Probability that a specific protein sequence has been correctly identified from the PSM and distinct peptide evidence, and based on the available protein sequences presented to the analysis software." [PSI:PI]
 is_a: MS:1001116 ! single protein identification statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002368
@@ -15531,14 +15531,14 @@ id: MS:1002369
 name: protein group-level global FDR
 def: "Estimation of the global false discovery rate of protein groups." [PSI:PI]
 is_a: MS:1002706 ! protein group-level result list statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002370
 name: protein group-level local FDR
 def: "Estimation of the local false discovery rate of protein groups." [PSI:PI]
 is_a: MS:1002348 ! protein group-level identification statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002371
@@ -15546,7 +15546,7 @@ name: protein group-level p-value
 def: "Estimation of the p-value for protein groups." [PSI:PI]
 is_a: MS:1002348 ! protein group-level identification statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002372
@@ -15554,7 +15554,7 @@ name: protein group-level e-value
 def: "Estimation of the e-value for protein groups." [PSI:PI]
 is_a: MS:1002348 ! protein group-level identification statistic
 relationship: has_domain MS:1002306 ! value greater than zero
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002373
@@ -15562,7 +15562,7 @@ name: protein group-level q-value
 def: "Estimation of the q-value for protein groups." [PSI:PI]
 is_a: MS:1002348 ! protein group-level identification statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002374
@@ -15570,7 +15570,7 @@ name: protein group-level FDRScore
 def: "mzidLibrary FDRScore for protein groups." [PSI:PI]
 is_a: MS:1002368 ! search engine specific score for protein groups
 relationship: has_domain MS:1002349 ! value greater than zero but less than or equal to one
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002375
@@ -15578,7 +15578,7 @@ name: protein group-level combined FDRScore
 def: "mzidLibrary Combined FDRScore for proteins specifically obtained for distinct combinations of single, pairs or triplets of search engines making a given PSM, used for integrating results from these distinct pools." [PMID:19253293]
 is_a: MS:1002368 ! search engine specific score for protein groups
 relationship: has_domain MS:1002349 ! value greater than zero but less than or equal to one
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002376
@@ -15586,35 +15586,35 @@ name: protein group-level probability
 def: "Probability that at least one of the members of a group of protein sequences has been correctly identified from the PSM and distinct peptide evidence, and based on the available protein sequences presented to the analysis software." [PSI:PI]
 is_a: MS:1002348 ! protein group-level identification statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002377
 name: ProteomeDiscoverer:Relaxed Score Threshold
 def: "Specifies the threshold value for relaxed scoring." [PSI:PI]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002378
 name: ProteomeDiscoverer:Strict Score Threshold
 def: "Specifies the threshold value for strict scoring." [PSI:PI]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002379
 name: ProteomeDiscoverer:Peptide Without Protein Cut Off Score
 def: "Cut off score for storing peptides that do not belong to a protein." [PSI:PI]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002380
 name: false localization rate
 def: "Estimation of the false localization rate for modification site assignment." [PSI:PI]
 is_a: MS:1001405 ! spectrum identification result details
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002381
@@ -15682,28 +15682,28 @@ id: MS:1002390
 name: PIA:FDRScore calculated
 def: "Indicates whether the FDR score was calculated for the input file." [PSI:PI]
 is_a: MS:1002389 ! PIA workflow parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002391
 name: PIA:Combined FDRScore calculated
 def: "Indicates whether the combined FDR score was calculated for the PIA compilation." [PSI:PI]
 is_a: MS:1002389 ! PIA workflow parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002392
 name: PIA:PSM sets created
 def: "Indicates whether PSM sets were created." [PSI:PI]
 is_a: MS:1002389 ! PIA workflow parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002393
 name: PIA:used top identifications for FDR
 def: "The number of top identifications per spectrum used for the FDR calculation, 0 means all." [PSI:PI]
 is_a: MS:1002389 ! PIA workflow parameter
-relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term
+relationship: has_value_type xsd:positiveInteger ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002394
@@ -15711,49 +15711,49 @@ name: PIA:protein score
 def: "The score given to a protein by any protein inference." [PSI:PI]
 is_a: MS:1002363 ! search engine specific score for proteins
 relationship: has_order MS:1002108 ! higher score better
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002395
 name: PIA:protein inference
 def: "The used algorithm for the protein inference using PIA." [PSI:PI]
 is_a: MS:1002389 ! PIA workflow parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002396
 name: PIA:protein inference filter
 def: "A filter used by PIA for the protein inference." [PSI:PI]
 is_a: MS:1002389 ! PIA workflow parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002397
 name: PIA:protein inference scoring
 def: "The used scoring method for the protein inference using PIA." [PSI:PI]
 is_a: MS:1002389 ! PIA workflow parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002398
 name: PIA:protein inference used score
 def: "The used base score for the protein inference using PIA." [PSI:PI]
 is_a: MS:1002389 ! PIA workflow parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002399
 name: PIA:protein inference used PSMs
 def: "The method to determine the PSMs used for scoring by the protein inference." [PSI:PI]
 is_a: MS:1002389 ! PIA workflow parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002400
 name: PIA:filter
 def: "A filter used for the report generation." [PSI:PI]
 is_a: MS:1002389 ! PIA workflow parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002401
@@ -15778,7 +15778,7 @@ id: MS:1002404
 name: count of identified proteins
 def: "The number of proteins that have been identified, which must match the number of groups that pass the threshold in the file." [PSI:PI]
 is_a: MS:1002704 ! protein-level result list attribute
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
+relationship: has_value_type xsd:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002405
@@ -15791,21 +15791,21 @@ id: MS:1002406
 name: count of identified clusters
 def: "The number of protein clusters that have been identified, which must match the number of clusters that pass the threshold in the file." [DOI:10.1002/pmic.201400080, PMID:25092112]
 is_a: MS:1002405 ! protein group-level result list attribute
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
+relationship: has_value_type xsd:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002407
 name: cluster identifier
 def: "An identifier applied to protein groups to indicate that they are linked by shared peptides." [PSI:PI]
 is_a: MS:1002698 ! protein cluster identification attribute
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
+relationship: has_value_type xsd:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002408
 name: number of distinct protein sequences
 def: "The number of protein clusters that have been identified, which must match the number of clusters that pass the threshold in the file." [PSI:PI]
 is_a: MS:1002405 ! protein group-level result list attribute
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
+relationship: has_value_type xsd:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002409
@@ -15831,14 +15831,14 @@ id: MS:1002412
 name: total XIC area
 def: "Summed area of all the extracted ion chromatogram for the peptide (e.g. of all the transitions in SRM)." [PSI:PI]
 is_a: MS:1002737 ! peptide-level quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002413
 name: product background
 def: "The background area for the quantified transition." [PSI:PI]
 is_a: MS:1001805 ! quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002414
@@ -15851,7 +15851,7 @@ id: MS:1002415
 name: protein group passes threshold
 def: "A Boolean attribute to determine whether the protein group has passed the threshold indicated in the file." [PSI:PI]
 is_a: MS:1002346 ! protein group-level identification attribute
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002416
@@ -15882,7 +15882,7 @@ id: MS:1002420
 name: PASSEL experiment URI
 def: "URI that allows access to a PASSEL experiment." [PSI:PI]
 is_a: MS:1000878 ! external reference identifier
-relationship: has_value_type xsd\:anyURI ! The allowed value-type for this CV term
+relationship: has_value_type xsd:anyURI ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002421
@@ -15895,70 +15895,70 @@ id: MS:1002422
 name: Paragon: sample type
 def: "The Paragon method setting indicating the type of sample at the high level, generally meaning the type of quantitation labelling or lack thereof. 'Identification' is indicated for samples without any labels for quantitation." [PSI:PI]
 is_a: MS:1002421 ! Paragon input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002423
 name: Paragon: cysteine alkylation
 def: "The Paragon method setting indicating the actual cysteine alkylation agent; 'None' is indicated if there was no cysteine alkylation." [PSI:PI]
 is_a: MS:1002421 ! Paragon input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002424
 name: Paragon: instrument setting
 def: "The Paragon method setting (translating to a large number of lower level settings) indicating the instrument used or a category of instrument." [PSI:PI]
 is_a: MS:1002421 ! Paragon input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002425
 name: Paragon: search effort
 def: "The Paragon method setting that controls the two major modes of search effort of the Paragon algorithm: the Rapid mode uses a conventional database search, while the Thorough mode uses a hybrid search, starting with the same approach as the Rapid mode but then follows it with a separate tag-based approach enabling a more extensive search." [PSI:PI]
 is_a: MS:1002421 ! Paragon input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002426
 name: Paragon: ID focus
 def: "A Paragon method setting that allows the inclusion of large sets of features such as biological modification or substitutions." [PSI:PI]
 is_a: MS:1002421 ! Paragon input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002427
 name: Paragon: FDR analysis
 def: "The Paragon method setting that controls whether FDR analysis is conducted." [PSI:PI]
 is_a: MS:1002421 ! Paragon input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002428
 name: Paragon: quantitation
 def: "The Paragon method setting that controls whether quantitation analysis is conducted." [PSI:PI]
 is_a: MS:1002421 ! Paragon input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002429
 name: Paragon: background correction
 def: "The Paragon method setting that controls whether the 'Background Correction' analysis is conducted; this processing estimates a correction to the attenuation in extremity ratios that can occur in isobaric quantatitation workflows on complex samples." [PSI:PI]
 is_a: MS:1002421 ! Paragon input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002430
 name: Paragon: bias correction
 def: "The Paragon method setting that controls whether 'Bias Correction' is invoked in quantitation analysis; this correction is a normalization to set the central tendency of protein ratios to unity." [PSI:PI]
 is_a: MS:1002421 ! Paragon input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002431
 name: Paragon: channel to use as denominator in ratios
 def: "The Paragon method setting that controls which label channel is used as the denominator in calculating relative expression ratios." [PSI:PI]
 is_a: MS:1002421 ! Paragon input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002432
@@ -15971,35 +15971,35 @@ id: MS:1002433
 name: Paragon: modified data dictionary or parameter translation
 def: "This metric detects if any changes have been made to the originally installed key control files for the software; if no changes have been made, then the software version and settings are sufficient to enable exact reproduction; if changes have been made, then the modified ParameterTranslation- and ProteinPilot DataDictionary-XML files much also be provided in order to exactly reproduce a result." [PSI:PI]
 is_a: MS:1002432 ! search engine specific input metadata
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002434
 name: number of spectra searched
 def: "Number of spectra in a search." [PSI:PI]
 is_a: MS:1001249 ! search input details
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
+relationship: has_value_type xsd:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002435
 name: data processing start time
 def: "The time that a data processing action was started." [PSI:MS]
 is_a: MS:1000630 ! data processing parameter
-relationship: has_value_type xsd\:dateTime ! The allowed value-type for this CV term
+relationship: has_value_type xsd:dateTime ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002436
 name: Paragon: digestion
 def: "The Paragon method setting indicating the actual digestion agent - unlike other search tools, this setting does not include options that control partial specificity like 'semitrypsin'; if trypsin is used, trypsin is set, and partially conforming peptides are found in the Thorough mode of search; 'None' should be indicated only if there was really no digestion done." [PSI:PI]
 is_a: MS:1001249 ! search input details
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002437
 name: number of decoy sequences
 def: "The number of decoy sequences, if the concatenated target-decoy approach is used." [PSI:PI]
 is_a: MS:1001011 ! search database details
-relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term
+relationship: has_value_type xsd:positiveInteger ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002438
@@ -16060,21 +16060,21 @@ id: MS:1002447
 name: Paragon:special factor
 def: "The Paragon method setting indicating a list of one or more 'special factors', which generally capture secondary effects (relative to other settings) as a set of probabilities of modification features that override the assumed levels. For example the 'gel-based ID' special factor causes an increase probability of oxidation on several resides because of the air exposure impact on a gel, in addition to other effects." [PSI:PI]
 is_a: MS:1002421 ! Paragon input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002448
 name: PEAKS:inChorusPeptideScore
 def: "The PEAKS inChorus peptide score." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002449
 name: PEAKS:inChorusProteinScore
 def: "The PEAKS inChorus protein score." [PSI:PI]
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002450
@@ -16191,7 +16191,7 @@ name: PeptideShaker PSM score
 def: "The probability based PeptideShaker PSM score." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002108 ! higher score better
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002467
@@ -16199,7 +16199,7 @@ name: PeptideShaker PSM confidence
 def: "The probability based PeptideShaker PSM confidence." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002108 ! higher score better
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002468
@@ -16208,7 +16208,7 @@ def: "The probability based PeptideShaker peptide score." [PSI:PI]
 is_a: MS:1002358 ! search engine specific peptide sequence-level identification statistic
 is_a: MS:1002363 ! search engine specific score for proteins
 relationship: has_order MS:1002108 ! higher score better
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002469
@@ -16216,7 +16216,7 @@ name: PeptideShaker peptide confidence
 def: "The probability based PeptideShaker peptide confidence." [PSI:PI]
 is_a: MS:1002363 ! search engine specific score for proteins
 relationship: has_order MS:1002108 ! higher score better
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002470
@@ -16225,7 +16225,7 @@ def: "The probability based PeptideShaker protein group score." [PSI:PI]
 is_a: MS:1002363 ! search engine specific score for proteins
 is_a: MS:1002368 ! search engine specific score for protein groups
 relationship: has_order MS:1002108 ! higher score better
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002471
@@ -16233,7 +16233,7 @@ name: PeptideShaker protein group confidence
 def: "The probability based PeptideShaker protein group confidence." [PSI:PI]
 is_a: MS:1002363 ! search engine specific score for proteins
 relationship: has_order MS:1002108 ! higher score better
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002472
@@ -16253,14 +16253,14 @@ name: ProteoAnnotator:non-canonical gene model score
 def: "The sum of peptide-level scores for peptides mapped only to non-canonical gene models within the group." [PSI:PI]
 is_a: MS:1002368 ! search engine specific score for protein groups
 relationship: has_order MS:1002108 ! higher score better
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002475
 name: ProteoAnnotator:count alternative peptides
 def: "The count of the number of peptide sequences mapped to non-canonical gene models only within the group." [PSI:PI]
 is_a: MS:1002368 ! search engine specific score for protein groups
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
+relationship: has_value_type xsd:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002476
@@ -16269,7 +16269,7 @@ def: "Drift time of an ion or spectrum of ions as measured in an ion mobility ma
 is_a: MS:1000455 ! ion selection attribute
 is_a: MS:1002892 ! ion mobility attribute
 relationship: has_units UO:0000028 ! millisecond
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002477
@@ -16278,7 +16278,7 @@ def: "Array of population mean ion mobility values from a drift time device, rep
 is_a: MS:1002893 ! ion mobility array
 relationship: has_units UO:0000028 ! millisecond
 relationship: has_units UO:0000010 ! second
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002478
@@ -16340,14 +16340,14 @@ id: MS:1002487
 name: MassIVE dataset identifier
 def: "Dataset identifier issued by the MassIVE repository. A dataset can refer to either a single sample as part of a study, or all samples that are part of the study corresponding to a publication." [PSI:PI]
 is_a: MS:1000878 ! external reference identifier
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002488
 name: MassIVE dataset URI
 def: "URI that allows the access to one dataset in the MassIVE repository. A dataset can refer to either a single sample as part of a study, or all samples that are part of the study corresponding to a publication." [PSI:PI]
 is_a: MS:1000878 ! external reference identifier
-relationship: has_value_type xsd\:anyURI ! The allowed value-type for this CV term
+relationship: has_value_type xsd:anyURI ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002489
@@ -16423,7 +16423,7 @@ id: MS:1002500
 name: peptide passes threshold
 def: "A Boolean attribute to determine whether the peptide has passed the threshold indicated in the file." [PSI:PI]
 is_a: MS:1001105 ! peptide sequence-level identification attribute
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002501
@@ -16448,7 +16448,7 @@ id: MS:1002504
 name: modification index
 def: "The order of modifications to be referenced elsewhere in the document." [PSI:PI]
 is_a: MS:1001055 ! modification parameters
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
+relationship: has_value_type xsd:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002505
@@ -16468,7 +16468,7 @@ name: modification rescoring:false localization rate
 def: "Mod position score: false localization rate." [PSI:PI]
 is_a: MS:1002506 ! modification position score
 relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002508
@@ -16481,35 +16481,35 @@ id: MS:1002509
 name: cross-link donor
 def: "The Cross-linking donor, assigned according to the following rules: the export software SHOULD use the following rules to choose the cross-link donor as the: longer peptide, then higher peptide neutral mass, then alphabetical order." [PSI:PI]
 is_a: MS:1002508 ! cross-linking attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002510
 name: cross-link acceptor
 def: "Cross-linking acceptor, assigned according to the following rules: the export software SHOULD use the following rules to choose the cross-link donor as the: longer peptide, then higher peptide neutral mass, then alphabetical order." [PSI:PI]
 is_a: MS:1002508 ! cross-linking attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002511
 name: cross-link spectrum identification item
 def: "Cross-linked spectrum identification item." [PSI:PI]
 is_a: MS:1002508 ! cross-linking attribute
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
+relationship: has_value_type xsd:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002512
 name: cross-linking score
 def: "Cross-linking scoring value." [PSI:PI]
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002513
 name: molecules per cell
 def: "The absolute abundance of protein in a cell." [PSI:PI]
 is_a: MS:1001805 ! quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002514
@@ -16522,42 +16522,42 @@ id: MS:1002515
 name: internal peptide reference used
 def: "States whether an internal peptide reference is used or not in absolute quantitation analysis." [PSI:PI]
 is_a: MS:1001832 ! quantitation software comment or customizations
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002516
 name: internal protein reference used
 def: "States whether an internal protein reference is used or not in absolute quantitation analysis." [PSI:PI]
 is_a: MS:1001832 ! quantitation software comment or customizations
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002517
 name: internal reference abundance
 def: "The absolute abundance of the spiked in reference peptide or protein used for absolute quantitation analysis." [PSI:PI]
 is_a: MS:1001805 ! quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002518
 name: Progenesis:protein group normalised abundance
 def: "The data type normalised abundance for protein groups produced by Progenesis LC-MS." [PSI:PI]
 is_a: MS:1002739 ! protein group-level quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002519
 name: Progenesis:protein group raw abundance
 def: "The data type raw abundance for protein groups produced by Progenesis LC-MS." [PSI:PI]
 is_a: MS:1002739 ! protein group-level quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002520
 name: peptide group ID
 def: "Peptide group identifier for peptide-level stats." [PSI:PI]
 is_a: MS:1001105 ! peptide sequence-level identification attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002521
@@ -16570,7 +16570,7 @@ id: MS:1002522
 name: ProteomeDiscoverer:1. Static Terminal Modification
 def: "Determine 1st static terminal post-translational modifications (PTMs)." [PSI:PI]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002523
@@ -16649,14 +16649,14 @@ name: ProLuCID:xcorr
 def: "The ProLuCID result 'XCorr'." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002108 ! higher score better
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002535
 name: ProLuCID:deltacn
 def: "The ProLuCID result 'DeltaCn'." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002536
@@ -16664,7 +16664,7 @@ name: D-Score
 def: "D-Score for PTM site location at the PSM-level." [PMID:23307401]
 is_a: MS:1001968 ! PTM localization PSM-level statistic
 relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002537
@@ -16672,42 +16672,42 @@ name: MD-Score
 def: "MD-Score for PTM site location at the PSM-level." [PMID:21057138]
 is_a: MS:1001968 ! PTM localization PSM-level statistic
 relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002538
 name: PTM localization confidence metric
 def: "Localization confidence metric for a post translational modification (PTM)." [PSI:PI]
 is_a: MS:1001405 ! spectrum identification result details
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002539
 name: PeptideShaker PTM confidence type
 def: "PeptideShaker quality criteria for the confidence of PTM localizations." [PSI:PI]
 is_a: MS:1002538 ! PTM localization confidence metric
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002540
 name: PeptideShaker PSM confidence type
 def: "PeptideShaker quality criteria for the confidence of PSM's." [PSI:PI]
 is_a: MS:1002347 ! PSM-level identification statistic
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002541
 name: PeptideShaker peptide confidence type
 def: "PeptideShaker quality criteria for the confidence of peptide identifications." [PSI:PI]
 is_a: MS:1002358 ! search engine specific peptide sequence-level identification statistic
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002542
 name: PeptideShaker protein confidence type
 def: "PeptideShaker quality criteria for the confidence of protein identifications." [PSI:PI]
 is_a: MS:1001116 ! single protein identification statistic
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002543
@@ -16727,7 +16727,7 @@ name: xi:score
 def: "The xi result 'Score'." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002108 ! higher score better
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002546
@@ -16760,7 +16760,7 @@ name: peptide:phosphoRS score
 def: "phosphoRS score for PTM site location at the peptide-level." [PSI:PI]
 is_a: MS:1002549 ! PTM localization distinct peptide-level statistic
 relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002551
@@ -16768,7 +16768,7 @@ name: peptide:Ascore
 def: "A-score for PTM site location at the peptide-level." [PSI:PI]
 is_a: MS:1002549 ! PTM localization distinct peptide-level statistic
 relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002552
@@ -16776,7 +16776,7 @@ name: peptide:H-Score
 def: "H-Score for peptide phosphorylation site location at the peptide-level." [PSI:PI]
 is_a: MS:1002549 ! PTM localization distinct peptide-level statistic
 relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002553
@@ -16784,7 +16784,7 @@ name: peptide:D-Score
 def: "D-Score for PTM site location at the peptide-level." [PSI:PI]
 is_a: MS:1002549 ! PTM localization distinct peptide-level statistic
 relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002554
@@ -16792,7 +16792,7 @@ name: peptide:MD-Score
 def: "MD-Score for PTM site location at the peptide-level." [PSI:PI]
 is_a: MS:1002549 ! PTM localization distinct peptide-level statistic
 relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002555
@@ -16805,112 +16805,112 @@ id: MS:1002556
 name: Ascore threshold
 def: "Threshold for Ascore PTM site location score." [PSI:PI]
 is_a: MS:1002555 ! PTM localization score threshold
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002557
 name: D-Score threshold
 def: "Threshold for D-score PTM site location score." [PSI:PI]
 is_a: MS:1002555 ! PTM localization score threshold
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002558
 name: MD-Score threshold
 def: "Threshold for MD-score PTM site location score." [PSI:PI]
 is_a: MS:1002555 ! PTM localization score threshold
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002559
 name: H-Score threshold
 def: "Threshold for H-score PTM site location score." [PSI:PI]
 is_a: MS:1002555 ! PTM localization score threshold
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002560
 name: DeBunker:score threshold
 def: "Threshold for DeBunker PTM site location score." [PSI:PI]
 is_a: MS:1002555 ! PTM localization score threshold
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002561
 name: Mascot:PTM site assignment confidence threshold
 def: "Threshold for Mascot PTM site assignment confidence." [PSI:PI]
 is_a: MS:1002555 ! PTM localization score threshold
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002562
 name: MSQuant:PTM-score threshold
 def: "Threshold for MSQuant:PTM-score." [PSI:PI]
 is_a: MS:1002555 ! PTM localization score threshold
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002563
 name: MaxQuant:PTM Score threshold
 def: "Threshold for MaxQuant:PTM Score." [PSI:PI]
 is_a: MS:1002555 ! PTM localization score threshold
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002564
 name: MaxQuant:P-site localization probability threshold
 def: "Threshold for MaxQuant:P-site localization probability." [PSI:PI]
 is_a: MS:1002555 ! PTM localization score threshold
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002565
 name: MaxQuant:PTM Delta Score threshold
 def: "Threshold for MaxQuant:PTM Delta Score." [PSI:PI]
 is_a: MS:1002555 ! PTM localization score threshold
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002566
 name: MaxQuant:Phospho (STY) Probabilities threshold
 def: "Threshold for MaxQuant:Phospho (STY) Probabilities." [PSI:PI]
 is_a: MS:1002555 ! PTM localization score threshold
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002567
 name: phosphoRS score threshold
 def: "Threshold for phosphoRS score." [PSI:PI]
 is_a: MS:1002555 ! PTM localization score threshold
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002568
 name: phosphoRS site probability threshold
 def: "Threshold for phosphoRS site probability." [PSI:PI]
 is_a: MS:1002555 ! PTM localization score threshold
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002569
 name: ProteomeDiscoverer:Number of Spectra Processed At Once
 def: "Number of spectra processed at once in a ProteomeDiscoverer search." [PSI:PI]
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
+relationship: has_value_type xsd:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002570
 name: sequence multiply subsumable protein
 def: "A protein for which the matched peptide sequences are the same, or a subset of, the matched peptide sequences for two or more other proteins combined. These other proteins need not all be in the same group." [PSI:PI]
 is_a: MS:1001101 ! protein group or subset relationship
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002571
 name: spectrum multiply subsumable protein
 def: "A protein for which the matched spectra are the same, or a subset of, the matched spectra for two or more other proteins combined. These other proteins need not all be in the same group." [PSI:PI]
 is_a: MS:1001101 ! protein group or subset relationship
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002572
@@ -17079,7 +17079,7 @@ id: MS:1002599
 name: splash key
 def: "Spectral Hash key, an unique identifier for spectra." [PMID:27824832]
 is_a: MS:1001405 ! spectrum identification result details
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002600
@@ -17281,14 +17281,14 @@ id: MS:1002632
 name: jPOST dataset identifier
 def: "Dataset identifier issued by the jPOST repository. A dataset can refer to either a single sample as part of a study, or all samples that are part of the study corresponding to a publication." [PSI:PI]
 is_a: MS:1000878 ! external reference identifier
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002633
 name: jPOST dataset URI
 def: "URI that allows the access to one dataset in the jPOST repository. A dataset can refer to either a single sample as part of a study, or all samples that are part of the study corresponding to a publication." [PSI:PI]
 is_a: MS:1000878 ! external reference identifier
-relationship: has_value_type xsd\:anyURI ! The allowed value-type for this CV term
+relationship: has_value_type xsd:anyURI ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002634
@@ -17313,14 +17313,14 @@ id: MS:1002637
 name: chromosome name
 def: "The name or number of the chromosome to which a given peptide has been mapped." [PSI:PI]
 is_a: MS:1002636 ! proteogenomics attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002638
 name: chromosome strand
 def: "The strand (+ or -) to which the peptide has been mapped." [PSI:PI]
 is_a: MS:1002636 ! proteogenomics attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002639
@@ -17329,42 +17329,42 @@ def: "OBSOLETE The overall start position on the chromosome to which a peptide h
 comment: This term was obsoleted because it contains redundant info contained in term MS:1002643 - peptide start positions on chromosome.
 is_a: MS:1002636 ! proteogenomics attribute
 is_obsolete: true
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
+relationship: has_value_type xsd:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002640
 name: peptide end on chromosome
 def: "The overall end position on the chromosome to which a peptide has been mapped i.e. the position of the third base of the last codon, using a zero-based counting system." [PSI:PI]
 is_a: MS:1002636 ! proteogenomics attribute
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
+relationship: has_value_type xsd:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002641
 name: peptide exon count
 def: "The number of exons to which the peptide has been mapped." [PSI:PI]
 is_a: MS:1002636 ! proteogenomics attribute
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
+relationship: has_value_type xsd:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002642
 name: peptide exon nucleotide sizes
 def: "A comma separated list of the number of DNA bases within each exon to which a peptide has been mapped. Assuming standard operation of a search engine, the peptide exon sizes should sum to exactly three times the peptide length." [PSI:PI]
 is_a: MS:1002636 ! proteogenomics attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002643
 name: peptide start positions on chromosome
 def: "A comma separated list of start positions within exons to which the peptide has been mapped, relative to peptide-chromosome start, assuming a zero-based counting system. The first value MUST match the value in peptide start on chromosome." [PSI:PI]
 is_a: MS:1002636 ! proteogenomics attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002644
 name: genome reference version
 def: "The reference genome and versioning string as used for mapping. All coordinates are within this frame of reference." [PSI:PI]
 is_a: MS:1002636 ! proteogenomics attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002645
@@ -17385,35 +17385,35 @@ id: MS:1002647
 name: Thermo nativeID format, combined spectra
 def: "Thermo comma separated list of spectra that have been combined prior to searching or interpretation." [PSI:PI]
 is_a: MS:1002646 ! native spectrum identifier format, combined spectra
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002648
 name: Waters nativeID format, combined spectra
 def: "Waters comma separated list of spectra that have been combined prior to searching or interpretation." [PSI:PI]
 is_a: MS:1002646 ! native spectrum identifier format, combined spectra
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002649
 name: WIFF nativeID format, combined spectra
 def: "WIFF comma separated list of spectra that have been combined prior to searching or interpretation." [PSI:PI]
 is_a: MS:1002646 ! native spectrum identifier format, combined spectra
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002650
 name: Bruker/Agilent YEP nativeID format, combined spectra
 def: "Bruker/Agilent comma separated list of spectra that have been combined prior to searching or interpretation." [PSI:PI]
 is_a: MS:1002646 ! native spectrum identifier format, combined spectra
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002651
 name: Bruker BAF nativeID format, combined spectra
 def: "Bruker BAF comma separated list of spectra that have been combined prior to searching or interpretation." [PSI:PI]
 is_a: MS:1002646 ! native spectrum identifier format, combined spectra
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002652
@@ -17421,7 +17421,7 @@ name: Bruker FID nativeID format, combined spectra
 def: "Bruker FID comma separated list of spectra that have been combined prior to searching or interpretation." [PSI:PI]
 comment: The nativeID must be the same as the source file ID.
 is_a: MS:1002646 ! native spectrum identifier format, combined spectra
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002653
@@ -17429,7 +17429,7 @@ name: multiple peak list nativeID format, combined spectra
 def: "Comma separated list of spectra that have been combined prior to searching or interpretation." [PSI:PI]
 comment: Used for conversion of peak list files with multiple spectra, i.e. MGF, PKL, merged DTA files. Index is the spectrum number in the file, starting from 0.
 is_a: MS:1002646 ! native spectrum identifier format, combined spectra
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002654
@@ -17437,7 +17437,7 @@ name: single peak list nativeID format, combined spectra
 def: "Comma separated list of spectra that have been combined prior to searching or interpretation." [PSI:PI]
 comment: The nativeID must be the same as the source file ID. Used for conversion of peak list files with one spectrum per file, typically folder of PKL or DTAs, each sourceFileRef is different.
 is_a: MS:1002646 ! native spectrum identifier format, combined spectra
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002655
@@ -17445,7 +17445,7 @@ name: scan number only nativeID format, combined spectra
 def: "Comma separated list of spectra that have been combined prior to searching or interpretation." [PSI:PI]
 comment: Used for conversion from mzXML, or DTA folder where native scan numbers can be derived.
 is_a: MS:1002646 ! native spectrum identifier format, combined spectra
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002656
@@ -17453,7 +17453,7 @@ name: spectrum identifier nativeID format, combined spectra
 def: "Comma separated list of spectra that have been combined prior to searching or interpretation." [PSI:PI]
 comment: Used for conversion from mzData. The spectrum id attribute is referenced.
 is_a: MS:1002646 ! native spectrum identifier format, combined spectra
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002657
@@ -17461,7 +17461,7 @@ name: mzML unique identifier, combined spectra
 def: "Comma separated list of spectra that have been combined prior to searching or interpretation." [PSI:PI]
 comment: A unique identifier of a spectrum stored in an mzML file.
 is_a: MS:1002646 ! native spectrum identifier format, combined spectra
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002658
@@ -17493,7 +17493,7 @@ name: Morpheus:Morpheus score
 def: "Morpheus score for PSMs." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002108 ! higher score better
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002663
@@ -17501,7 +17501,7 @@ name: Morpheus:summed Morpheus score
 def: "Summed Morpheus score for protein groups." [PSI:PI]
 is_a: MS:1002368 ! search engine specific score for protein groups
 relationship: has_order MS:1002108 ! higher score better
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002664
@@ -17509,7 +17509,7 @@ name: interaction score derived from cross-linking
 def: "Parent term for interaction scores derived from cross-linking." [PSI:PI]
 is_a: MS:1002675 ! cross-linking result details
 relationship: has_regexp MS:1002665 ! ([:digit:]+[.][a|b]:[:digit:]+:[:digit:]+[.][:digit:]+([Ee][+-][0-9]+)*:(true|false]\{1\}))
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002665
@@ -17534,28 +17534,28 @@ id: MS:1002668
 name: frag: iTRAQ 4plex reporter ion
 def: "Standard reporter ion for iTRAQ 4Plex. The value slot holds the integer mass of the iTRAQ 4Plex reporter ion, e.g. 114." [PSI:PI]
 is_a: MS:1002307 ! fragmentation ion type
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
+relationship: has_value_type xsd:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002669
 name: frag: iTRAQ 8plex reporter ion
 def: "Standard reporter ion for iTRAQ 8Plex. The value slot holds the integer mass of the iTRAQ 8Plex reporter ion, e.g. 113." [PSI:PI]
 is_a: MS:1002307 ! fragmentation ion type
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
+relationship: has_value_type xsd:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002670
 name: frag: TMT reporter ion
 def: "Standard reporter ion for TMT. The value slot holds the integer mass of the TMT reporter ion and can be suffixed with either N or C, indicating whether the mass difference is encoded at a Nitrogen or Carbon atom, e.g. 127N." [PSI:PI]
 is_a: MS:1002307 ! fragmentation ion type
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002671
 name: frag: TMT ETD reporter ion
 def: "Standard reporter ion for TMT with ETD fragmentation. The value slot holds the integer mass of the TMT ETD reporter ion and can be suffixed with either N or C, indicating whether the mass difference is encoded at a Nitrogen or Carbon atom, e.g. 127C." [PSI:PI]
 is_a: MS:1002307 ! fragmentation ion type
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002672
@@ -17588,7 +17588,7 @@ def: "Estimation of the global false discovery rate of proteins-pairs in cross-l
 is_a: MS:1002664 ! interaction score derived from cross-linking
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
 relationship: has_regexp MS:1002665 ! ([:digit:]+[.][a|b]:[:digit:]+:[:digit:]+[.][:digit:]+([Ee][+-][0-9]+)*:(true|false]\{1\}))
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002677
@@ -17597,7 +17597,7 @@ def: "Estimation of the global false discovery rate of residue-pairs in cross-li
 is_a: MS:1002664 ! interaction score derived from cross-linking
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
 relationship: has_regexp MS:1002665 ! ([:digit:]+[.][a|b]:[:digit:]+:[:digit:]+[.][:digit:]+([Ee][+-][0-9]+)*:(true|false]\{1\}))
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002678
@@ -17617,7 +17617,7 @@ name: supplemental collision energy
 def: "Energy for an ion experiencing supplemental collision with a stationary gas particle resulting in dissociation of the ion." [PSI:MS]
 is_a: MS:1000510 ! precursor activation attribute
 relationship: has_units UO:0000266 ! electronvolt
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002681
@@ -17626,7 +17626,7 @@ def: "OpenXQuest's combined score for a cross-link spectrum match." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1001153 ! search engine specific score
 relationship: has_order MS:1002108 ! higher score better
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002682
@@ -17635,7 +17635,7 @@ def: "OpenXQuest's cross-correlation of cross-linked ions subscore." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1001153 ! search engine specific score
 relationship: has_order MS:1002108 ! higher score better
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002683
@@ -17644,7 +17644,7 @@ def: "OpenXQuest's cross-correlation of unlinked ions subscore." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1001153 ! search engine specific score
 relationship: has_order MS:1002108 ! higher score better
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002684
@@ -17654,7 +17654,7 @@ is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1001153 ! search engine specific score
 relationship: has_order MS:1002108 ! higher score better
 relationship: has_domain MS:1002306 ! value greater than zero
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002685
@@ -17664,7 +17664,7 @@ is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1001153 ! search engine specific score
 relationship: has_order MS:1002108 ! higher score better
 relationship: has_domain MS:1002306 ! value greater than zero
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002686
@@ -17674,7 +17674,7 @@ is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1001153 ! search engine specific score
 relationship: has_order MS:1002108 ! higher score better
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002687
@@ -17820,21 +17820,21 @@ id: MS:1002711
 name: list of strings
 def: "A list of xsd:string." []
 is_a: MS:1002710 ! list of type
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002712
 name: list of integers
 def: "A list of xsd:integer." []
 is_a: MS:1002710 ! list of type
-relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term
+relationship: has_value_type xsd:integer ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002713
 name: list of floats
 def: "A list of xsd:float." []
 is_a: MS:1002710 ! list of type
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002719
@@ -17855,7 +17855,7 @@ def: "MSPathFinder spectral E-value." [PSI:PI]
 is_a: MS:1002353 ! PSM-level e-value
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002109 ! lower score better
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002722
@@ -17864,7 +17864,7 @@ def: "MSPathFinder E-value." [PSI:PI]
 is_a: MS:1002353 ! PSM-level e-value
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002109 ! lower score better
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002723
@@ -17872,21 +17872,21 @@ name: MSPathFinder:QValue
 def: "MSPathFinder Q-value." [PSI:PI]
 is_a: MS:1002354 ! PSM-level q-value
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002724
 name: MSPathFinder:PepQValue
 def: "MSPathFinder peptide-level Q-value." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002725
 name: MSPathFinder:RawScore
 def: "MSPathFinder raw score." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002726
@@ -17935,14 +17935,14 @@ id: MS:1002733
 name: peptide-level spectral count
 def: "The number of MS2 spectra identified for a peptide sequence specified by the amino acid one-letter codes plus optional PTMs in spectral counting." [PSI:PI]
 is_a: MS:1002737 ! peptide-level quantification datatype
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
+relationship: has_value_type xsd:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002734
 name: peptide ion-level spectral count
 def: "The number of MS2 spectra identified for a molecular ion defined by the peptide sequence represented by the amino acid one-letter codes, plus optional PTMs plus optional charged aducts plus the charge state, in spectral counting." [PSI:PI]
 is_a: MS:1002737 ! peptide-level quantification datatype
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
+relationship: has_value_type xsd:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002735
@@ -18043,7 +18043,7 @@ id: MS:1002749
 name: Mascot:IntegratedSpectralLibrarySearch
 def: "Means that Mascot has integrated the search results of database and spectral library search into a single data set." [PSI:PI]
 is_a: MS:1002095 ! Mascot input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002750
@@ -18412,7 +18412,7 @@ id: MS:1002810
 name: adduct ion X m/z
 def: "Theoretical m/z of the X component in the adduct (addition product) M+X or M-X. This term was formerly called 'adduct ion mass', but it is not really a mass. It corresponds to the column mislabelled as 'mass' at https://fiehnlab.ucdavis.edu/staff/kind/Metabolomics/MS-Adduct-Calculator." [PSI:MS]
 is_a: MS:1003056 ! adduct ion property
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 relationship: has_units MS:1000040 ! m/z
 
 [Term]
@@ -18420,7 +18420,7 @@ id: MS:1002811
 name: adduct ion isotope
 def: "Isotope of the matrix molecule M of an adduct formation." [PSI:MS]
 is_a: MS:1003056 ! adduct ion property
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002812
@@ -18434,7 +18434,7 @@ name: adduct ion formula
 def: "Adduct formation formula of the form M+X or M-X, as constrained by the provided regular expression." [PSI:MS]
 is_a: MS:1002809 ! adduct ion attribute
 relationship: has_regexp MS:1002812 ! (\[[:digit:]{0,1}M([+][:digit:]{0,1}(H|K|(Na)|(Li)|(Cl)|(Br)|(NH3)|(NH4)|(CH3OH)|(IsoProp)|(DMSO)|(FA)|(Hac)|(TFA)|(NaCOOH)|(HCOOH)|(CF3COOH)|(ACN))){0,}([-][:digit:]{0,1}(H|(H2O)|(CH2)|(CH4)|(NH3)|(CO)|(CO2)|(COCH2)|(HCOOH)|(C2H4)|(C4H8)|(C3H2O3)|(C5H8O4)|(C6H10O4)|(C6H10O5)|(C6H8O6))){0,}\][:digit:]{0,1}[+-])
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002814
@@ -18450,7 +18450,7 @@ def: "Ion mobility measurement for an ion or spectrum of ions as measured in an 
 is_a: MS:1000455 ! ion selection attribute
 is_a: MS:1002892 ! ion mobility attribute
 relationship: has_units MS:1002814 ! volt-second per square centimeter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002816
@@ -18459,7 +18459,7 @@ def: "Array of population mean ion mobility values (K or K0) based on ion separa
 is_a: MS:1002893 ! ion mobility array
 relationship: has_units UO:0000028 ! millisecond
 relationship: has_units UO:0000010 ! second
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002817
@@ -18478,7 +18478,7 @@ id: MS:1002819
 name: Bruker TDF nativeID format, combined spectra
 def: "Bruker TDF comma separated list of spectra that have been combined prior to searching or interpretation." [PSI:PI]
 is_a: MS:1002646 ! native spectrum identifier format, combined spectra
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002820
@@ -18530,7 +18530,7 @@ name: MetaMorpheus:score
 def: "MetaMorpheus score for PSMs." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002108 ! higher score better
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002828
@@ -18538,35 +18538,35 @@ name: MetaMorpheus:protein score
 def: "MetaMorpheus score for protein groups." [PSI:PI]
 is_a: MS:1002368 ! search engine specific score for protein groups
 relationship: has_order MS:1002108 ! higher score better
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002829
 name: XCMS:into
 def: "Feature intensity produced by XCMS findPeaks() from integrated peak intensity." [PSI:PI]
 is_a: MS:1002735 ! feature-level quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002830
 name: XCMS:intf
 def: "Feature intensity produced by XCMS findPeaks() from baseline corrected integrated peak intensity." [PSI:PI]
 is_a: MS:1002735 ! feature-level quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002831
 name: XCMS:maxo
 def: "Feature intensity produced by XCMS findPeaks() from maximum peak intensity." [PSI:PI]
 is_a: MS:1002735 ! feature-level quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002832
 name: XCMS:area
 def: "Feature intensity produced by XCMS findPeaks() from feature area that is not normalized by the scan rate." [PSI:PI]
 is_a: MS:1002735 ! feature-level quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002833
@@ -18579,7 +18579,7 @@ id: MS:1002834
 name: ProteomeDiscoverer:Delta Score
 def: "The Delta Score reported by Proteome Discoverer version 2." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002835
@@ -18592,14 +18592,14 @@ id: MS:1002836
 name: iProX dataset identifier
 def: "Dataset identifier issued by the iProX repository. A dataset can refer to either a single sample as part of a study, or all samples that are part of the study corresponding to a publication." [PSI:PI]
 is_a: MS:1000878 ! external reference identifier
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002837
 name: iProX dataset URI
 def: "URI that allows the access to one dataset in the iProX repository. A dataset can refer to either a single sample as part of a study, or all samples that are part of the study corresponding to a publication." [PSI:PI]
 is_a: MS:1000878 ! external reference identifier
-relationship: has_value_type xsd\:anyURI ! The allowed value-type for this CV term
+relationship: has_value_type xsd:anyURI ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002838
@@ -18624,7 +18624,7 @@ id: MS:1002841
 name: external HDF5 dataset
 def: "The HDF5 dataset location containing the binary data, relative to the dataset containing the mzML. Also indicates that there is no data in the <binary> section of the BinaryDataArray." [PSI:PI]
 is_a: MS:1002840 ! external reference data
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002842
@@ -18632,7 +18632,7 @@ name: external offset
 def: "The position in the external data where the array begins." [PSI:PI]
 relationship: has_units UO:0000189 ! Count
 is_a: MS:1002840 ! external reference data
-relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term
+relationship: has_value_type xsd:nonNegativeInteger ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002843
@@ -18640,7 +18640,7 @@ name: external array length
 def: "Describes how many fields an array contains." [PSI:PI]
 relationship: has_units UO:0000189 ! Count
 is_a: MS:1002840 ! external reference data
-relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term
+relationship: has_value_type xsd:nonNegativeInteger ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002844
@@ -18653,56 +18653,56 @@ id: MS:1002845
 name: Associated file URI
 def: "URI of one external file associated to the PRIDE experiment (maybe through a PX submission)." [PSI:PI]
 is_a: MS:1002844 ! Experiment additional parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002846
 name: Associated raw file URI
 def: "URI of one raw data file associated to the PRIDE experiment (maybe through a PX submission)." [PSI:PI]
 is_a: MS:1002845 ! Associated file URI
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002847
 name: ProteomeCentral dataset URI
 def: "URI associated to one PX submission in ProteomeCentral." [PSI:PI]
 is_a: MS:1002844 ! Experiment additional parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002848
 name: Result file URI
 def: "URI of one file labeled as 'Result', associated to one PX submission." [PSI:PI]
 is_a: MS:1002845 ! Associated file URI
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002849
 name: Search engine output file URI
 def: "URI of one search engine output file associated to one PX submission." [PSI:PI]
 is_a: MS:1002845 ! Associated file URI
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002850
 name: Peak list file URI
 def: "URI of one of one search engine output file associated to one PX submission." [PSI:PI]
 is_a: MS:1002845 ! Associated file URI
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002851
 name: Other type file URI
 def: "URI of one file labeled as 'Other', associated to one PX submission." [PSI:PI]
 is_a: MS:1002845 ! Associated file URI
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002852
 name: Dataset FTP location
 def: "FTP location of one entire PX data set." [PSI:PI]
 is_a: MS:1002844 ! Experiment additional parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002853
@@ -18745,28 +18745,28 @@ id: MS:1002859
 name: Additional associated raw file URI
 def: "Additional URI of one raw data file associated to the PRIDE experiment (maybe through a PX submission). The URI is provided via an additional resource to PRIDE." [PSI:PI]
 is_a: MS:1002845 ! Associated file URI
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002860
 name: Gel image file URI
 def: "URI of one gel image file associated to one PX submission." [PSI:PI]
 is_a: MS:1002845 ! Associated file URI
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002861
 name: Reprocessed complete dataset
 def: "All the raw files included in the original dataset (or group of original datasets) have been reanalysed." [PSI:PI]
 is_a: MS:1002844 ! Experiment additional parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002862
 name: Reprocessed subset dataset
 def: "A subset of the raw files included in the original dataset (or group of original datasets) has been reanalysed." [PSI:PI]
 is_a: MS:1002844 ! Experiment additional parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002863
@@ -18791,7 +18791,7 @@ id: MS:1002866
 name: Reference
 def: "Literature reference associated with one dataset (including the authors, title, year and journal details). The value field can be used for the PubMedID, or to specify if one manuscript is just submitted or accepted, but it does not have a PubMedID yet." [PSI:PI]
 is_a: MS:1002844 ! Experiment additional parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002867
@@ -18831,14 +18831,14 @@ id: MS:1002872
 name: Panorama Public dataset identifier
 def: "Dataset identifier issued by the Panorama Public repository. A dataset can refer to either a single sample as part of a study, or all samples that are part of the study corresponding to a publication." [PSI:PI]
 is_a: MS:1000878 ! external reference identifier
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002873
 name: Panorama Public dataset URI
 def: "URI that allows the access to one dataset in the Panorama Public repository. A dataset can refer to either a single sample as part of a study, or all samples that are part of the study corresponding to a publication." [PSI:PI]
 is_a: MS:1000878 ! external reference identifier
-relationship: has_value_type xsd\:anyURI ! The allowed value-type for this CV term
+relationship: has_value_type xsd:anyURI ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002874
@@ -18923,7 +18923,7 @@ id: MS:1002887
 name: Progenesis QI normalised abundance
 def: "The normalised abundance produced by Progenesis QI LC-MS." [PSI:PI]
 is_a: MS:1002886 ! small molecule quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002888
@@ -18936,21 +18936,21 @@ id: MS:1002889
 name: Progenesis MetaScope score
 def: "The confidence score produced by Progenesis QI." [PSI:PI]
 is_a: MS:1002888 ! small molecule confidence measure
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002890
 name: fragmentation score
 def: "The fragmentation confidence score." [PSI:PI]
 is_a: MS:1002888 ! small molecule confidence measure
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002891
 name: isotopic fit score
 def: "The isotopic fit confidence score." [PSI:PI]
 is_a: MS:1002888 ! small molecule confidence measure
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002892
@@ -18970,7 +18970,7 @@ id: MS:1002894
 name: InChIKey
 def: "Unique chemical structure identifier for chemical compounds." [PMID:273343401]
 is_a: MS:1001405 ! spectrum identification result details
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002895
@@ -18983,7 +18983,7 @@ id: MS:1002896
 name: compound identification confidence level
 def: "Confidence level for annotation of identified compounds as defined by the Metabolomics Standards Initiative (MSI). The value slot can have the values 'Level 0' until 'Level 4'." [PMID:29748461]
 is_a: MS:1002895 ! small molecule identification attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002897
@@ -18992,7 +18992,7 @@ def: "OBSOLETE Identifies a peak when no de-isotoping has been performed. The va
 comment: This term was obsoleted because it was replaced by the more exact terms MS:1002956 'isotopic ion MS peak', MS:1002957 'isotopomer MS peak' and MS:1002958 'isotopologue MS peak' instead.
 is_a: MS:1000231 ! peak
 is_obsolete: true
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002898
@@ -19054,7 +19054,7 @@ name: proteoform-level global FDR
 def: "Estimation of the global false discovery rate of proteoforms." [PSI:PI]
 is_a: MS:1002905 ! proteoform-level identification statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002908
@@ -19062,7 +19062,7 @@ name: proteoform-level local FDR
 def: "Estimation of the local false discovery rate of proteoforms." [PSI:PI]
 is_a: MS:1002905 ! proteoform-level identification statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002909
@@ -19075,14 +19075,14 @@ id: MS:1002910
 name: proteoform-level global FDR threshold
 def: "Threshold for the global false discovery rate of proteoforms." [PSI:PI]
 is_a: MS:1002909 ! proteoform-level statistical threshold
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002911
 name: proteoform-level local FDR threshold
 def: "Threshold for the local false discovery rate of proteoforms." [PSI:PI]
 is_a: MS:1002909 ! proteoform-level statistical threshold
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002912
@@ -19107,70 +19107,70 @@ id: MS:1002915
 name: TopPIC:error tolerance
 def: "Error tolerance for precursor and fragment masses in PPM." [PSI:PI]
 is_a: MS:1002912 ! TopPIC input parameter
-relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term
+relationship: has_value_type xsd:integer ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002916
 name: TopPIC:max shift
 def: "Maximum value of the mass shift (in Dalton) of an unexpected modification." [PSI:PI]
 is_a: MS:1002912 ! TopPIC input parameter
-relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term
+relationship: has_value_type xsd:integer ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002917
 name: TopPIC:min shift
 def: "Minimum value of the mass shift (in Dalton) of an unexpected modification." [PSI:PI]
 is_a: MS:1002912 ! TopPIC input parameter
-relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term
+relationship: has_value_type xsd:integer ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002918
 name: TopPIC:shift num
 def: "Maximum number of unexpected modifications in a proteoform spectrum match." [PSI:PI]
 is_a: MS:1002912 ! TopPIC input parameter
-relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term
+relationship: has_value_type xsd:integer ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002919
 name: TopPIC:spectral cutoff type
 def: "Spectrum-level cutoff type for filtering identified proteoform spectrum matches." [PSI:PI]
 is_a: MS:1002912 ! TopPIC input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002920
 name: TopPIC:spectral cutoff value
 def: "Spectrum-level cutoff value for filtering identified proteoform spectrum matches." [PSI:PI]
 is_a: MS:1002912 ! TopPIC input parameter
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002921
 name: TopPIC:proteoform-level cutoff type
 def: "Proteoform-level cutoff type for filtering identified proteoform spectrum matches." [PSI:PI]
 is_a: MS:1002912 ! TopPIC input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002922
 name: TopPIC:proteoform-level cutoff value
 def: "Proteoform-level cutoff value for filtering identified proteoform spectrum matches." [PSI:PI]
 is_a: MS:1002912 ! TopPIC input parameter
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002923
 name: TopPIC:generating function
 def: "P-value and E-value estimation using generating function." [PSI:PI]
 is_a: MS:1002912 ! TopPIC input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002924
 name: TopPIC:combined spectrum number
 def: "Number of combined spectra." [PSI:PI]
 is_a: MS:1002912 ! TopPIC input parameter
-relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term
+relationship: has_value_type xsd:integer ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002925
@@ -19183,14 +19183,14 @@ id: MS:1002926
 name: TopPIC:thread number
 def: "Number of threads used in TopPIC." [PSI:PI]
 is_a: MS:1002912 ! TopPIC input parameter
-relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term
+relationship: has_value_type xsd:integer ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002927
 name: TopPIC:use TopFD feature
 def: "Proteoform identification using TopFD feature file." [PSI:PI]
 is_a: MS:1002912 ! TopPIC input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002928
@@ -19199,7 +19199,7 @@ def: "TopPIC spectrum-level E-value." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1002353 ! PSM-level e-value
 relationship: has_order MS:1002109 ! lower score better
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002929
@@ -19207,7 +19207,7 @@ name: TopPIC:spectral FDR
 def: "TopPIC spectrum-level FDR." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1002351 ! PSM-level local FDR
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002930
@@ -19215,7 +19215,7 @@ name: TopPIC:proteoform-level FDR
 def: "TopPIC proteoform-level FDR." [PSI:PI]
 is_a: MS:1002908 ! proteoform-level local FDR
 is_a: MS:1002906 ! search engine specific score for proteoforms
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002931
@@ -19223,21 +19223,21 @@ name: TopPIC:spectral p-value
 def: "TopPIC spectrum-level p-value." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1002352 ! PSM-level p-value
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002932
 name: TopPIC:MIScore
 def: "Modification identification score." [PMID:27291504]
 is_a: MS:1001968 ! PTM localization PSM-level statistic
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002933
 name: TopPIC:MIScore threshold
 def: "TopPIC:MIScore threshold." [PSI:PI]
 is_a: MS:1002555 ! PTM localization score threshold
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002934
@@ -19262,42 +19262,42 @@ id: MS:1002937
 name: TopMG:error tolerance
 def: "Error tolerance for precursor and fragment masses in PPM." [PSI:PI]
 is_a: MS:1002934 ! TopMG input parameter
-relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term
+relationship: has_value_type xsd:integer ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002938
 name: TopMG:max shift
 def: "Maximum value of the mass shift (in Dalton)." [PSI:PI]
 is_a: MS:1002934 ! TopMG input parameter
-relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term
+relationship: has_value_type xsd:integer ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002939
 name: TopMG:spectral cutoff type
 def: "Spectrum-level cutoff type for filtering identified proteoform spectrum matches." [PSI:PI]
 is_a: MS:1002934 ! TopMG input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002940
 name: TopMG:spectral cutoff value
 def: "Spectrum-level cutoff value for filtering identified proteoform spectrum matches." [PSI:PI]
 is_a: MS:1002934 ! TopMG input parameter
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002941
 name: TopMG:proteoform-level cutoff type
 def: "Proteoform-level cutoff type for filtering identified proteoform spectrum matches." [PSI:PI]
 is_a: MS:1002934 ! TopMG input parameter
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002942
 name: TopMG:proteoform-level cutoff value
 def: "Proteoform-level cutoff value for filtering identified proteoform spectrum matches." [PSI:PI]
 is_a: MS:1002934 ! TopMG input parameter
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002943
@@ -19310,42 +19310,42 @@ id: MS:1002944
 name: TopMG:thread number
 def: "Number of threads used in TopMG." [PSI:PI]
 is_a: MS:1002934 ! TopMG input parameter
-relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term
+relationship: has_value_type xsd:integer ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002945
 name: TopMG:use TopFD feature
 def: "Proteoform identification using TopFD feature file." [PSI:PI]
 is_a: MS:1002934 ! TopMG input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002946
 name: TopMG:proteoform graph gap size
 def: "Gap size in constructing proteoform graph." [PSI:PI]
 is_a: MS:1002934 ! TopMG input parameter
-relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term
+relationship: has_value_type xsd:integer ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002947
 name: TopMG:variable PTM number
 def: "Maximum number of variable PTMs." [PSI:PI]
 is_a: MS:1002934 ! TopMG input parameter
-relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term
+relationship: has_value_type xsd:integer ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002948
 name: TopMG:variable PTM number in proteoform graph gap
 def: "Maximum number of variable PTMs in a proteoform graph gap." [PSI:PI]
 is_a: MS:1002934 ! TopMG input parameter
-relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term
+relationship: has_value_type xsd:integer ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002949
 name: TopMG:use ASF-DIAGONAL
 def: "Protein filtering using ASF-DIAGONAL method." [PMID:29327814]
 is_a: MS:1002934 ! TopMG input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002950
@@ -19354,7 +19354,7 @@ def: "TopMG spectrum-level E-value." [PSI:PI]
 is_a: MS:1002353 ! PSM-level e-value
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002109 ! lower score better
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002951
@@ -19362,7 +19362,7 @@ name: TopMG:spectral FDR
 def: "TopMG spectrum-level FDR." [PSI:PI]
 is_a: MS:1002351 ! PSM-level local FDR
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002952
@@ -19370,7 +19370,7 @@ name: TopMG:proteoform-level FDR
 def: "TopMG proteoform-level FDR." [PSI:PI]
 is_a: MS:1002908 ! proteoform-level local FDR
 is_a: MS:1002906 ! search engine specific score for proteoforms
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002953
@@ -19378,7 +19378,7 @@ name: TopMG:spectral p-value
 def: "TopMG spectrum-level p-value." [PSI:PI]
 is_a: MS:1002352 ! PSM-level p-value
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002954
@@ -19386,56 +19386,56 @@ name: collisional cross sectional area
 def: "Structural molecular descriptor for the effective interaction area between the ion and neutral gas measured in ion mobility mass spectrometry." [PSI:PI]
 is_a: MS:1000861 ! molecular entity property
 relationship: has_units UO:0000324 ! square angstrom
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002955
 name: hr-ms compound identification confidence level
 def: "Refined High Resolution mass spectrometry confidence level for annotation of identified compounds as proposed by Schymanski et al. The value slot can have the values 'Level 1', 'Level 2', 'Level 2a', 'Level 2b', 'Level 3', 'Level 4', and 'Level 5'." [PMID:24476540]
 is_a: MS:1002895 ! small molecule identification attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002956
 name: isotopic ion MS peak
 def: "A mass spectrometry peak that represents one or more isotopic ions. The value slot contains a description of the represented isotope set, e.g. 'M+1 peak'." [PSI:PI]
 is_a: MS:1000231 ! peak
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002957
 name: isotopomer MS peak
 def: "The described isotopomer mass spectrometric signal. The value slot contains a description of the represented isotopomer, e.g. '13C peak', '15N peak', '2H peak', '18O peak' or '31P peak'." [PSI:PI]
 is_a: MS:1002956 ! isotopic ion MS peak
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002958
 name: isotopologue MS peak
 def: "The described isotopologue mass spectrometric signal. The value slot contains a description of the represented isotopologue, e.g. '13C1 peak' or '15N1 peak'." [PSI:PI]
 is_a: MS:1002956 ! isotopic ion MS peak
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002959
 name: isomer
 def: "One of several species (or molecular entities) that have the same atomic composition (molecular formula) but different line formulae or different stereochemical formulae." [https://goldbook.iupac.org/html/I/I03289.html]
 is_a: MS:1000859 ! molecule
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002960
 name: isotopomer
 def: "An isomer that differs from another only in the spatial distribution of the constitutive isotopic atoms." [https://goldbook.iupac.org/html/I/I03352.html]
 is_a: MS:1002959 ! isomer
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002961
 name: isotopologue
 def: "A molecular entity that differs only in isotopic composition (number of isotopic substitutions)." [https://goldbook.iupac.org/html/I/I03351.html]
 is_a: MS:1002959 ! isomer
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002962
@@ -19614,7 +19614,7 @@ name: IdentiPy:RHNS
 def: "The IdentiPy result 'RHNS'." [PSI:PI]
 is_a: MS:1001153 ! search engine specific score
 relationship: has_order MS:1002108 ! higher score better
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002989
@@ -19622,7 +19622,7 @@ name: IdentiPy:hyperscore
 def: "The IdentiPy result 'hyperscore'." [PSI:PI]
 is_a: MS:1001153 ! search engine specific score
 relationship: has_order MS:1002108 ! higher score better
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002990
@@ -19643,7 +19643,7 @@ def: "Posterior error probability of the best identified peptide of the Andromed
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
 relationship: has_order MS:1002108 ! higher score better
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002996
@@ -19656,7 +19656,7 @@ id: MS:1002997
 name: ProteomeXchange dataset identifier reanalysis number
 def: "Index number of a reanalysis within a ProteomeXchange reprocessed dataset identifier container (RPXD)." [PSI:PI]
 is_a: MS:1000878 ! external reference identifier
-relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term
+relationship: has_value_type xsd:nonNegativeInteger ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1002998
@@ -19712,7 +19712,7 @@ name: mean inverse reduced ion mobility array
 def: "Array of population mean ion mobility values based on ion separation in gaseous phase due to different ion mobilities under an electric field based on ion size, m/z and shape, normalized for the local conditions and reported in volt-second per square centimeter, corresponding to a spectrum of individual peaks encoded with an m/z array." [PSI:MS]
 is_a: MS:1002893 ! ion mobility array
 relationship: has_units MS:1002814 ! volt-second per square centimeter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003007
@@ -19721,7 +19721,7 @@ def: "Array of raw ion mobility values (K or K0) based on ion separation in gase
 is_a: MS:1002893 ! ion mobility array
 relationship: has_units UO:0000028 ! millisecond
 relationship: has_units UO:0000010 ! second
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003008
@@ -19729,7 +19729,7 @@ name: raw inverse reduced ion mobility array
 def: "Array of raw ion mobility values based on ion separation in gaseous phase due to different ion mobilities under an electric field based on ion size, m/z and shape, normalized for the local conditions and reported in volt-second per square centimeter, corresponding to a spectrum of individual peaks encoded with an m/z array." [PSI:MS]
 is_a: MS:1002893 ! ion mobility array
 relationship: has_units MS:1002814 ! volt-second per square centimeter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003009
@@ -19783,7 +19783,7 @@ is_a: MS:1002490 ! peptide-level scoring
 is_a: MS:1001153 ! search engine specific score
 relationship: has_order MS:1002108 ! higher score better
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003017
@@ -19793,7 +19793,7 @@ is_a: MS:1002490 ! peptide-level scoring
 is_a: MS:1001153 ! search engine specific score
 relationship: has_order MS:1002108 ! higher score better
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003018
@@ -19840,7 +19840,7 @@ def: "The OpenPepXL score for a cross-link spectrum match." [PSI:PI]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1001153 ! search engine specific score
 relationship: has_order MS:1002108 ! higher score better
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003025
@@ -19877,21 +19877,21 @@ id: MS:1003030
 name: Mascot:MinNumSigUniqueSeqs
 def: "Minimum number of significant unique sequences required in a protein hit. The setting is only relevant if the protein grouping strategy is 'family clustering'." [PSI:PI]
 is_a: MS:1002095 ! Mascot input parameter
-relationship: has_value_type xsd\:nonNegativeInteger ! The allowed value-type for this CV term
+relationship: has_value_type xsd:nonNegativeInteger ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003031
 name: CPTAC accession number
 def: "Main identifier of a CPTAC dataset." [PSI:PI]
 is_a: MS:1000878 ! external reference identifier
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003032
 name: compound identification confidence code in MS-DIAL
 def: "The confidence code to describe the confidence of annotated compounds as defined by the MS-DIAL program." [PMID:25938372, http://prime.psc.riken.jp/Metabolomics_Software/MS-DIAL]
 is_a: MS:1002895 ! small molecule identification attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003033
@@ -19982,7 +19982,7 @@ id: MS:1003047
 name: protein sequence offset
 def: "Offset in number of residues from the n terminus of the protein at which the peptide begins. Use 1 when the first residue of the peptide sequence is the first residue of the protein sequence." [PSI:PI]
 is_a: MS:1003046 ! peptide-to-protein mapping attribute
-relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term
+relationship: has_value_type xsd:integer ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003048
@@ -20022,14 +20022,14 @@ id: MS:1003053
 name: theoretical monoisotopic m/z
 def: "Mass-to-charge ratio of a peptidoform ion composed of the most common isotope of each atom computed from the putative knowledge of its molecular constituents." [PSI:PI]
 is_a: MS:1003052 ! peptidoform ion property
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003054
 name: theoretical average m/z
 def: "Mass-to-charge ratio of a peptidoform ion computed from the putative knowledge of its molecular constituents, averaged over the distribution of naturally occurring isotopes." [PSI:PI]
 is_a: MS:1003052 ! peptidoform ion property
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003055
@@ -20060,21 +20060,21 @@ id: MS:1003059
 name: number of peaks
 def: "Number of peaks or features in a spectrum. For a peak-picked spectrum, this will correspond to the number of data points. For a non-peak-picked spectrum, this corresponds to the number of features discernable in the spectrum, which will be fewer than the number of data points." [PSI:PI]
 is_a: MS:1003058 ! spectrum property
-relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term
+relationship: has_value_type xsd:integer ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003060
 name: number of data points
 def: "Number of data points in a spectrum. For a peak-picked spectrum, this will correspond to the number of peaks. For a non-peak-picked spectrum, this corresponds to the number of values in the data array, which are not all peaks." [PSI:PI]
 is_a: MS:1003058 ! spectrum property
-relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term
+relationship: has_value_type xsd:integer ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003061
 name: library spectrum name
 def: "Label attached to a spectrum uniquely naming it within a collection of spectra, often in a spectral library. It is often a string combination of peptide sequence, charge, mass modifications, collision energy, but will obviously be different for small molecules or unidentified spectra. It must be unique within a collection." [PSI:PI]
 is_a: MS:1000499 ! spectrum attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 synonym: "spectrum name" EXACT []
 
 [Term]
@@ -20082,14 +20082,14 @@ id: MS:1003062
 name: library spectrum index
 def: "Integer index value that indicates the spectrum's ordered position within a spectral library. By custom, index counters should begin with 0." [PSI:PI]
 is_a: MS:1003234 ! library spectrum attribute
-relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term
+relationship: has_value_type xsd:integer ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003063
 name: universal spectrum identifier
 def: "PSI universal spectrum identifier (USI) multipart key that uniquely identifies a spectrum available in a ProteomeXchange datasets or spectral library." [PSI:PI]
 is_a: MS:1000499 ! spectrum attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 synonym: "USI" EXACT []
 
 [Term]
@@ -20127,14 +20127,14 @@ id: MS:1003069
 name: number of replicate spectra available
 def: "Number of replicate spectra available for use during the aggregation process." [PSI:PI]
 is_a: MS:1003064 ! spectrum aggregation attribute
-relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term
+relationship: has_value_type xsd:integer ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003070
 name: number of replicate spectra used
 def: "Number of replicate spectra used during the aggregation process. This is generally applicable when there are many replicates available, but some are discarded as being low S/N, blended, or otherwise unsuitable, and the remaining set is then used for merging via a consensus algorithm." [PSI:PI]
 is_a: MS:1003064 ! spectrum aggregation attribute
-relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term
+relationship: has_value_type xsd:integer ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003071
@@ -20195,7 +20195,7 @@ id: MS:1003080
 name: top 20 peak unassigned intensity fraction
 def: "Fraction of intensity summed from unassigned peaks among the top 20 divided by the intensity summed from all top 20 peaks in the spectrum." [PSI:PI]
 is_a: MS:1003078 ! interpreted spectrum attribute
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003081
@@ -20203,7 +20203,7 @@ name: unidentified modification monoisotopic mass delta
 def: "Monoisotopic mass delta in Daltons of an amino acid residue modification whose atomic composition or molecular identity has not been determined. This term should not be used for modifications of known molecular identity such as those available in Unimod, RESID or PSI-MOD. This term MUST NOT be used inside the <Modification> element in mzIdentML." [PSI:PI]
 is_a: MS:1001471 ! peptide modification details
 relationship: has_units UO:0000221 ! dalton
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003082
@@ -20223,7 +20223,7 @@ id: MS:1003084
 name: processed data file
 def: "File that contains data that has been substantially processed or transformed from what was originally acquired by an instrument." [PSI:MS]
 is_a: MS:1000577 ! source data file
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003085
@@ -20231,7 +20231,7 @@ name: previous MSn-1 scan precursor intensity
 def: "Intensity of the precursor ion in the previous MSn-1 scan (prior in time to the referencing MSn scan). For an MS2 scan, this means the MS1 precursor intensity. It is unspecified on whether this is an apex (across m/z) intensity, integrated (across m/z) intensity, a centroided peak intensity of unknown origin, or even summed across several isotopes." [PSI:MS]
 is_a: MS:1001141 ! intensity of precursor ion
 is_a: MS:1000499 ! spectrum attribute
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003086
@@ -20239,7 +20239,7 @@ name: precursor apex intensity
 def: "Intensity of the precursor ion current as measured by its apex point over time and m/z. It is unspecified whether this is the intensity of the selected isotope or the most intense isotope." [PSI:MS]
 is_a: MS:1001141 ! intensity of precursor ion
 is_a: MS:1000499 ! spectrum attribute
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003087
@@ -20277,7 +20277,7 @@ id: MS:1003092
 name: number of mantissa bits truncated
 def: "Number of extraneous mantissa bits truncated to improve subsequent compression." [PSI:MS]
 is_a: MS:1003091 ! binary data compression parameter
-relationship: has_value_type xsd\:positiveInteger ! The allowed value-type for this CV term
+relationship: has_value_type xsd:positiveInteger ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003093
@@ -20309,42 +20309,42 @@ id: MS:1003097
 name: MaxQuant protein group-level score
 def: "The probability based MaxQuant protein group score." [PSI:MS]
 is_a: MS:1002368 ! search engine specific score for protein groups
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003098
 name: Andromeda peptide PEP
 def: "Peptide probability from Andromeda." [PSI:MS]
 is_a: MS:1002358 ! search engine specific peptide sequence-level identification statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003099
 name: MaxQuant-DIA peptide PEP
 def: "Peptide probability from MaxQuant-DIA algorithm." [PSI:MS]
 is_a: MS:1002358 ! search engine specific peptide sequence-level identification statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003100
 name: MaxQuant-DIA score
 def: "PSM evidence score from MaxQuant-DIA algorithm." [PSI:MS]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003101
 name: MaxQuant-DIA PEP
 def: "PSM evidence PEP probability from MaxQuant-DIA algorithm." [PSI:MS]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003102
 name: NIST msp comment
 def: "Term for a comment field withing the NIST msp file format" [PSI:MS]
 is_a: MS:1000499 ! spectrum attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003103
@@ -20395,7 +20395,7 @@ name: SIM-XL score
 def: "SIM-XL identification search engine score" [PSI:MS]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002108 ! higher score better
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003111
@@ -20414,35 +20414,35 @@ id: MS:1003113
 name: OpenMS:ConsensusID PEP
 def: "The OpenMS ConsesusID tool posterior error probability" [PSI:MS]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003114
 name: OpenMS:Best PSM Score
 def: "The score of the best PSM selected by the underlying identification tool" [PSI:MS]
 is_a: MS:1002358 ! search engine specific peptide sequence-level identification statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003115
 name: OpenMS:Target-decoy PSM q-value
 def: "The OpenMS Target-decoy q-values at PSM level" [PSI:MS]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003116
 name: OpenMS:Target-decoy peptide q-value
 def: "The OpenMS Target-decoy q-values at peptide sequence level" [PSI:MS]
 is_a: MS:1002358 ! search engine specific peptide sequence-level identification statistic
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003117
 name: OpenMS:Target-decoy protein q-value
 def: "The OpenMS Target-decoy q-values at protein level" [PSI:MS]
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003118
@@ -20456,21 +20456,21 @@ id: MS:1003119
 name: EPIFANY:Protein posterior probability
 def: "Protein Posterior probability calculated by EPIFANY protein inference algorithm" [PSI:MS]
 is_a: MS:1002363 ! search engine specific score for proteins
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003120
 name: OpenMS:LFQ intensity
 def: "The data type LFQ intensity produced by OpenMS." [PSI:MS]
 is_a: MS:1001805 ! quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003121
 name: OpenMS:LFQ spectral count
 def: "The data type LFQ spectral count produced by OpenMS." [PSI:MS]
 is_a: MS:1001805 ! quantification datatype
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003122
@@ -20497,7 +20497,7 @@ def: "ProSight spectrum-level Q-value." [PSI:MS]
 is_a: MS:1002354 ! PSM-level q-value
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002109 ! lower score better
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003126
@@ -20505,7 +20505,7 @@ name: ProSight:spectral P-score
 def: "ProSight spectrum-level P-score." [PSI:MS]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002109 ! lower score better
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003127
@@ -20514,7 +20514,7 @@ def: "ProSight spectrum-level E-value." [PSI:MS]
 is_a: MS:1002353 ! PSM-level e-value
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002109 ! lower score better
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003128
@@ -20522,7 +20522,7 @@ name: ProSight:spectral C-score
 def: "ProSight spectrum-level C-score." [PSI:MS]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002108 ! higher score better
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003129
@@ -20531,7 +20531,7 @@ def: "Estimation of the Q-value for proteoforms." [PSI:MS]
 is_a: MS:1002905 ! proteoform-level identification statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
 relationship: has_order MS:1002109 ! lower score better
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003130
@@ -20539,7 +20539,7 @@ name: ProSight:proteoform Q-value
 def: "ProSight proteoform-level Q-value." [PSI:MS]
 is_a: MS:1003129 ! proteoform-level Q-value
 relationship: has_order MS:1002109 ! lower score better
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003131
@@ -20559,7 +20559,7 @@ name: isoform-level Q-value
 def: "Estimation of the Q-value for isoforms." [PSI:MS]
 is_a: MS:1003132 ! isoform-level identification statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003134
@@ -20567,7 +20567,7 @@ name: ProSight:isoform Q-value
 def: "ProSight isoform-level Q-value." [PSI:MS]
 is_a: MS:1003133 ! isoform-level Q-value
 relationship: has_order MS:1002109 ! lower score better
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003135
@@ -20575,7 +20575,7 @@ name: ProSight:protein Q-value
 def: "ProSight protein-level Q-value." [PSI:MS]
 is_a: MS:1001869 ! protein-level q-value
 relationship: has_order MS:1002109 ! lower score better
-relationship: has_value_type xsd\:double ! The allowed value-type for this CV term
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003136
@@ -20595,7 +20595,7 @@ name: ProSight:Run delta m mode
 def: "If true, runs delta m mode in ProSight." [PSI:MS]
 is_a: MS:1003136 ! ProSight input parameter
 is_a: MS:1003137 ! TDPortal input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003139
@@ -20603,7 +20603,7 @@ name: ProSight:Run Subsequence Search mode
 def: "If true, runs Subsequence Search mode in ProSight." [PSI:MS]
 is_a: MS:1003136 ! ProSight input parameter
 is_a: MS:1003137 ! TDPortal input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003140
@@ -20611,7 +20611,7 @@ name: ProSight:Run Annotated Proteoform Search mode
 def: "If true, runs Annotated Proteoform Search mode in ProSight." [PSI:MS]
 is_a: MS:1003136 ! ProSight input parameter
 is_a: MS:1003137 ! TDPortal input parameter
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003141
@@ -20685,7 +20685,7 @@ id: MS:1003151
 name: SHA-256
 def: "SHA-256 (member of Secure Hash Algorithm-2 family) is a cryptographic hash function designed by the National Security Agency (NSA) and published by the NIST as a U. S. government standard. It is also used to verify file integrity." [PSI:MS]
 is_a: MS:1000561 ! data file checksum type
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003152
@@ -20700,7 +20700,7 @@ def: "Array of raw ion mobility values from a drift time device, reported in sec
 is_a: MS:1002893 ! ion mobility array
 relationship: has_units UO:0000028 ! millisecond
 relationship: has_units UO:0000010 ! second
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003154
@@ -20709,7 +20709,7 @@ def: "Array of ion mobility values (K or K0) based on ion separation in gaseous 
 is_a: MS:1002893 ! ion mobility array
 relationship: has_units UO:0000028 ! millisecond
 relationship: has_units UO:0000010 ! second
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003155
@@ -20717,7 +20717,7 @@ name: deconvoluted inverse reduced ion mobility array
 def: "Array of ion mobility values based on ion separation in gaseous phase due to different ion mobilities under an electric field based on ion size, m/z and shape, normalized for the local conditions and reported in volt-second per square centimeter, as an average property of an analyte post peak-detection, weighted charge state reduction, and/or adduct aggregation, corresponding to a spectrum of individual peaks encoded with an m/z array." [PSI:MS]
 is_a: MS:1002893 ! ion mobility array
 relationship: has_units MS:1002814 ! volt-second per square centimeter
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003156
@@ -20726,7 +20726,7 @@ def: "Array of mean ion mobility values from a drift time device, reported in se
 is_a: MS:1002893 ! ion mobility array
 relationship: has_units UO:0000028 ! millisecond
 relationship: has_units UO:0000010 ! second
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003157
@@ -20734,7 +20734,7 @@ name: scanning quadrupole position lower bound m/z array
 def: "Array of m/z values representing the lower bound m/z of the quadrupole position at each point in the spectrum." [PSI:MS]
 is_a: MS:1000513 ! binary data array
 relationship: has_units MS:1000040 ! m/z
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003158
@@ -20742,7 +20742,7 @@ name: scanning quadrupole position upper bound m/z array
 def: "Array of m/z values representing the upper bound m/z of the quadrupole position at each point in the spectrum." [PSI:MS]
 is_a: MS:1000513 ! binary data array
 relationship: has_units MS:1000040 ! m/z
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003159
@@ -20794,28 +20794,28 @@ id: MS:1003166
 name: assigned intensity fraction
 def: "Fraction of intensity summed from all peaks that can be attributed to expected fragments of the analyte, divided by the intensity summed from all peaks in the spectrum" [PSI:PI]
 is_a: MS:1003078 ! interpreted spectrum attribute
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003167
 name: MSn-1 isolation window precursor purity
 def: "The fraction of total intensities in the isolation window in the previous round of MS (i.e. the MSn-1 scan) that can be assigned to this identified analyte" [PSI:PI]
 is_a: MS:1003078 ! interpreted spectrum attribute
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003168
 name: library spectrum comment
 def: "A free-text string providing additional information of the library spectrum not encoded otherwise, usually for human use and not parsed by software tools." [PSI:PI]
 is_a: MS:1003234 ! library spectrum attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003169
 name: proforma peptidoform sequence
 def: "Sequence string describing the amino acids and mass modifications of a peptidoform using the PSI ProForma notation" [PSI:PI]
 is_a: MS:1000889 ! peptidoform sequence
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003170
@@ -20840,64 +20840,64 @@ id: MS:1003173
 name: numeric attribute
 def: "An attribute that takes on a numeric value" [PSI:PI]
 is_a: MS:1000547 ! object attribute
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:int ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003174
 name: attribute maximum
 def: "The maximum value for this attribute" [PSI:PI]
 relationship: part_of MS:1003171 ! numeric attribute
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:int ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003175
 name: attribute minimum
 def: "The minimum value for this attribute" [PSI:PI]
 relationship: part_of MS:1003171 ! numeric attribute
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:int ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003176
 name: attribute mean
 def: "The arithmetic mean value for this attribute" [PSI:PI]
 relationship: part_of MS:1003171 ! numeric attribute
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:int ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003177
 name: attribute standard deviation
 def: "The standard deviation (exact value of population, or estimate from sample) of this attribute" [PSI:PI]
 relationship: part_of MS:1003171 ! numeric attribute
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:int ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003178
 name: attribute coefficient of variation
 def: "The coefficient of variation of this attribute, i.e. standard deviation divided by the mean" [PSI:PI]
 relationship: part_of MS:1003171 ! numeric attribute
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:int ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003179
 name: attribute summary value
 def: "The most appropriate summary value of the attribute, usually but not necessarily the mean" [PSI:PI]
 relationship: part_of MS:1003171 ! numeric attribute
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:int ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003180
 name: attribute median
 def: "The median of this attribute" [PSI:PI]
 relationship: part_of MS:1003171 ! numeric attribute
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:int ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003181
@@ -20935,42 +20935,42 @@ id: MS:1003186
 name: library format version
 def: "Version number of the [PSI] library format specification" [PSI:PI]
 is_a: MS:1003171 ! spectral library attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003187
 name: library identifier
 def: "Short identifier for the library for easy reference, preferably but not necessarily globally unique" [PSI:PI]
 is_a: MS:1003171 ! spectral library attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003188
 name: library name
 def: "A short name identifying the library to potential users. The same name may refer to multiple versions of the same continually updated library." [PSI:PI]
 is_a: MS:1003171 ! spectral library attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003189
 name: library description
 def: "Extended free-text description of the library" [PSI:PI]
 is_a: MS:1003171 ! spectral library attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003190
 name: library version
 def: "Version number of the library, usually refering to a certain release of a continually updated library " [PSI:PI]
 is_a: MS:1003171 ! spectral library attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003191
 name: library URI
 def: "URI or URL that uniquely identifies the library" [PSI:PI]
 is_a: MS:1003171 ! spectral library attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003192
@@ -21007,28 +21007,28 @@ id: MS:1003197
 name: license URI
 def: "URI of the license controlling use of the library (e.g. https://creativecommons.org/publicdomain/zero/1.0/)" [PSI:PI]
 is_a: MS:1003171 ! spectral library attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003198
 name: copyright notice
 def: "Notice of statutorily prescribed form that informs users of the underlying claim to copyright ownership in a published work" [PSI:PI]
 is_a: MS:1003171 ! spectral library attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003199
 name: change log
 def: "Extended free-text description of the difference from the previous version" [PSI:PI]
 is_a: MS:1003171 ! spectral library attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003200
 name: software version
 def: "Version number of the software package used for library creation" [PSI:PI]
 is_a: MS:1003171 ! spectral library attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003201
@@ -21048,28 +21048,28 @@ id: MS:1003203
 name: constituent spectrum file
 def: "Spectrum data file from which (at least) a subset of spectra were extracted from. Should use USI notation mzspec:PXDxxxx:msRunName if possible, or a URI if USI notation is not possible." [PSI:PI]
 is_a: MS:1003201 ! library provenance attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003204
 name: constituent identification file
 def: "Identification file where (at least) a subset of identifications were extracted from. Should use a URI if possible" [PSI:PI]
 is_a: MS:1003201 ! library provenance attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003205
 name: constituent library file
 def: "Source library URI which(at least) a subset of spectra were extracted from." [PSI:PI]
 is_a: MS:1003201 ! library provenance attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003206
 name: library creation log
 def: "String of logging information generated when the library was constructed from its constituent files. Multiple lines should be separated with escaped \n" [PSI:PI]
 is_a: MS:1003201 ! library provenance attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003207
@@ -21084,7 +21084,7 @@ name: experimental precursor monoisotopic m/z
 def: "The measured or inferred m/z (as reported by the mass spectrometer acquisition software or post-processing software) of the monoisotopic peak of the precursor ion based on the MSn-1 spectrum." [PSI:MS]
 is_a: MS:1000455 ! ion selection attribute
 relationship: has_units MS:1000040 ! m/z
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003209
@@ -21093,7 +21093,7 @@ def: "The measured monoisotopic m/z (as reported by the mass spectrometer acquis
 is_a: MS:1003078 ! interpreted spectrum attribute
 relationship: has_units MS:1000040 ! m/z
 relationship: has_units UO:0000169 ! parts per million
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003210
@@ -21102,7 +21102,7 @@ def: "The measured average m/z (as reported by the mass spectrometer acquisition
 is_a: MS:1003078 ! interpreted spectrum attribute
 relationship: has_units MS:1000040 ! m/z
 relationship: has_units UO:0000169 ! parts per million
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003211
@@ -21117,7 +21117,7 @@ def: "A name to refer to a library attribute set" [PSI:PI]
 relationship: part_of MS:1003211 ! library spectrum attribute set
 relationship: part_of MS:1003238 ! library analyte attribute set
 relationship: part_of MS:1003239 ! library interpretation attribute set
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003213
@@ -21268,7 +21268,7 @@ id: MS:1003237
 name: library spectrum key
 def: "An ordinal number uniquely identifying a spectrum in a library. Library spectrum keys should start at 1. Library spectrum keys SHOULD not change if entries are re-ordered or removed from a library." [PSI:PI]
 is_a: MS:1003234 ! library spectrum attribute
-relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term
+relationship: has_value_type xsd:integer ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003238
@@ -21305,14 +21305,14 @@ id: MS:1003243
 name: adduct ion mass
 def: "The theoretical mass of the adduct ion (e.g. for a singly-charged protonated peptide ion, this value would be the neutral peptide molecule’s mass plus the mass of a proton)" [PSI:PI]
 is_a: MS:1003056 ! adduct ion property
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003244
 name: peptide accession number
 def: "Accession number (e.g. in PeptideAtlas) of the peptide sequence" [PSI:PI]
 is_a: MS:1003050 ! peptidoform attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003245
@@ -21353,14 +21353,14 @@ id: MS:1003250
 name: count of identified peptidoforms
 def: "The number of peptidoforms that pass the threshold to be considered identified with sufficient confidence." [PSI:PI]
 is_a: MS:1002702 ! peptide sequence-level result list attribute
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
+relationship: has_value_type xsd:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003251
 name: count of identified spectra
 def: "The number of spectra that pass the threshold to be considered identified with sufficient confidence." [PSI:PI]
 is_a: MS:1002700 ! PSM-level result list attribute
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
+relationship: has_value_type xsd:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003252
@@ -21417,14 +21417,14 @@ id: MS:1003260
 name: related spectrum USI
 def: "A cross reference to a related spectrum in the form of a PSI Universal Spectrum Identifier" [PSI:PI]
 is_a: MS:1003258 ! related spectrum
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003261
 name: related spectrum description
 def: "A free-text string describing the related spectrum and/or its relationship to this spectrum" [PSI:PI]
 relationship: part_of MS:1003258 ! related spectrum
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003262
@@ -21444,7 +21444,7 @@ id: MS:1003264
 name: similar spectrum USI
 def: "A cross reference to a similar spectrum in the form of a PSI Universal Spectrum Identifier" [PSI:PI]
 is_a: MS:1003262 ! similar spectrum
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003265
@@ -21463,7 +21463,7 @@ id: MS:1003267
 name: spectrum cluster key
 def: "An ordinal number uniquely identifying a spectrum cluster. It should start with 1." [PSI:PI]
 is_a: MS:1003266 ! spectrum cluster attribute
-relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term
+relationship: has_value_type xsd:integer ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003268
@@ -21477,7 +21477,7 @@ id: MS:1003269
 name: spectrum cluster member USI
 def: "A member of this cluster external to the library, specified using a PSI Universal Spectrum Identifier " [PSI:PI]
 is_a: MS:1003266 ! spectrum cluster attribute
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:1003270
@@ -21640,7 +21640,7 @@ synonym: "XIC-WideFrac" EXACT [PMID:24494671]
 is_a: MS:4000003 ! single value
 relationship: has_metric_category MS:4000009 ! ID free metric
 relationship: has_metric_category MS:4000012 ! single run based metric
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 relationship: has_value_concept UO:0000191 ! fraction
 
 [Term]
@@ -21654,7 +21654,7 @@ is_a: MS:4000004 ! n-tuple
 relationship: has_metric_category MS:4000009 ! ID free metric
 relationship: has_metric_category MS:4000012 ! single run based metric
 relationship: has_metric_category MS:4000018 ! XIC metric
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 relationship: has_value_concept MS:1000086 ! full width at half-maximum
 relationship: has_value_concept STATO:0000291 ! quantile
 relationship: has_units UO:0000010 ! second
@@ -21670,7 +21670,7 @@ is_a: MS:4000004 ! n-tuple
 relationship: has_metric_category MS:4000009 ! ID free metric
 relationship: has_metric_category MS:4000012 ! single run based metric
 relationship: has_metric_category MS:4000018 ! XIC metric
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 relationship: has_value_concept STATO:0000105 ! log signal intensity ratio
 relationship: has_value_concept UO:0000191 ! fraction
 
@@ -21683,7 +21683,7 @@ is_a: MS:4000003 ! single value
 relationship: has_metric_category MS:4000009 ! ID free metric
 relationship: has_metric_category MS:4000012 ! single run based metric
 relationship: has_metric_category MS:4000016 ! retention time metric
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 relationship: has_value_concept NCIT:C25330 ! Duration
 relationship: has_units UO:0000010 ! second
 
@@ -21700,7 +21700,7 @@ relationship: has_metric_category MS:4000009 ! ID free metric
 relationship: has_metric_category MS:4000012 ! single run based metric
 relationship: has_metric_category MS:4000016 ! retention time metric
 relationship: has_metric_category MS:4000017 ! chromatogram metric
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 relationship: has_units UO:0000191 ! fraction
 
 [Term]
@@ -21716,7 +21716,7 @@ relationship: has_metric_category MS:4000009 ! ID free metric
 relationship: has_metric_category MS:4000012 ! single run based metric
 relationship: has_metric_category MS:4000016 ! retention time metric
 relationship: has_metric_category MS:4000021 ! MS1 metric
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 relationship: has_units UO:0000191 ! fraction
 
 [Term]
@@ -21732,7 +21732,7 @@ relationship: has_metric_category MS:4000009 ! ID free metric
 relationship: has_metric_category MS:4000012 ! single run based metric
 relationship: has_metric_category MS:4000016 ! retention time metric
 relationship: has_metric_category MS:4000022 ! MS2 metric
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 relationship: has_units UO:0000191 ! fraction
 
 [Term]
@@ -21747,7 +21747,7 @@ relationship: has_metric_category MS:4000009 ! ID free metric
 relationship: has_metric_category MS:4000012 ! single run based metric
 relationship: has_metric_category MS:4000017 ! chromatogram metric
 relationship: has_metric_category MS:4000021 ! MS1 metric
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 relationship: has_value_concept STATO:0000105 ! log signal intensity ratio
 
 [Term]
@@ -21762,7 +21762,7 @@ relationship: has_metric_category MS:4000009 ! ID free metric
 relationship: has_metric_category MS:4000012 ! single run based metric
 relationship: has_metric_category MS:4000017 ! chromatogram metric
 relationship: has_metric_category MS:4000021 ! MS1 metric
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 relationship: has_value_concept STATO:0000105 ! log signal intensity ratio
 
 [Term]
@@ -21774,7 +21774,7 @@ is_a: MS:4000003 ! single value
 relationship: has_metric_category MS:4000009 ! ID free metric
 relationship: has_metric_category MS:4000012 ! single run based metric
 relationship: has_metric_category MS:4000021 ! MS1 metric
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
+relationship: has_value_type xsd:int ! The allowed value-type for this CV term
 relationship: has_units UO:0000189 ! count unit
 
 [Term]
@@ -21786,7 +21786,7 @@ is_a: MS:4000003 ! single value
 relationship: has_metric_category MS:4000009 ! ID free metric
 relationship: has_metric_category MS:4000012 ! single run based metric
 relationship: has_metric_category MS:4000022 ! MS2 metric
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
+relationship: has_value_type xsd:int ! The allowed value-type for this CV term
 relationship: has_units UO:0000189 ! count unit
 
 [Term]
@@ -21800,7 +21800,7 @@ is_a: MS:4000004 ! n-tuple
 relationship: has_metric_category MS:4000009 ! ID free metric
 relationship: has_metric_category MS:4000012 ! single run based metric
 relationship: has_metric_category MS:4000021 ! MS1 metric
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
+relationship: has_value_type xsd:int ! The allowed value-type for this CV term
 relationship: has_value_concept NCIT:C45781 ! Density
 relationship: has_units UO:0000189 ! count unit
 
@@ -21815,7 +21815,7 @@ is_a: MS:4000004 ! n-tuple
 relationship: has_metric_category MS:4000009 ! ID free metric
 relationship: has_metric_category MS:4000012 ! single run based metric
 relationship: has_metric_category MS:4000022 ! MS2 metric
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
+relationship: has_value_type xsd:int ! The allowed value-type for this CV term
 relationship: has_value_concept NCIT:C45781 ! Density
 relationship: has_units UO:0000189 ! count unit
 
@@ -21865,7 +21865,7 @@ is_a: MS:4000003 ! single value
 relationship: has_metric_category MS:4000009 ! ID free metric
 relationship: has_metric_category MS:4000012 ! single run based metric
 relationship: has_metric_category MS:4000021 ! MS1 metric
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 relationship: has_units UO:0000106 ! hertz
 
 [Term]
@@ -21878,7 +21878,7 @@ is_a: MS:4000003 ! single value
 relationship: has_metric_category MS:4000009 ! ID free metric
 relationship: has_metric_category MS:4000012 ! single run based metric
 relationship: has_metric_category MS:4000022 ! MS2 metric
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 relationship: has_units UO:0000106 ! hertz
 
 [Term]
@@ -21889,7 +21889,7 @@ is_a: MS:4000003 ! single value
 relationship: has_metric_category MS:4000009 ! ID free metric
 relationship: has_metric_category MS:4000012 ! single run based metric
 relationship: has_metric_category MS:4000019 ! MS metric
-relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 relationship: has_value_concept NCIT:C25330 ! Duration
 relationship: has_units UO:0000010 ! second
 
@@ -21936,7 +21936,7 @@ is_a: MS:4000003 ! single value
 relationship: has_metric_category MS:4000009 ! ID free metric
 relationship: has_metric_category MS:4000012 ! single run based metric
 relationship: has_metric_category MS:4000017 ! chromatogram metric
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
+relationship: has_value_type xsd:int ! The allowed value-type for this CV term
 relationship: has_units UO:0000189 ! count unit
 
 [Term]
@@ -22056,28 +22056,28 @@ id: MS:4000086
 name: mzQC input reference
 def: "Used to refer to data elements of input sections in mzQC, either inputFile names or metadata labels." [PSI:MS]
 is_a: MS:4000080 ! QC non-metric term
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:4000087
 name: mzQC plot label
 def: "Used to supply alternative labels for plotting figures." [PSI:MS]
 is_a: MS:4000080 ! QC non-metric term
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:4000088
 name: batch label
 def: "Used to supply batch label information with any string value." [PSI:MS]
 is_a: MS:4000080 ! QC non-metric term
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: MS:4000089
 name: injection sequence label
 def: "Used to supply injection sequence information with consecutive whole numbers." [PSI:MS]
 is_a: MS:4000080 ! QC non-metric term
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
+relationship: has_value_type xsd:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:4000090
@@ -22186,42 +22186,42 @@ id: PEFF:0000008
 name: DbName
 def: "PEFF keyword for the sequence database name." [PSI:PEFF]
 is_a: PEFF:0000002 ! PEFF file header section term
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0000009
 name: Prefix
 def: "PEFF keyword for the sequence database prefix." [PSI:PEFF]
 is_a: PEFF:0000002 ! PEFF file header section term
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0000010
 name: DbDescription
 def: "PEFF keyword for the sequence database short description." [PSI:PEFF]
 is_a: PEFF:0000002 ! PEFF file header section term
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0000011
 name: Decoy
 def: "PEFF keyword for the specifying whether the sequence database is a decoy database." [PSI:PEFF]
 is_a: PEFF:0000002 ! PEFF file header section term
-relationship: has_value_type xsd\:boolean ! The allowed value-type for this CV term
+relationship: has_value_type xsd:boolean ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0000012
 name: DbSource
 def: "PEFF keyword for the source of the database file." [PSI:PEFF]
 is_a: PEFF:0000002 ! PEFF file header section term
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0000013
 name: DbVersion
 def: "PEFF keyword for the database version (release date) according to database provider." [PSI:PEFF]
 is_a: PEFF:0000002 ! PEFF file header section term
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0000014
@@ -22236,14 +22236,14 @@ id: PEFF:0000015
 name: NumberOfEntries
 def: "PEFF keyword for the sumber of sequence entries in the database." [PSI:PEFF]
 is_a: PEFF:0000002 ! PEFF file header section term
-relationship: has_value_type xsd\:integer ! The allowed value-type for this CV term
+relationship: has_value_type xsd:integer ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0000016
 name: Conversion
 def: "PEFF keyword for the description of the conversion from original format to this current one." [PSI:PEFF]
 is_a: PEFF:0000002 ! PEFF file header section term
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0000017
@@ -22251,56 +22251,56 @@ name: SequenceType
 def: "PEFF keyword for the molecular type of the sequences." [PSI:PEFF]
 is_a: PEFF:0000002 ! PEFF file header section term
 relationship: has_regexp PEFF:1002002 ! regular expression for PEFF molecular sequence type
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0000018
 name: SpecificKey
 def: "PEFF keyword for database specific keywords not included in the current controlled vocabulary." [PSI:PEFF]
 is_a: PEFF:0000002 ! PEFF file header section term
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0000019
 name: SpecificValue
 def: "PEFF keyword for the specific values for a custom key." [PSI:PEFF]
 is_a: PEFF:0000002 ! PEFF file header section term
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0000020
 name: DatabaseDescription
 def: "PEFF keyword for the short description of the PEFF file." [PSI:PEFF]
 is_a: PEFF:0000002 ! PEFF file header section term
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0000021
 name: GeneralComment
 def: "PEFF keyword for a general comment." [PSI:PEFF]
 is_a: PEFF:0000002 ! PEFF file header section term
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0000022
 name: ProteoformDb
 def: "PEFF keyword that when set to 'true' indicates that the database contains complete proteoforms." [PSI:PEFF]
 is_a: PEFF:0000002 ! PEFF file header section term
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0000023
 name: OptionalTagDef
 def: "PEFF keyword for the short tag (abbreviation) and longer definition used to annotate a sequence annotation (such as variant or modification) in the OptionalTag location." [PSI:PEFF]
 is_a: PEFF:0000002 ! PEFF file header section term
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0000024
 name: HasAnnotationIdentifiers
 def: "PEFF keyword that when set to 'true' indicates that entries in the database have identifiers for each annotation." [PSI:PEFF]
 is_a: PEFF:0000002 ! PEFF file header section term
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0001001
@@ -22309,63 +22309,63 @@ def: "OBSOLETE Sequence database unique identifier." [PSI:PEFF]
 comment: This term was made obsolete because decided in Heidelberg 2018-04 that this is redundant.
 is_a: PEFF:0000003 ! PEFF file sequence entry term
 is_obsolete: true
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0001002
 name: PName
 def: "PEFF keyword for the protein full name." [PSI:PEFF]
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0001003
 name: NcbiTaxId
 def: "PEFF keyword for the NCBI taxonomy identifier." [PSI:PEFF]
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
+relationship: has_value_type xsd:int ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0001004
 name: TaxName
 def: "PEFF keyword for the taxonomy name (latin or common name)." [PSI:PEFF]
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0001005
 name: GName
 def: "PEFF keyword for the gene name." [PSI:PEFF]
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0001006
 name: Length
 def: "PEFF keyword for the sequence length." [PSI:PEFF]
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
+relationship: has_value_type xsd:int ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0001007
 name: SV
 def: "PEFF keyword for the sequence version." [PSI:PEFF]
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0001008
 name: EV
 def: "PEFF keyword for the entry version." [PSI:PEFF]
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0001009
 name: PE
 def: "PEFF keyword for the Protein Evidence; A UniProtKB code 1-5." [PSI:PEFF]
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
+relationship: has_value_type xsd:int ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0001010
@@ -22373,7 +22373,7 @@ name: Processed
 def: "PEFF keyword for information on how the full length original protein sequence can be processed into shorter components such as signal peptides and chains." [PSI:PEFF]
 is_a: PEFF:0000003 ! PEFF file sequence entry term
 relationship: has_regexp PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0001011
@@ -22383,7 +22383,7 @@ comment: This term was made obsolete in favor of VariantSimple and VariantComple
 is_a: PEFF:0000003 ! PEFF file sequence entry term
 relationship: has_regexp PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
 is_obsolete: true
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0001012
@@ -22391,7 +22391,7 @@ name: ModResPsi
 def: "PEFF keyword for the modified residue with PSI-MOD identifier." [PSI:PEFF]
 is_a: PEFF:0000003 ! PEFF file sequence entry term
 relationship: has_regexp PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0001013
@@ -22399,14 +22399,14 @@ name: ModRes
 def: "PEFF keyword for the modified residue without aPSI-MOD or UniMod identifier." [PSI:PEFF]
 is_a: PEFF:0000003 ! PEFF file sequence entry term
 relationship: has_regexp PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0001014
 name: AltAC
 def: "PEFF keyword for the Alternative Accession Code." [PSI:PEFF]
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0001015
@@ -22414,35 +22414,35 @@ name: SeqStatus
 def: "PEFF keyword for the sequence status. Complete or Fragment." [PSI:PEFF]
 is_a: PEFF:0000003 ! PEFF file sequence entry term
 relationship: has_regexp PEFF:1002003 ! regular expression for PEFF sequence status
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0001016
 name: CC
 def: "PEFF keyword for the entry associated comment." [PSI:PEFF]
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0001017
 name: KW
 def: "PEFF keyword for the entry associated keyword(s)." [PSI:PEFF]
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0001018
 name: GO
 def: "PEFF keyword for the Gene Ontology code." [PSI:PEFF]
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0001019
 name: XRef
 def: "PEFF keyword for the cross-reference to an external resource." [PSI:PEFF]
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0001020
@@ -22450,7 +22450,7 @@ name: mature protein
 def: "Portion of a newly synthesized protein that contributes to a final structure after other components such as signal peptides are removed." [PSI:PEFF]
 is_a: PEFF:0001032 ! PEFF molecule processing keyword
 relationship: has_regexp PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0001021
@@ -22458,7 +22458,7 @@ name: signal peptide
 def: "Short peptide present at the N-terminus of a newly synthesized protein that is cleaved off and is not part of the final mature protein." [PSI:PEFF]
 is_a: PEFF:0001032 ! PEFF molecule processing keyword
 relationship: has_regexp PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0001022
@@ -22466,7 +22466,7 @@ name: transit peptide
 def: "Short peptide present at the N-terminus of a newly synthesized protein that helps the protein through the membrane of its destination organelle." [PSI:PEFF]
 is_a: PEFF:0001032 ! PEFF molecule processing keyword
 relationship: has_regexp PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0001023
@@ -22474,28 +22474,28 @@ name: Conflict
 def: "PEFF keyword for the sequence conflict; a UniProtKB term." [PSI:PEFF]
 is_a: PEFF:0000003 ! PEFF file sequence entry term
 relationship: has_regexp PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0001024
 name: Crc64
 def: "PEFF keyword for the Sequence checksum in crc64." [PSI:PEFF]
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0001025
 name: Domain
 def: "PEFF keyword for the sequence range of a domain." [PSI:PEFF]
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0001026
 name: ID
 def: "PEFF keyword for the UniProtKB specific Protein identifier ID; a UniProtKB term." [PSI:PEFF]
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0001027
@@ -22503,7 +22503,7 @@ name: ModResUnimod
 def: "PEFF keyword for the modified residue with UniMod identifier." [PSI:PEFF]
 is_a: PEFF:0000003 ! PEFF file sequence entry term
 relationship: has_regexp PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0001028
@@ -22511,7 +22511,7 @@ name: VariantSimple
 def: "PEFF keyword for the simple sequence variation of a single amino acid change. A change to a stop codon is permitted with a * symbol. More complex variations must be encoded with the VariantComplex term." [PSI:PEFF]
 is_a: PEFF:0000003 ! PEFF file sequence entry term
 relationship: has_regexp PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0001029
@@ -22519,21 +22519,21 @@ name: VariantComplex
 def: "PEFF keyword for a sequence variation that is more complex than a single amino acid change or change to a stop codon." [PSI:PEFF]
 is_a: PEFF:0000003 ! PEFF file sequence entry term
 relationship: has_regexp PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0001030
 name: Proteoform
 def: "PEFF keyword for the proteoforms of this protein, constructed as a set of annotation identifiers." [PSI:PEFF]
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0001031
 name: DisulfideBond
 def: "PEFF keyword for the disulfide bonds in this protein, constructed as a sets of annotation identifiers of two half-cystine modifications." [PSI:PEFF]
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0001032
@@ -22546,7 +22546,7 @@ id: PEFF:0001033
 name: Comment
 def: "PEFF keyword for the individual protein entry comment. It is discouraged to put parsable information here. This is only for free-text commentary." [PSI:PEFF]
 is_a: PEFF:0000003 ! PEFF file sequence entry term
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0001034
@@ -22554,7 +22554,7 @@ name: propeptide
 def: "Short peptide that is cleaved off a newly synthesized protein and generally immediately degraded in the process of protein maturation, and is not a signal peptide or transit peptide." [PSI:PEFF]
 is_a: PEFF:0001032 ! PEFF molecule processing keyword
 relationship: has_regexp PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0001035
@@ -22562,7 +22562,7 @@ name: initiator methionine
 def: "N-terminal methionine residue of a protein that can be co-translationally cleaved." [PSI:PEFF]
 is_a: PEFF:0001032 ! PEFF molecule processing keyword
 relationship: has_regexp PEFF:1002001 ! regular expression for a value in a key-value pair of a PEFF description line describing one sequence position followed by one PEFF term name and one optional comment
-relationship: has_value_type xsd\:string ! The allowed value-type for this CV term
+relationship: has_value_type xsd:string ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:1002001


### PR DESCRIPTION
RE @chambm's comment on #130, this PR removes the colon escape from `xsd:` type declarations in relationships