### PR TITLE
distribution representation for various idfree metrics

### DIFF
--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -22663,9 +22663,7 @@ comment: The distribution of peak densities in MS1 can provide insight into the 
 is_a: MS:4000004 ! n-tuple
 relationship: has_metric_category MS:4000009 ! ID free metric
 relationship: has_metric_category MS:4000021 ! MS1 metric
-relationship: has_value_concept STATO:0000167 ! first quartile
-relationship: has_value_concept STATO:0000574 ! center value
-relationship: has_value_concept STATO:0000170 ! third quartile
+relationship: has_value_concept STATO:0000291 ! quantile
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 	
 [Term]
@@ -22777,9 +22775,7 @@ comment: The intensity distribution of the precursors informs about the dynamic 
 is_a: MS:4000004 ! n-tuple
 relationship: has_metric_category MS:4000009 ! ID free metric
 relationship: has_metric_category MS:4000022 ! MS2 metric
-relationship: has_value_concept STATO:0000167 ! first quartile
-relationship: has_value_concept STATO:0000574 ! center value
-relationship: has_value_concept STATO:0000170 ! third quartile
+relationship: has_value_concept STATO:0000291 ! quantile
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 relationship: has_units MS:1000043 ! intensity unit
 
@@ -22835,9 +22831,7 @@ comment: The Signal-to-noise ratio in MS1 distribution can provide insight to th
 is_a: MS:4000004 ! n-tuple
 relationship: has_metric_category MS:4000009 ! ID free metric
 relationship: has_metric_category MS:4000021 ! MS1 metric
-relationship: has_value_concept STATO:0000167 ! first quartile
-relationship: has_value_concept STATO:0000574 ! center value
-relationship: has_value_concept STATO:0000170 ! third quartile
+relationship: has_value_concept STATO:0000291 ! quantile
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
@@ -22892,9 +22886,7 @@ comment: A high signal-to-noise ratio in MS2 distribution can explain a high rat
 is_a: MS:4000004 ! n-tuple
 relationship: has_metric_category MS:4000009 ! ID free metric
 relationship: has_metric_category MS:4000022 ! MS2 metric
-relationship: has_value_concept STATO:0000167 ! first quartile
-relationship: has_value_concept STATO:0000574 ! center value
-relationship: has_value_concept STATO:0000170 ! third quartile
+relationship: has_value_concept STATO:0000291 ! quantile
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 	
 [Term]
@@ -22947,10 +22939,8 @@ name: MS1 ion collection time - quantiles
 def: "From the distribution of ion injection times (MS:1000927) for MS1, the quantiles. I.e. a value triplet represents the quartiles Q1, Q2, Q3" [PSI:MS]
 comment: Injection time distribution can be used to gauge the suitability of used instrument settings for the sample content used.
 is_a: MS:4000004 ! n-tuple
-relationship: has_value_concept STATO:0000167 ! first quartile
 relationship: has_metric_category MS:4000021 ! MS1 metric
-relationship: has_value_concept STATO:0000574 ! center value
-relationship: has_value_concept STATO:0000170 ! third quartile
+relationship: has_value_concept STATO:0000291 ! quantile
 relationship: has_units UO:0000028 ! millisecond
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
@@ -23010,9 +23000,7 @@ def: "From the distribution of ion injection times (MS:1000927) for MS2, the qua
 comment: Injection time distribution can be used to gauge the suitability of used instrument settings for the sample content used.
 is_a: MS:4000004 ! n-tuple
 relationship: has_metric_category MS:4000009 ! ID free metric
-relationship: has_value_concept STATO:0000167 ! first quartile
-relationship: has_value_concept STATO:0000574 ! center value
-relationship: has_value_concept STATO:0000170 ! third quartile
+relationship: has_value_concept STATO:0000291 ! quantile
 relationship: has_units UO:0000028 ! millisecond
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 	

--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -1,7 +1,7 @@
 format-version: 1.2
-data-version: 4.1.108
-date: 26:10:2022 11:38
-saved-by: Joshua Klein
+data-version: 4.1.110
+date: 09:12:2022 12:01
+saved-by: Mathias Walzer
 auto-generated-by: OBO-Edit 2.3.1
 import: http://purl.obolibrary.org/obo/pato.obo
 import: http://purl.obolibrary.org/obo/stato.owl
@@ -20682,7 +20682,7 @@ relationship: has_regexp MS:1002505 ! regular expression for modification locali
 [Term]
 id: MS:1003149
 name: PTMProphet normalized information content
-def: " PTMProphet-computed PSM-specific normalized (0.0 – 1.0) measure of information content across all modifications of a specific type." [DOI:10.1021/acs.jproteome.9b00205, PMID:31290668]
+def: " PTMProphet-computed PSM-specific normalized (0.0 - 1.0) measure of information content across all modifications of a specific type." [DOI:10.1021/acs.jproteome.9b00205, PMID:31290668]
 is_a: MS:1001968 ! PTM localization PSM-level statistic
 relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
 
@@ -21319,7 +21319,7 @@ is_a: MS:1003240 ! peak intensity transform
 [Term]
 id: MS:1003243
 name: adduct ion mass
-def: "The theoretical mass of the adduct ion (e.g. for a singly-charged protonated peptide ion, this value would be the neutral peptide molecule’s mass plus the mass of a proton)" [PSI:PI]
+def: "The theoretical mass of the adduct ion (e.g. for a singly-charged protonated peptide ion, this value would be the neutral peptide molecule's mass plus the mass of a proton)" [PSI:PI]
 is_a: MS:1003056 ! adduct ion property
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
@@ -22086,7 +22086,7 @@ relationship: has_units UO:0000010 ! second
 [Term]
 id: MS:4000054
 name: TIC quarters RT fraction
-def: "The interval when the respective quarter of the TIC accumulates divided by retention time duration." [PSI:QC]
+def: "The interval when the respective quarter of the TIC accumulates divided by retention time duration." [PSI:MS]
 synonym: "RT-TIC-Q1" RELATED [PMID:24494671]
 synonym: "RT-TIC-Q2" RELATED [PMID:24494671]
 synonym: "RT-TIC-Q3" RELATED [PMID:24494671]
@@ -22102,7 +22102,7 @@ relationship: has_units UO:0000191 ! fraction
 [Term]
 id: MS:4000055
 name: MS1 quarter RT fraction
-def: "The interval used for acquisition of the first, second, third, and fourth quarter of all MS1 events divided by retention time duration." [PSI:QC]
+def: "The interval used for acquisition of the first, second, third, and fourth quarter of all MS1 events divided by retention time duration." [PSI:MS]
 synonym: "RT-MS-Q1" RELATED [PMID:24494671]
 synonym: "RT-MS-Q2" RELATED [PMID:24494671]
 synonym: "RT-MS-Q3" RELATED [PMID:24494671]
@@ -22118,7 +22118,7 @@ relationship: has_units UO:0000191 ! fraction
 [Term]
 id: MS:4000056
 name: MS2 quarter RT fraction
-def: "The interval used for acquisition of the first, second, third, and fourth quarter of all MS2 events divided by retention time duration." [PSI:QC]
+def: "The interval used for acquisition of the first, second, third, and fourth quarter of all MS2 events divided by retention time duration." [PSI:MS]
 synonym: "RT-MSMS-Q1" RELATED [PMID:24494671]
 synonym: "RT-MSMS-Q2" RELATED [PMID:24494671]
 synonym: "RT-MSMS-Q3" RELATED [PMID:24494671]
@@ -22654,6 +22654,381 @@ relationship: has_metric_category MS:4000008 ! ID based metric
 relationship: has_metric_category MS:4000012 ! single run based metric
 relationship: has_value_type xsd:int ! The allowed value-type for this CV term
 relationship: has_units UO:0000189 ! count unit
+
+[Term]
+id: QC:4000108
+name: Peak density distribution MS1 Q1, Q2, Q3
+def: "From the distribution of peak densities in MS1, the quartiles Q1, Q2, Q3" [PSI:MS]
+comment: The distribution of peak densities in MS1 can provide insight into the presence of nuisance factors.
+is_a: MS:4000004 ! n-tuple
+relationship: has_metric_category MS:4000009 ! ID free metric
+relationship: has_value_concept STATO:0000167 ! first quartile
+relationship: has_value_concept STATO:0000574 ! center value
+relationship: has_value_concept STATO:0000170 ! third quartile
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
+	
+[Term]
+id: QC:4000158
+name: Peak density distribution MS1 mean
+def: "From the distribution of peak densities in MS1, the mean" [PSI:MS]
+comment: The distribution of peak densities in MS1 can provide insight into the presence of nuisance factors.
+is_a: MS:4000003 ! single value
+relationship: has_metric_category MS:4000009 ! ID free metric
+relationship: has_value_concept STATO:0000401 ! sample mean
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
+	
+[Term]
+id: QC:4000159
+name: Peak density distribution MS1 sigma
+def: "From the distribution of peak densities in MS1, the sigma value" [PSI:MS]
+comment: The distribution of peak densities in MS1 can provide insight into the presence of nuisance factors.
+is_a: MS:4000003 ! single value
+relationship: has_metric_category MS:4000009 ! ID free metric
+relationship: has_value_concept STATO:0000237 ! standard deviation
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
+	
+[Term]
+id: QC:4000160
+name: Peak density distribution MS1 low outliers (<Q1-1.5*IQR)
+def: "From the distribution of peak densities in MS1, the list of outliers below Q1-1.5*IQR" [PSI:MS]
+comment: The distribution of peak densities in MS1 can provide insight into the presence of nuisance factors.
+relationship: has_metric_category MS:4000009 ! ID free metric
+is_a: MS:4000004 ! n-tuple
+relationship: has_value_concept STATO:0000036 ! outlier
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
+
+[Term]
+id: QC:4000161
+name: Peak density distribution MS1 high outliers (>Q3+1.5*IQR)
+def: "From the distribution of peak densities in MS1, the list of outliers above Q3+1.5*IQR" [PSI:MS]
+comment: The distribution of peak densities in MS1 can provide insight into the presence of nuisance factors.
+is_a: MS:4000004 ! n-tuple
+relationship: has_metric_category MS:4000009 ! ID free metric
+relationship: has_value_concept STATO:0000036 ! outlier
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
+
+[Term]
+id: QC:4000162
+name: Peak density distribution MS2 Q1, Q2, Q3
+def: "From the distribution of peak densities in MS2, the quartiles Q1, Q2, Q3" [PSI:MS]
+comment: The distribution of peak densities in MS2 can provide insight into the instruments ion selction settings.
+is_a: MS:4000004 ! n-tuple
+relationship: has_metric_category MS:4000009 ! ID free metric
+relationship: has_type STATO:0000167 ! first quartile
+relationship: has_type STATO:0000574 ! center value
+relationship: has_type STATO:0000170 ! third quartile
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
+	
+[Term]
+id: QC:4000163
+name: Peak density distribution MS2 mean
+def: "From the distribution of peak densities in MS2, the mean" [PSI:MS]
+comment: The distribution of peak densities in MS2 can provide insight into the instruments ion selction settings.
+is_a: MS:4000003 ! single value
+relationship: has_metric_category MS:4000009 ! ID free metric
+relationship: has_value_concept STATO:0000401 ! sample mean
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
+	
+[Term]
+id: QC:4000164
+name: Peak density distribution MS2 sigma
+def: "From the distribution of peak densities in MS2, the sigma value" [PSI:MS]
+comment: The distribution of peak densities in MS2 can provide insight into the instruments ion selction settings.
+is_a: MS:4000003 ! single value
+relationship: has_metric_category MS:4000009 ! ID free metric
+relationship: has_value_concept STATO:0000237 ! standard deviation
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
+	
+[Term]
+id: QC:4000165
+name: Peak density distribution MS2 low outliers (<Q1-1.5*IQR)
+def: "From the distribution of peak densities in MS2, the list of outliers below Q1-1.5*IQR" [PSI:MS]
+comment: The distribution of peak densities in MS2 can provide insight into the instruments ion selction settings.
+is_a: MS:4000004 ! n-tuple
+relationship: has_metric_category MS:4000009 ! ID free metric
+relationship: has_value_concept STATO:0000036 ! outlier
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
+
+[Term]
+id: QC:4000166
+name: Peak density distribution MS2 high outliers (>Q3+1.5*IQR)
+def: "From the distribution of peak densities in MS2, the list of outliers above Q3+1.5*IQR" [PSI:MS]
+comment: The distribution of peak densities in MS2 can provide insight into the instruments ion selction settings.
+is_a: MS:4000004 ! n-tuple
+relationship: has_metric_category MS:4000009 ! ID free metric
+relationship: has_value_concept STATO:0000036 ! outlier
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
+
+[Term]
+id: QC:4000167
+name: Precursor intensity distribution Q1, Q2, Q3
+def: "From the distribution of precursor intensities, the quartiles Q1, Q2, Q3" [PSI:MS]
+comment: The intensity distribution of the precursors informs about the dynamic range of the acquisition.
+is_a: MS:4000004 ! n-tuple
+relationship: has_metric_category MS:4000009 ! ID free metric
+relationship: has_value_concept STATO:0000167 ! first quartile
+relationship: has_value_concept STATO:0000574 ! center value
+relationship: has_value_concept STATO:0000170 ! third quartile
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
+	
+[Term]
+id: QC:4000168
+name: Precursor intensity distribution mean
+def: "From the distribution of precursor intensities, the mean" [PSI:MS]
+comment: The intensity distribution of the precursors informs about the dynamic range of the acquisition.
+is_a: MS:4000003 ! single value
+relationship: has_metric_category MS:4000009 ! ID free metric
+relationship: has_value_concept STATO:0000401 ! sample mean
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
+	
+[Term]
+id: QC:4000169
+name: Precursor intensity distribution sigma
+def: "From the distribution of precursor intensities, the sigma value" [PSI:MS]
+comment: The intensity distribution of the precursors informs about the dynamic range of the acquisition.
+is_a: MS:4000003 ! single value
+relationship: has_metric_category MS:4000009 ! ID free metric
+relationship: has_value_concept STATO:0000237 ! standard deviation
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
+	
+[Term]
+id: QC:4000170
+name: Precursor intensity distribution low outliers (<Q1-1.5*IQR)
+def: "From the distribution of precursor intensities, the list of outliers below Q1-1.5*IQR" [PSI:MS]
+comment: The intensity distribution of the precursors informs about the dynamic range of the acquisition.
+is_a: MS:4000004 ! n-tuple
+relationship: has_metric_category MS:4000009 ! ID free metric
+relationship: has_value_concept STATO:0000036 ! outlier
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
+
+[Term]
+id: QC:4000171
+name: Precursor intensity distribution high outliers (>Q3+1.5*IQR)
+def: "From the distribution of precursor intensities, the list of outliers above Q3+1.5*IQR" [PSI:MS]
+comment: The intensity distribution of the precursors informs about the dynamic range of the acquisition.
+is_a: MS:4000004 ! n-tuple
+relationship: has_metric_category MS:4000009 ! ID free metric
+relationship: has_value_concept STATO:0000036 ! outlier
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
+
+[Term]
+id: QC:4000218
+name: Signal-to-noise ratio in MS1 - Q1, Q2, Q3
+def: "From the distribution of signal-to-noise ratio in MS1, the quartiles Q1, Q2, Q3 value" [PSI:MS]
+comment: The Signal-to-noise ratio in MS1 distribution can provide insight to the presence of nuisance factors.
+is_a: MS:4000004 ! n-tuple
+relationship: has_metric_category MS:4000009 ! ID free metric
+relationship: has_value_concept STATO:0000167 ! first quartile
+relationship: has_value_concept STATO:0000574 ! center value
+relationship: has_value_concept STATO:0000170 ! third quartile
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
+	
+[Term]
+id: QC:4000219
+name: Signal-to-noise ratio in MS1 - mean
+comment: The signal-to-noise ratio in MS1 distribution can provide insight into the presence of nuisance factors. Comparisons will likely only make local sense where the same method of S/N calculation is applied (or overall the same software to calculate this metric, see mzQC 'analysisSoftware').
+def: "From the distribution of signal-to-noise ratio in MS1, the mean" [PSI:MS]
+is_a: MS:4000003 ! single value
+relationship: has_metric_category MS:4000009 ! ID free metric
+relationship: has_value_concept STATO:0000401 ! sample mean
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
+	
+[Term]
+id: QC:4000220
+name: Signal-to-noise ratio in MS1 - sigma
+def: "From the distribution of signal-to-noise ratio in MS1, the sigma value" [PSI:MS]
+comment: The Signal-to-noise ratio in MS1 distribution can provide insight into the presence of nuisance factors. Comparisons will likely only make local sense where the same method of S/N calculation is applied (or overall the same software to calculate this metric, see mzQC 'analysisSoftware').
+is_a: MS:4000003 ! single value
+relationship: has_metric_category MS:4000009 ! ID free metric
+relationship: has_value_concept STATO:0000237 ! standard deviation
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
+	
+[Term]
+id: QC:4000221
+name: Signal-to-noise ratio in MS1 - low outliers (<Q1-1.5*IQR)
+def: "From the distribution of signal-to-noise ratio in MS1, the list of outliers below Q1-1.5IQR" [PSI:MS]
+comment: The Signal-to-noise ratio in MS1 distribution can provide insight into the presence of nuisance factors. Comparisons will likely only make local sense where the same method of S/N calculation is applied (or overall the same software to calculate this metric, see mzQC 'analysisSoftware').
+is_a: MS:4000004 ! n-tuple
+relationship: has_metric_category MS:4000009 ! ID free metric
+relationship: has_value_concept STATO:0000036 ! outlier
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
+
+[Term]
+id: QC:4000222
+name: Signal-to-noise ratio in MS1 - high outliers (>Q3+1.5*IQR)
+def: "From the distribution of signal-to-noise ratio in MS1, the list of outliers above Q3+1.5IQR" [PSI:MS]
+comment: The Signal-to-noise ratio in MS1 distribution can provide insight into the presence of nuisance factors. Comparisons will likely only make local sense where the same method of S/N calculation is applied (or overall the same software to calculate this metric, see mzQC 'analysisSoftware').
+is_a: MS:4000004 ! n-tuple
+relationship: has_metric_category MS:4000009 ! ID free metric
+relationship: has_value_concept STATO:0000036 ! outlier
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
+
+[Term]
+id: QC:4000223
+name: Signal-to-noise ratio in MS2 - Q1, Q2, Q3
+def: "From the distribution of signal-to-noise ratio in MS2, the quartiles Q1, Q2, Q3 value" [PSI:MS]
+comment: A high signal-to-noise ratio in MS2 distribution can explain a high rate of unidentified spectra. Comparisons will likely only make local sense where the same method of S/N calculation is applied (or overall the same software to calculate this metric, see mzQC 'analysisSoftware').
+is_a: MS:4000004 ! n-tuple
+relationship: has_metric_category MS:4000009 ! ID free metric
+relationship: has_value_concept STATO:0000167 ! first quartile
+relationship: has_value_concept STATO:0000574 ! center value
+relationship: has_value_concept STATO:0000170 ! third quartile
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
+	
+[Term]
+id: QC:4000224
+name: Signal-to-noise ratio in MS2 - mean
+def: "From the distribution of signal-to-noise ratio in MS2, the mean" [PSI:MS]
+comment: A high signal-to-noise ratio in MS2 distribution can explain a high rate of unidentified spectra. Comparisons will likely only make local sense where the same method of S/N calculation is applied (or overall the same software to calculate this metric, see mzQC 'analysisSoftware').
+is_a: MS:4000003 ! single value
+relationship: has_metric_category MS:4000009 ! ID free metric
+relationship: has_value_concept STATO:0000401 ! sample mean
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
+	
+[Term]
+id: QC:4000225
+name: Signal-to-noise ratio in MS2 - sigma
+def: "From the distribution of signal-to-noise ratio in MS2, the sigma value" [PSI:MS]
+comment: A high signal-to-noise ratio in MS2 distribution can explain a high rate of unidentified spectra. Comparisons will likely only make local sense where the same method of S/N calculation is applied (or overall the same software to calculate this metric, see mzQC 'analysisSoftware').
+is_a: MS:4000003 ! single value
+relationship: has_metric_category MS:4000009 ! ID free metric
+relationship: has_value_concept STATO:0000237 ! standard deviation
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
+	
+[Term]
+id: QC:4000226
+name: Signal-to-noise ratio in MS2 - low outliers (<Q1-1.5*IQR)
+def: "From the distribution of signal-to-noise ratio in MS2, the list of outliers below Q1-1.5IQR" [PSI:MS]
+comment: A high signal-to-noise ratio in MS2 distribution can explain a high rate of unidentified spectra. Comparisons will likely only make local sense where the same method of S/N calculation is applied (or overall the same software to calculate this metric, see mzQC 'analysisSoftware').
+is_a: MS:4000004 ! n-tuple
+relationship: has_metric_category MS:4000009 ! ID free metric
+relationship: has_value_concept STATO:0000036 ! outlier
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
+
+[Term]
+id: QC:4000227
+name: Signal-to-noise ratio in MS2 - high outliers (>Q3+1.5*IQR)
+def: "From the distribution of signal-to-noise ratio in MS2, the list of outliers above Q3+1.5IQR" [PSI:MS]
+comment: A high signal-to-noise ratio in MS2 distribution can explain a high rate of unidentified spectra. Comparisons will likely only make local sense where the same method of S/N calculation is applied (or overall the same software to calculate this metric, see mzQC 'analysisSoftware').
+is_a: MS:4000004 ! n-tuple
+relationship: has_metric_category MS:4000009 ! ID free metric
+relationship: has_value_concept STATO:0000036 ! outlier
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
+
+[Term]
+id: QC:4000147
+name: MS1 ion collection time Q1, Q2, Q3
+def: "From the distribution of ion injection times (MS:1000927) for MS1, the quartiles Q1, Q2, Q3" [PSI:MS]
+comment: Injection time distribution can be used to gauge the suitability of used instrument settings for the sample content used.
+is_a: MS:4000004 ! n-tuple
+relationship: has_value_concept STATO:0000167 ! first quartile
+relationship: has_value_concept STATO:0000574 ! center value
+relationship: has_value_concept STATO:0000170 ! third quartile
+relationship: has_units UO:0000028 ! millisecond
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
+
+[Term]
+id: QC:4000148
+name: MS1 ion collection time mean
+def: "From the distribution of ion injection times (MS:1000927) for MS1, the mean" [PSI:MS]
+comment: Injection time distribution can be used to gauge the suitability of used instrument settings for the sample content used.
+is_a: MS:4000003 ! single value
+relationship: has_metric_category MS:4000009 ! ID free metric
+relationship: has_value_concept STATO:0000401 ! sample mean
+relationship: has_units UO:0000028 ! millisecond
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
+	
+[Term]
+id: QC:4000149
+name: MS1 ion collection time sigma
+def: "From the distribution of ion injection times (MS:1000927) for MS1, the sigma value" [PSI:MS]
+comment: Injection time distribution can be used to gauge the suitability of used instrument settings for the sample content used.
+is_a: MS:4000003 ! single value
+relationship: has_metric_category MS:4000009 ! ID free metric
+relationship: has_value_concept STATO:0000237 ! standard deviation
+relationship: has_units UO:0000028 ! millisecond
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
+	
+[Term]
+id: QC:4000150
+name: MS1 ion collection time low outliers (<Q1-1.5*IQR)
+def: "From the distribution of ion injection times (MS:1000927) for MS1, the list of outliers below Q1-1.5*IQR" [PSI:MS]
+comment: Injection time distribution can be used to gauge the suitability of used instrument settings for the sample content used.
+is_a: MS:4000004 ! n-tuple
+relationship: has_metric_category MS:4000009 ! ID free metric
+relationship: has_value_concept STATO:0000036 ! outlier
+relationship: has_units UO:0000028 ! millisecond
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
+
+
+[Term]
+id: QC:4000151
+name: MS1 ion collection time high outliers (>Q3+1.5*IQR)
+def: "From the distribution of ion injection times (MS:1000927) for MS1, the list of outliers above Q3+1.5*IQR" [PSI:MS]
+comment: Injection time distribution can be used to gauge the suitability of used instrument settings for the sample content used.
+is_a: MS:4000004 ! n-tuple
+relationship: has_metric_category MS:4000009 ! ID free metric
+relationship: has_value_concept STATO:0000036 ! outlier
+relationship: has_units UO:0000028 ! millisecond
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
+
+[Term]
+id: QC:4000152
+name: MS2 ion collection time Q1, Q2, Q3
+def: "From the distribution of ion injection times (MS:1000927) for MS2, the quartiles Q1, Q2, Q3" [PSI:MS]
+comment: Injection time distribution can be used to gauge the suitability of used instrument settings for the sample content used.
+is_a: MS:4000004 ! n-tuple
+relationship: has_metric_category MS:4000009 ! ID free metric
+relationship: has_value_concept STATO:0000167 ! first quartile
+relationship: has_value_concept STATO:0000574 ! center value
+relationship: has_value_concept STATO:0000170 ! third quartile
+relationship: has_units UO:0000028 ! millisecond
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
+	
+[Term]
+id: QC:4000153
+name: MS2 ion collection time mean
+def: "From the distribution of ion injection times (MS:1000927) for MS2, the mean" [PSI:MS]
+comment: Injection time distribution can be used to gauge the suitability of used instrument settings for the sample content used.
+is_a: MS:4000003 ! single value
+relationship: has_metric_category MS:4000009 ! ID free metric
+relationship: has_value_concept STATO:0000401 ! sample mean
+relationship: has_units UO:0000028 ! millisecond
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
+	
+[Term]
+id: QC:4000154
+name: MS2 ion collection time sigma
+def: "From the distribution of ion injection times (MS:1000927) for MS2, the sigma value" [PSI:MS]
+comment: Injection time distribution can be used to gauge the suitability of used instrument settings for the sample content used.
+is_a: MS:4000003 ! single value
+relationship: has_metric_category MS:4000009 ! ID free metric
+relationship: has_value_concept STATO:0000237 ! standard deviation
+relationship: has_units UO:0000028 ! millisecond
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
+	
+[Term]
+id: QC:4000155
+name: MS2 ion collection time low outliers (<Q1-1.5*IQR)
+def: "From the distribution of ion injection times (MS:1000927) for MS2, the list of outliers below Q1-1.5*IQR" [PSI:MS]
+comment: Injection time distribution can be used to gauge the suitability of used instrument settings for the sample content used.
+is_a: MS:4000004 ! n-tuple
+relationship: has_metric_category MS:4000009 ! ID free metric
+relationship: has_value_concept STATO:0000036 ! outlier
+relationship: has_units UO:0000028 ! millisecond
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
+
+
+[Term]
+id: QC:4000156
+name: MS2 ion collection time high outliers (>Q3+1.5*IQR)
+def: "From the distribution of ion injection times (MS:1000927) for MS2, the list of outliers above Q3+1.5*IQR" [PSI:MS]
+comment: Injection time distribution can be used to gauge the suitability of used instrument settings for the sample content used.
+is_a: MS:4000004 ! n-tuple
+relationship: has_metric_category MS:4000009 ! ID free metric
+relationship: has_value_concept STATO:0000036 ! outlier
+relationship: has_units UO:0000028 ! millisecond
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0000001
@@ -23603,4 +23978,3 @@ synonym: "A^[2]" RELATED []
 is_a: UO:0000047
 created_by: gkoutos
 creation_date: 2013-06-27T05:06:40Z
-

--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -22657,8 +22657,8 @@ relationship: has_units UO:0000189 ! count unit
 
 [Term]
 id: MS:4000108
-name: MS1 peak density distribution - Q1, Q2, Q3
-def: "From the distribution of peak densities in MS1, the quartiles Q1, Q2, Q3" [PSI:MS]
+name: MS1 peak density distribution - quantiles
+def: "From the distribution of peak densities in MS1, the quantiles. I.e. a value triplet represents the quartiles Q1, Q2, Q3" [PSI:MS]
 comment: The distribution of peak densities in MS1 can provide insight into the presence of nuisance factors.
 is_a: MS:4000004 ! n-tuple
 relationship: has_metric_category MS:4000009 ! ID free metric
@@ -22714,8 +22714,8 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:4000113
-name: MS2 peak density distribution - Q1, Q2, Q3
-def: "From the distribution of peak densities in MS2, the quartiles Q1, Q2, Q3" [PSI:MS]
+name: MS2 peak density distribution - quantiles
+def: "From the distribution of peak densities in MS2, the quantiles. I.e. a value triplet represents the quartiles Q1, Q2, Q3" [PSI:MS]
 comment: The distribution of peak densities in MS2 can provide insight into the instruments ion selection settings.
 is_a: MS:4000004 ! n-tuple
 relationship: has_metric_category MS:4000009 ! ID free metric
@@ -22771,8 +22771,8 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:4000118
-name: precursor intensity distribution - Q1, Q2, Q3
-def: "From the distribution of precursor intensities, the quartiles Q1, Q2, Q3" [PSI:MS]
+name: precursor intensity distribution - quantiles
+def: "From the distribution of precursor intensities, the quantiles. I.e. a value triplet represents the quartiles Q1, Q2, Q3" [PSI:MS]
 comment: The intensity distribution of the precursors informs about the dynamic range of the acquisition.
 is_a: MS:4000004 ! n-tuple
 relationship: has_metric_category MS:4000009 ! ID free metric
@@ -22829,8 +22829,8 @@ relationship: has_units MS:1000043 ! intensity unit
 
 [Term]
 id: MS:4000123
-name: MS1 signal-to-noise ratio - Q1, Q2, Q3
-def: "From the distribution of signal-to-noise ratio in MS1, the quartiles Q1, Q2, Q3 value" [PSI:MS]
+name: MS1 signal-to-noise ratio - quantiles
+def: "From the distribution of signal-to-noise ratio in MS1, the quantiles. I.e. a value triplet represents the quartiles Q1, Q2, Q3" [PSI:MS]
 comment: The Signal-to-noise ratio in MS1 distribution can provide insight to the presence of nuisance factors.
 is_a: MS:4000004 ! n-tuple
 relationship: has_metric_category MS:4000009 ! ID free metric
@@ -22886,8 +22886,8 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:4000128
-name: signal-to-noise ratio in MS2 - Q1, Q2, Q3
-def: "From the distribution of signal-to-noise ratio in MS2, the quartiles Q1, Q2, Q3 value" [PSI:MS]
+name: signal-to-noise ratio in MS2 - quantiles
+def: "From the distribution of signal-to-noise ratio in MS2, the quantiles. I.e. a value triplet represents the quartiles Q1, Q2, Q3" [PSI:MS]
 comment: A high signal-to-noise ratio in MS2 distribution can explain a high rate of unidentified spectra. Comparisons will likely only make local sense where the same method of S/N calculation is applied (or overall the same software to calculate this metric, see mzQC 'analysisSoftware').
 is_a: MS:4000004 ! n-tuple
 relationship: has_metric_category MS:4000009 ! ID free metric
@@ -22943,8 +22943,8 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:4000133
-name: MS1 ion collection time - Q1, Q2, Q3
-def: "From the distribution of ion injection times (MS:1000927) for MS1, the quartiles Q1, Q2, Q3" [PSI:MS]
+name: MS1 ion collection time - quantiles
+def: "From the distribution of ion injection times (MS:1000927) for MS1, the quantiles. I.e. a value triplet represents the quartiles Q1, Q2, Q3" [PSI:MS]
 comment: Injection time distribution can be used to gauge the suitability of used instrument settings for the sample content used.
 is_a: MS:4000004 ! n-tuple
 relationship: has_value_concept STATO:0000167 ! first quartile
@@ -23005,8 +23005,8 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:4000138
-name: MS2 ion collection time - Q1, Q2, Q3
-def: "From the distribution of ion injection times (MS:1000927) for MS2, the quartiles Q1, Q2, Q3" [PSI:MS]
+name: MS2 ion collection time - quantiles
+def: "From the distribution of ion injection times (MS:1000927) for MS2, the quantiles. I.e. a value triplet represents the quartiles Q1, Q2, Q3" [PSI:MS]
 comment: Injection time distribution can be used to gauge the suitability of used instrument settings for the sample content used.
 is_a: MS:4000004 ! n-tuple
 relationship: has_metric_category MS:4000009 ! ID free metric

--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -22660,7 +22660,7 @@ relationship: has_value_type xsd:int ! The allowed value-type for this CV term
 relationship: has_units UO:0000189 ! count unit
 
 [Term]
-id: MS:4000109
+id: MS:4000108
 name: MS1 peak density distribution - mean
 def: "From the distribution of peak densities in MS1, the mean" [PSI:MS]
 comment: The distribution of peak densities in MS1 can provide insight into the presence of nuisance factors.
@@ -22671,7 +22671,7 @@ relationship: has_value_concept STATO:0000401 ! sample mean
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 	
 [Term]
-id: MS:4000110
+id: MS:4000109
 name: MS1 peak density distribution - sigma
 def: "From the distribution of peak densities in MS1, the sigma value" [PSI:MS]
 comment: The distribution of peak densities in MS1 can provide insight into the presence of nuisance factors.
@@ -22682,7 +22682,7 @@ relationship: has_value_concept STATO:0000237 ! standard deviation
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 	
 [Term]
-id: MS:4000111
+id: MS:4000110
 name: MS1 peak density distribution - low outliers
 def: "From the distribution of peak densities in MS1, the list of outliers below a in-file defined threshold" [PSI:MS]
 comment: The distribution of peak densities in MS1 can provide insight into the presence of nuisance factors.
@@ -22693,7 +22693,7 @@ relationship: has_value_concept STATO:0000036 ! outlier
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
-id: MS:4000112
+id: MS:4000111
 name: MS1 peak density distribution - high outliers
 def: "From the distribution of peak densities in MS1, the list of outliers above a in-file defined threshold" [PSI:MS]
 comment: The distribution of peak densities in MS1 can provide insight into the presence of nuisance factors.
@@ -22704,7 +22704,7 @@ relationship: has_value_concept STATO:0000036 ! outlier
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
-id: MS:4000114
+id: MS:4000112
 name: MS2 peak density distribution - mean
 def: "From the distribution of peak densities in MS2, the mean" [PSI:MS]
 comment: The distribution of peak densities in MS2 can provide insight into the instruments ion selection settings.
@@ -22715,7 +22715,7 @@ relationship: has_value_concept STATO:0000401 ! sample mean
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 	
 [Term]
-id: MS:4000115
+id: MS:4000113
 name: MS2 peak density distribution - sigma
 def: "From the distribution of peak densities in MS2, the sigma value" [PSI:MS]
 comment: The distribution of peak densities in MS2 can provide insight into the instruments ion selection settings.
@@ -22726,7 +22726,7 @@ relationship: has_value_concept STATO:0000237 ! standard deviation
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 	
 [Term]
-id: MS:4000116
+id: MS:4000114
 name: MS2 peak density distribution - low outliers
 def: "From the distribution of peak densities in MS2, the list of outliers below a in-file defined threshold" [PSI:MS]
 comment: The distribution of peak densities in MS2 can provide insight into the instruments ion selection settings.
@@ -22737,7 +22737,7 @@ relationship: has_value_concept STATO:0000036 ! outlier
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
-id: MS:4000117
+id: MS:4000115
 name: MS2 peak density distribution - high outliers
 def: "From the distribution of peak densities in MS2, the list of outliers above a in-file defined threshold" [PSI:MS]
 comment: The distribution of peak densities in MS2 can provide insight into the instruments ion selection settings.
@@ -22748,7 +22748,7 @@ relationship: has_value_concept STATO:0000036 ! outlier
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
-id: MS:4000118
+id: MS:4000116
 name: precursor intensity distribution - quantiles
 def: "From the distribution of precursor intensities, the quantiles. I.e. a value triplet represents the quartiles Q1, Q2, Q3" [PSI:MS]
 comment: The intensity distribution of the precursors informs about the dynamic range of the acquisition.
@@ -22760,7 +22760,7 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 relationship: has_units MS:1000043 ! intensity unit
 
 [Term]
-id: MS:4000119
+id: MS:4000117
 name: precursor intensity distribution - mean
 def: "From the distribution of precursor intensities, the mean" [PSI:MS]
 comment: The intensity distribution of the precursors informs about the dynamic range of the acquisition.
@@ -22771,7 +22771,7 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 relationship: has_units MS:1000043 ! intensity unit
 
 [Term]
-id: MS:4000120
+id: MS:4000118
 name: precursor intensity distribution - sigma
 def: "From the distribution of precursor intensities, the sigma value" [PSI:MS]
 comment: The intensity distribution of the precursors informs about the dynamic range of the acquisition.
@@ -22782,7 +22782,7 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 relationship: has_units MS:1000043 ! intensity unit
 	
 [Term]
-id: MS:4000121
+id: MS:4000119
 name: precursor intensity distribution - low outliers
 def: "From the distribution of precursor intensities, the list of outliers below a in-file defined threshold" [PSI:MS]
 comment: The intensity distribution of the precursors informs about the dynamic range of the acquisition.
@@ -22793,7 +22793,7 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 relationship: has_units MS:1000043 ! intensity unit
 
 [Term]
-id: MS:4000122
+id: MS:4000120
 name: precursor intensity distribution - high outliers
 def: "From the distribution of precursor intensities, the list of outliers above a in-file defined threshold" [PSI:MS]
 comment: The intensity distribution of the precursors informs about the dynamic range of the acquisition.
@@ -22804,7 +22804,7 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 relationship: has_units MS:1000043 ! intensity unit
 
 [Term]
-id: MS:4000123
+id: MS:4000121
 name: MS1 signal-to-noise ratio - quantiles
 def: "From the distribution of signal-to-noise ratio in MS1, the quantiles. I.e. a value triplet represents the quartiles Q1, Q2, Q3" [PSI:MS]
 comment: The Signal-to-noise ratio in MS1 distribution can provide insight to the presence of nuisance factors.
@@ -22815,7 +22815,7 @@ relationship: has_value_concept STATO:0000291 ! quantile
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
-id: MS:4000124
+id: MS:4000122
 name: MS1 signal-to-noise ratio - mean
 comment: The signal-to-noise ratio in MS1 distribution can provide insight into the presence of nuisance factors. Comparisons will likely only make local sense where the same method of S/N calculation is applied (or overall the same software to calculate this metric, see mzQC 'analysisSoftware').
 def: "From the distribution of signal-to-noise ratio in MS1, the mean" [PSI:MS]
@@ -22826,7 +22826,7 @@ relationship: has_value_concept STATO:0000401 ! sample mean
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 	
 [Term]
-id: MS:4000125
+id: MS:4000123
 name: MS1 signal-to-noise ratio - sigma
 def: "From the distribution of signal-to-noise ratio in MS1, the sigma value" [PSI:MS]
 comment: The Signal-to-noise ratio in MS1 distribution can provide insight into the presence of nuisance factors. Comparisons will likely only make local sense where the same method of S/N calculation is applied (or overall the same software to calculate this metric, see mzQC 'analysisSoftware').
@@ -22837,7 +22837,7 @@ relationship: has_value_concept STATO:0000237 ! standard deviation
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 	
 [Term]
-id: MS:4000126
+id: MS:4000124
 name: MS1 signal-to-noise ratio - low outliers
 def: "From the distribution of signal-to-noise ratio in MS1, the list of outliers below Q1-1.5IQR" [PSI:MS]
 comment: The Signal-to-noise ratio in MS1 distribution can provide insight into the presence of nuisance factors. Comparisons will likely only make local sense where the same method of S/N calculation is applied (or overall the same software to calculate this metric, see mzQC 'analysisSoftware').
@@ -22848,7 +22848,7 @@ relationship: has_value_concept STATO:0000036 ! outlier
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
-id: MS:4000127
+id: MS:4000125
 name: MS1 signal-to-noise ratio - high outliers
 def: "From the distribution of signal-to-noise ratio in MS1, the list of outliers above Q3+1.5IQR" [PSI:MS]
 comment: The Signal-to-noise ratio in MS1 distribution can provide insight into the presence of nuisance factors. Comparisons will likely only make local sense where the same method of S/N calculation is applied (or overall the same software to calculate this metric, see mzQC 'analysisSoftware').
@@ -22859,7 +22859,7 @@ relationship: has_value_concept STATO:0000036 ! outlier
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
-id: MS:4000128
+id: MS:4000126
 name: signal-to-noise ratio in MS2 - quantiles
 def: "From the distribution of signal-to-noise ratio in MS2, the quantiles. I.e. a value triplet represents the quartiles Q1, Q2, Q3" [PSI:MS]
 comment: A high signal-to-noise ratio in MS2 distribution can explain a high rate of unidentified spectra. Comparisons will likely only make local sense where the same method of S/N calculation is applied (or overall the same software to calculate this metric, see mzQC 'analysisSoftware').
@@ -22870,7 +22870,7 @@ relationship: has_value_concept STATO:0000291 ! quantile
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 	
 [Term]
-id: MS:4000129
+id: MS:4000127
 name: signal-to-noise ratio in MS2 - mean
 def: "From the distribution of signal-to-noise ratio in MS2, the mean" [PSI:MS]
 comment: A high signal-to-noise ratio in MS2 distribution can explain a high rate of unidentified spectra. Comparisons will likely only make local sense where the same method of S/N calculation is applied (or overall the same software to calculate this metric, see mzQC 'analysisSoftware').
@@ -22881,7 +22881,7 @@ relationship: has_value_concept STATO:0000401 ! sample mean
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 	
 [Term]
-id: MS:4000130
+id: MS:4000128
 name: signal-to-noise ratio in MS2 - sigma
 def: "From the distribution of signal-to-noise ratio in MS2, the sigma value" [PSI:MS]
 comment: A high signal-to-noise ratio in MS2 distribution can explain a high rate of unidentified spectra. Comparisons will likely only make local sense where the same method of S/N calculation is applied (or overall the same software to calculate this metric, see mzQC 'analysisSoftware').
@@ -22892,7 +22892,7 @@ relationship: has_value_concept STATO:0000237 ! standard deviation
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 	
 [Term]
-id: MS:4000131
+id: MS:4000129
 name: signal-to-noise ratio in MS2 - low outliers
 def: "From the distribution of signal-to-noise ratio in MS2, the list of outliers below Q1-1.5IQR" [PSI:MS]
 comment: A high signal-to-noise ratio in MS2 distribution can explain a high rate of unidentified spectra. Comparisons will likely only make local sense where the same method of S/N calculation is applied (or overall the same software to calculate this metric, see mzQC 'analysisSoftware').
@@ -22903,7 +22903,7 @@ relationship: has_value_concept STATO:0000036 ! outlier
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
-id: MS:4000132
+id: MS:4000130
 name: signal-to-noise ratio in MS2 - high outliers
 def: "From the distribution of signal-to-noise ratio in MS2, the list of outliers above Q3+1.5IQR" [PSI:MS]
 comment: A high signal-to-noise ratio in MS2 distribution can explain a high rate of unidentified spectra. Comparisons will likely only make local sense where the same method of S/N calculation is applied (or overall the same software to calculate this metric, see mzQC 'analysisSoftware').
@@ -22914,7 +22914,7 @@ relationship: has_value_concept STATO:0000036 ! outlier
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
-id: MS:4000133
+id: MS:4000131
 name: MS1 ion collection time - quantiles
 def: "From the distribution of ion injection times (MS:1000927) for MS1, the quantiles. I.e. a value triplet represents the quartiles Q1, Q2, Q3" [PSI:MS]
 comment: Injection time distribution can be used to gauge the suitability of used instrument settings for the sample content used.
@@ -22925,7 +22925,7 @@ relationship: has_units UO:0000028 ! millisecond
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
-id: MS:4000134
+id: MS:4000132
 name: MS1 ion collection time - mean
 def: "From the distribution of ion injection times (MS:1000927) for MS1, the mean" [PSI:MS]
 comment: Injection time distribution can be used to gauge the suitability of used instrument settings for the sample content used.
@@ -22937,7 +22937,7 @@ relationship: has_units UO:0000028 ! millisecond
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 	
 [Term]
-id: MS:4000135
+id: MS:4000133
 name: MS1 ion collection time - sigma
 def: "From the distribution of ion injection times (MS:1000927) for MS1, the sigma value" [PSI:MS]
 comment: Injection time distribution can be used to gauge the suitability of used instrument settings for the sample content used.
@@ -22949,7 +22949,7 @@ relationship: has_units UO:0000028 ! millisecond
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 	
 [Term]
-id: MS:4000136
+id: MS:4000134
 name: MS1 ion collection time - low outliers
 def: "From the distribution of ion injection times (MS:1000927) for MS1, the list of outliers below a in-file defined threshold" [PSI:MS]
 comment: Injection time distribution can be used to gauge the suitability of used instrument settings for the sample content used.
@@ -22960,9 +22960,8 @@ relationship: has_value_concept STATO:0000036 ! outlier
 relationship: has_units UO:0000028 ! millisecond
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
-
 [Term]
-id: MS:4000137
+id: MS:4000135
 name: MS1 ion collection time - high outliers
 def: "From the distribution of ion injection times (MS:1000927) for MS1, the list of outliers above a in-file defined threshold" [PSI:MS]
 comment: Injection time distribution can be used to gauge the suitability of used instrument settings for the sample content used.
@@ -22974,7 +22973,7 @@ relationship: has_units UO:0000028 ! millisecond
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
-id: MS:4000138
+id: MS:4000136
 name: MS2 ion collection time - quantiles
 def: "From the distribution of ion injection times (MS:1000927) for MS2, the quantiles. I.e. a value triplet represents the quartiles Q1, Q2, Q3" [PSI:MS]
 comment: Injection time distribution can be used to gauge the suitability of used instrument settings for the sample content used.
@@ -22985,7 +22984,7 @@ relationship: has_units UO:0000028 ! millisecond
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 	
 [Term]
-id: MS:4000139
+id: MS:4000137
 name: MS2 ion collection time - mean
 def: "From the distribution of ion injection times (MS:1000927) for MS2, the mean" [PSI:MS]
 comment: Injection time distribution can be used to gauge the suitability of used instrument settings for the sample content used.
@@ -22997,7 +22996,7 @@ relationship: has_units UO:0000028 ! millisecond
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 	
 [Term]
-id: MS:4000140
+id: MS:4000138
 name: MS2 ion collection time - sigma
 def: "From the distribution of ion injection times (MS:1000927) for MS2, the sigma value" [PSI:MS]
 comment: Injection time distribution can be used to gauge the suitability of used instrument settings for the sample content used.
@@ -23009,7 +23008,7 @@ relationship: has_units UO:0000028 ! millisecond
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 	
 [Term]
-id: MS:4000141
+id: MS:4000139
 name: MS2 ion collection time - low outliers
 def: "From the distribution of ion injection times (MS:1000927) for MS2, the list of outliers below a in-file defined threshold" [PSI:MS]
 comment: Injection time distribution can be used to gauge the suitability of used instrument settings for the sample content used.
@@ -23020,9 +23019,8 @@ relationship: has_value_concept STATO:0000036 ! outlier
 relationship: has_units UO:0000028 ! millisecond
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
-
 [Term]
-id: MS:4000142
+id: MS:4000140
 name: MS2 ion collection time - high outliers
 def: "From the distribution of ion injection times (MS:1000927) for MS2, the list of outliers above a in-file defined threshold" [PSI:MS]
 comment: Injection time distribution can be used to gauge the suitability of used instrument settings for the sample content used.
@@ -23032,6 +23030,53 @@ relationship: has_metric_category MS:4000022 ! MS2 metric
 relationship: has_value_concept STATO:0000036 ! outlier
 relationship: has_units UO:0000028 ! millisecond
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
+
+[Term]
+id: MS:4000141
+name: outlier threshold criterion
+def: "The definition of the outlier criteria applied." [PSI:MS]
+
+[Term]
+id: MS:4000142
+name: Tukey's fence
+def: "Defines outliers with Tuckey's fence as <(Q1-x*IQR) for low outliers and >(Q3+x*IQR) for high outliers, where x is defined by the term's value. The default is x=1.5" [PSI:MS]
+is_a: MS:4000141 ! outlier threshold criterion
+
+[Term]
+id: MS:4000143
+name: Tukey's fence - high outliers
+def: "Defines high outliers with Tuckey's fence as >(Q3+x*IQR) for high outliers, where x is defined by the term's value. The default is x=1.5" [PSI:MS]
+is_a: MS:4000141 ! outlier threshold criterion
+
+[Term]
+id: MS:4000144
+name: Tukey's fence - low outliers
+def: "Defines low outliers with Tuckey's fence as <(Q1-x*IQR) for low outliers, where x is defined by the term's value. The default is x=1.5" [PSI:MS]
+is_a: MS:4000141 ! outlier threshold criterion
+
+[Term]
+id: MS:4000145
+name: Z-score threshold
+def: "Defines outliers with a Z-score threshold as <(-x) for low outliers and >(+x) for high outliers, where x is defined by the term's value. The default is x=3" [PSI:MS]
+is_a: MS:4000141 ! outlier threshold criterion
+
+[Term]
+id: MS:4000146
+name: Z-score threshold - high outliers
+def: "Defines outliers with a Z-score threshold as <(-x) for low outliers and >(+x) for high outliers, where x is defined by the term's value. The default is x=3" [PSI:MS]
+is_a: MS:4000141 ! outlier threshold criterion
+
+[Term]
+id: MS:4000147
+name: Z-score threshold - low outliers
+def: "Defines outliers with a Z-score threshold as <(-x) for low outliers and >(+x) for high outliers, where x is defined by the term's value. The default is x=3" [PSI:MS]
+is_a: MS:4000141 ! outlier threshold criterion
+
+[Term]
+id: MS:4000148
+name: algorithmical threshold
+def: "Defines outliers algorithmically, where a single value threshold might not be applicable or p.r.n. multivariate decision making is applied. The value of the term should name the algorithmical method used" [PSI:MS]
+is_a: MS:4000141 ! outlier threshold criterion
 
 [Term]
 id: PEFF:0000001

--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -1,5 +1,5 @@
 format-version: 1.2
-data-version: 4.1.112
+data-version: 4.1.113
 date: 30:01:2023 11:30
 saved-by: Mathias Walzer
 auto-generated-by: OBO-Edit 2.3.1
@@ -21888,25 +21888,25 @@ name: Lipid shorthand identification confidence - Complete structure
 def: "Lipid shorthand identification confidence level 'Complete structure'." [PMID:33037133]
 is_a: MS:1003310 ! Lipid shorthand identification confidence level
 
-[Term] 
-id: MS:1003327 
-name: number of identified protein groups 
-def: "The number of protein groups that pass the threshold to be considered identified with sufficient confidence." [PSI:PI]  
-is_a: MS:1002405 ! protein group-level result list attribute 
-is_a: MS:4000003 ! single value 
-relationship: has_metric_category MS:4000008 ! ID based metric 
-relationship: has_value_type xsd:int ! The allowed value-type for this CV term 
-relationship: has_units UO:0000189 ! count unit 
+[Term]
+id: MS:1003327
+name: number of identified protein groups
+def: "The number of protein groups that pass the threshold to be considered identified with sufficient confidence." [PSI:PI]
+is_a: MS:1002405 ! protein group-level result list attribute
+is_a: MS:4000003 ! single value
+relationship: has_metric_category MS:4000008 ! ID based metric
+relationship: has_value_type xsd:int ! The allowed value-type for this CV term
+relationship: has_units UO:0000189 ! count unit
 
-[Term] 
-id: MS:1003328 
-name: number of identified proteoforms 
-def: "The number of proteoforms that pass the threshold to be considered identified with sufficient confidence." [PSI:PI] 
+[Term]
+id: MS:1003328
+name: number of identified proteoforms
+def: "The number of proteoforms that pass the threshold to be considered identified with sufficient confidence." [PSI:PI]
 is_a: MS:1001085 ! protein-level identification attribute
 is_a: MS:4000003 ! single value
-relationship: has_metric_category MS:4000008 ! ID based metric 
-relationship: has_value_type xsd:int ! The allowed value-type for this CV term 
-relationship: has_units UO:0000189 ! count unit 
+relationship: has_metric_category MS:4000008 ! ID based metric
+relationship: has_value_type xsd:int ! The allowed value-type for this CV term
+relationship: has_units UO:0000189 ! count unit
 
 [Term]
 id: MS:4000000
@@ -22666,51 +22666,51 @@ relationship: has_metric_category MS:4000012 ! single run based metric
 relationship: has_units UO:0000189 ! count unit
 relationship: has_value_type xsd:integer ! The allowed value-type for this CV term
 
-[Term] 
-id: MS:4000102 
-name: number of detected quantification data points 
-def: "The number of data points detected for quantification purposes within the run. These data points may be for example XIC profiles, isotopic pattern areas, or reporter ions (see MS:1001805). The used type should be noted in the metadata or analysis methods section of the recording file for the respective run." [PSI:MS] 
-is_a: MS:4000003 ! single value 
-relationship: has_metric_category MS:4000009 ! ID free metric 
-relationship: has_metric_category MS:4000012 ! single run based metric 
-relationship: has_value_type xsd:int ! The allowed value-type for this CV term 
-relationship: has_units UO:0000189 ! count unit 
-
-[Term] 
-id: MS:4000103 
-name: number of identified quantification data points 
-def: "The number of identified data points for quantification purposes within the run after user defined acceptance criteria are applied.  These data points may be for example XIC profiles, isotopic pattern areas, or reporter ions (see MS:1001805). The used type should be noted in the metadata or analysis methods section of the recording file for the respective run. In case of multiple acceptance criteria (FDR) available in proteomics, PSM-level FDR should be used for better comparability." [PSI:MS] 
-is_a: MS:4000003 ! single value 
-relationship: has_metric_category MS:4000008 ! ID based metric 
-relationship: has_metric_category MS:4000012 ! single run based metric 
-relationship: has_value_type xsd:int ! The allowed value-type for this CV term 
-relationship: has_units UO:0000189 ! count unit 
+[Term]
+id: MS:4000102
+name: number of detected quantification data points
+def: "The number of data points detected for quantification purposes within the run. These data points may be for example XIC profiles, isotopic pattern areas, or reporter ions (see MS:1001805). The used type should be noted in the metadata or analysis methods section of the recording file for the respective run." [PSI:MS]
+is_a: MS:4000003 ! single value
+relationship: has_metric_category MS:4000009 ! ID free metric
+relationship: has_metric_category MS:4000012 ! single run based metric
+relationship: has_value_type xsd:int ! The allowed value-type for this CV term
+relationship: has_units UO:0000189 ! count unit
 
 [Term]
-id: MS:4000104 
-name: total ion currents 
-def: "Tabular representation of the total ion current detected in each of a series of mass spectra." [PSI:MS] 
-is_a: MS:4000005 ! table 
-is_a: MS:1000235 ! total ion current chromatogram 
-relationship: has_metric_category MS:4000009 ! ID free metric 
-relationship: has_metric_category MS:4000012 ! single run based metric 
-relationship: has_metric_category MS:4000016 ! retention time metric 
-relationship: has_column MS:1000767 ! native spectrum identifier format 
-relationship: has_optional_column MS:1000894 ! retention time  
-relationship: has_optional_column MS:1003059 ! number of peaks
-relationship: has_column MS:1000285 ! total ion current 
+id: MS:4000103
+name: number of identified quantification data points
+def: "The number of identified data points for quantification purposes within the run after user defined acceptance criteria are applied.  These data points may be for example XIC profiles, isotopic pattern areas, or reporter ions (see MS:1001805). The used type should be noted in the metadata or analysis methods section of the recording file for the respective run. In case of multiple acceptance criteria (FDR) available in proteomics, PSM-level FDR should be used for better comparability." [PSI:MS]
+is_a: MS:4000003 ! single value
+relationship: has_metric_category MS:4000008 ! ID based metric
+relationship: has_metric_category MS:4000012 ! single run based metric
+relationship: has_value_type xsd:int ! The allowed value-type for this CV term
+relationship: has_units UO:0000189 ! count unit
 
-[Term] 
-id: MS:4000105 
+[Term]
+id: MS:4000104
+name: total ion currents
+def: "Tabular representation of the total ion current detected in each of a series of mass spectra." [PSI:MS]
+is_a: MS:4000005 ! table
+is_a: MS:1000235 ! total ion current chromatogram
+relationship: has_metric_category MS:4000009 ! ID free metric
+relationship: has_metric_category MS:4000012 ! single run based metric
+relationship: has_metric_category MS:4000016 ! retention time metric
+relationship: has_column MS:1000767 ! native spectrum identifier format
+relationship: has_optional_column MS:1000894 ! retention time
+relationship: has_optional_column MS:1003059 ! number of peaks
+relationship: has_column MS:1000285 ! total ion current
+
+[Term]
+id: MS:4000105
 name: ion injection parameters
-def: "Tabular representation of the parameters around ion selection like the amount of time spent filling an ion trapping device for each scan acquisition." [PSI:MS] 
+def: "Tabular representation of the parameters around ion selection like the amount of time spent filling an ion trapping device for each scan acquisition." [PSI:MS]
 is_a: MS:4000005 ! table name: scan window upper limit
-relationship: has_metric_category MS:4000009 ! ID free metric 
-relationship: has_metric_category MS:4000012 ! single run based metric 
-relationship: has_column MS:1000767 ! native spectrum identifier format 
-relationship: has_column MS:1000927 ! ion injection time 
-relationship: has_optional_column MS:1000511! ms level  
-relationship: has_optional_column MS:1000465 ! scan polarity 
+relationship: has_metric_category MS:4000009 ! ID free metric
+relationship: has_metric_category MS:4000012 ! single run based metric
+relationship: has_column MS:1000767 ! native spectrum identifier format
+relationship: has_column MS:1000927 ! ion injection time
+relationship: has_optional_column MS:1000511! ms level
+relationship: has_optional_column MS:1000465 ! scan polarity
 relationship: has_optional_column MS:1000500 ! scan window upper limit
 relationship: has_optional_column MS:1000501 ! scan window lower limit
 
@@ -22748,7 +22748,7 @@ relationship: has_metric_category MS:4000009 ! ID free metric
 relationship: has_metric_category MS:4000021 ! MS1 metric
 relationship: has_value_concept STATO:0000401 ! sample mean
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
-	
+
 [Term]
 id: MS:4000109
 name: MS1 peak density distribution sigma
@@ -22759,7 +22759,7 @@ relationship: has_metric_category MS:4000009 ! ID free metric
 relationship: has_metric_category MS:4000021 ! MS1 metric
 relationship: has_value_concept STATO:0000237 ! standard deviation
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
-	
+
 [Term]
 id: MS:4000110
 name: MS1 peak density distribution low outliers
@@ -22792,7 +22792,7 @@ relationship: has_metric_category MS:4000009 ! ID free metric
 relationship: has_metric_category MS:4000022 ! MS2 metric
 relationship: has_value_concept STATO:0000401 ! sample mean
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
-	
+
 [Term]
 id: MS:4000113
 name: MS2 peak density distribution sigma
@@ -22803,7 +22803,7 @@ relationship: has_metric_category MS:4000009 ! ID free metric
 relationship: has_metric_category MS:4000022 ! MS2 metric
 relationship: has_value_concept STATO:0000237 ! standard deviation
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
-	
+
 [Term]
 id: MS:4000114
 name: MS2 peak density distribution low outliers
@@ -22859,7 +22859,7 @@ relationship: has_metric_category MS:4000009 ! ID free metric
 relationship: has_value_concept STATO:0000237 ! standard deviation
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 relationship: has_units MS:1000043 ! intensity unit
-	
+
 [Term]
 id: MS:4000119
 name: precursor intensity distribution low outliers
@@ -22903,7 +22903,7 @@ relationship: has_metric_category MS:4000009 ! ID free metric
 relationship: has_metric_category MS:4000021 ! MS1 metric
 relationship: has_value_concept STATO:0000401 ! sample mean
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
-	
+
 [Term]
 id: MS:4000123
 name: MS1 signal-to-noise ratio sigma
@@ -22914,7 +22914,7 @@ relationship: has_metric_category MS:4000009 ! ID free metric
 relationship: has_metric_category MS:4000021 ! MS1 metric
 relationship: has_value_concept STATO:0000237 ! standard deviation
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
-	
+
 [Term]
 id: MS:4000124
 name: MS1 signal-to-noise ratio low outliers
@@ -22947,7 +22947,7 @@ relationship: has_metric_category MS:4000009 ! ID free metric
 relationship: has_metric_category MS:4000022 ! MS2 metric
 relationship: has_value_concept STATO:0000291 ! quantile
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
-	
+
 [Term]
 id: MS:4000127
 name: MS2 signal-to-noise ratio mean
@@ -22958,7 +22958,7 @@ relationship: has_metric_category MS:4000009 ! ID free metric
 relationship: has_metric_category MS:4000022 ! MS2 metric
 relationship: has_value_concept STATO:0000401 ! sample mean
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
-	
+
 [Term]
 id: MS:4000128
 name: MS2 signal-to-noise ratio sigma
@@ -22969,7 +22969,7 @@ relationship: has_metric_category MS:4000009 ! ID free metric
 relationship: has_metric_category MS:4000022 ! MS2 metric
 relationship: has_value_concept STATO:0000237 ! standard deviation
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
-	
+
 [Term]
 id: MS:4000129
 name: MS2 signal-to-noise ratio low outliers
@@ -23014,7 +23014,7 @@ relationship: has_metric_category MS:4000021 ! MS1 metric
 relationship: has_value_concept STATO:0000401 ! sample mean
 relationship: has_units UO:0000028 ! millisecond
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
-	
+
 [Term]
 id: MS:4000133
 name: MS1 ion collection time sigma
@@ -23026,7 +23026,7 @@ relationship: has_metric_category MS:4000021 ! MS1 metric
 relationship: has_value_concept STATO:0000237 ! standard deviation
 relationship: has_units UO:0000028 ! millisecond
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
-	
+
 [Term]
 id: MS:4000134
 name: MS1 ion collection time low outliers
@@ -23061,7 +23061,7 @@ relationship: has_metric_category MS:4000009 ! ID free metric
 relationship: has_value_concept STATO:0000291 ! quantile
 relationship: has_units UO:0000028 ! millisecond
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
-	
+
 [Term]
 id: MS:4000137
 name: MS2 ion collection time mean
@@ -23073,7 +23073,7 @@ relationship: has_metric_category MS:4000022 ! MS2 metric
 relationship: has_value_concept STATO:0000401 ! sample mean
 relationship: has_units UO:0000028 ! millisecond
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
-	
+
 [Term]
 id: MS:4000138
 name: MS2 ion collection time sigma
@@ -23085,7 +23085,7 @@ relationship: has_metric_category MS:4000022 ! MS2 metric
 relationship: has_value_concept STATO:0000237 ! standard deviation
 relationship: has_units UO:0000028 ! millisecond
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
-	
+
 [Term]
 id: MS:4000139
 name: MS2 ion collection time low outliers

--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -22683,8 +22683,8 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 	
 [Term]
 id: MS:4000111
-name: MS1 peak density distribution - low outliers (<Q1-1.5*IQR)
-def: "From the distribution of peak densities in MS1, the list of outliers below Q1-1.5*IQR" [PSI:MS]
+name: MS1 peak density distribution - low outliers
+def: "From the distribution of peak densities in MS1, the list of outliers below a in-file defined threshold" [PSI:MS]
 comment: The distribution of peak densities in MS1 can provide insight into the presence of nuisance factors.
 is_a: MS:4000004 ! n-tuple
 relationship: has_metric_category MS:4000009 ! ID free metric
@@ -22694,8 +22694,8 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:4000112
-name: MS1 peak density distribution - high outliers (>Q3+1.5*IQR)
-def: "From the distribution of peak densities in MS1, the list of outliers above Q3+1.5*IQR" [PSI:MS]
+name: MS1 peak density distribution - high outliers
+def: "From the distribution of peak densities in MS1, the list of outliers above a in-file defined threshold" [PSI:MS]
 comment: The distribution of peak densities in MS1 can provide insight into the presence of nuisance factors.
 is_a: MS:4000004 ! n-tuple
 relationship: has_metric_category MS:4000009 ! ID free metric
@@ -22727,8 +22727,8 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 	
 [Term]
 id: MS:4000116
-name: MS2 peak density distribution - low outliers (<Q1-1.5*IQR)
-def: "From the distribution of peak densities in MS2, the list of outliers below Q1-1.5*IQR" [PSI:MS]
+name: MS2 peak density distribution - low outliers
+def: "From the distribution of peak densities in MS2, the list of outliers below a in-file defined threshold" [PSI:MS]
 comment: The distribution of peak densities in MS2 can provide insight into the instruments ion selection settings.
 is_a: MS:4000004 ! n-tuple
 relationship: has_metric_category MS:4000009 ! ID free metric
@@ -22738,8 +22738,8 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:4000117
-name: MS2 peak density distribution - high outliers (>Q3+1.5*IQR)
-def: "From the distribution of peak densities in MS2, the list of outliers above Q3+1.5*IQR" [PSI:MS]
+name: MS2 peak density distribution - high outliers
+def: "From the distribution of peak densities in MS2, the list of outliers above a in-file defined threshold" [PSI:MS]
 comment: The distribution of peak densities in MS2 can provide insight into the instruments ion selection settings.
 is_a: MS:4000004 ! n-tuple
 relationship: has_metric_category MS:4000009 ! ID free metric
@@ -22783,8 +22783,8 @@ relationship: has_units MS:1000043 ! intensity unit
 	
 [Term]
 id: MS:4000121
-name: precursor intensity distribution - low outliers (<Q1-1.5*IQR)
-def: "From the distribution of precursor intensities, the list of outliers below Q1-1.5*IQR" [PSI:MS]
+name: precursor intensity distribution - low outliers
+def: "From the distribution of precursor intensities, the list of outliers below a in-file defined threshold" [PSI:MS]
 comment: The intensity distribution of the precursors informs about the dynamic range of the acquisition.
 is_a: MS:4000004 ! n-tuple
 relationship: has_metric_category MS:4000009 ! ID free metric
@@ -22794,8 +22794,8 @@ relationship: has_units MS:1000043 ! intensity unit
 
 [Term]
 id: MS:4000122
-name: precursor intensity distribution - high outliers (>Q3+1.5*IQR)
-def: "From the distribution of precursor intensities, the list of outliers above Q3+1.5*IQR" [PSI:MS]
+name: precursor intensity distribution - high outliers
+def: "From the distribution of precursor intensities, the list of outliers above a in-file defined threshold" [PSI:MS]
 comment: The intensity distribution of the precursors informs about the dynamic range of the acquisition.
 is_a: MS:4000004 ! n-tuple
 relationship: has_metric_category MS:4000009 ! ID free metric
@@ -22838,7 +22838,7 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 	
 [Term]
 id: MS:4000126
-name: MS1 signal-to-noise ratio - low outliers (<Q1-1.5*IQR)
+name: MS1 signal-to-noise ratio - low outliers
 def: "From the distribution of signal-to-noise ratio in MS1, the list of outliers below Q1-1.5IQR" [PSI:MS]
 comment: The Signal-to-noise ratio in MS1 distribution can provide insight into the presence of nuisance factors. Comparisons will likely only make local sense where the same method of S/N calculation is applied (or overall the same software to calculate this metric, see mzQC 'analysisSoftware').
 is_a: MS:4000004 ! n-tuple
@@ -22849,7 +22849,7 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:4000127
-name: MS1 signal-to-noise ratio - high outliers (>Q3+1.5*IQR)
+name: MS1 signal-to-noise ratio - high outliers
 def: "From the distribution of signal-to-noise ratio in MS1, the list of outliers above Q3+1.5IQR" [PSI:MS]
 comment: The Signal-to-noise ratio in MS1 distribution can provide insight into the presence of nuisance factors. Comparisons will likely only make local sense where the same method of S/N calculation is applied (or overall the same software to calculate this metric, see mzQC 'analysisSoftware').
 is_a: MS:4000004 ! n-tuple
@@ -22893,7 +22893,7 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 	
 [Term]
 id: MS:4000131
-name: signal-to-noise ratio in MS2 - low outliers (<Q1-1.5*IQR)
+name: signal-to-noise ratio in MS2 - low outliers
 def: "From the distribution of signal-to-noise ratio in MS2, the list of outliers below Q1-1.5IQR" [PSI:MS]
 comment: A high signal-to-noise ratio in MS2 distribution can explain a high rate of unidentified spectra. Comparisons will likely only make local sense where the same method of S/N calculation is applied (or overall the same software to calculate this metric, see mzQC 'analysisSoftware').
 is_a: MS:4000004 ! n-tuple
@@ -22904,7 +22904,7 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:4000132
-name: signal-to-noise ratio in MS2 - high outliers (>Q3+1.5*IQR)
+name: signal-to-noise ratio in MS2 - high outliers
 def: "From the distribution of signal-to-noise ratio in MS2, the list of outliers above Q3+1.5IQR" [PSI:MS]
 comment: A high signal-to-noise ratio in MS2 distribution can explain a high rate of unidentified spectra. Comparisons will likely only make local sense where the same method of S/N calculation is applied (or overall the same software to calculate this metric, see mzQC 'analysisSoftware').
 is_a: MS:4000004 ! n-tuple
@@ -22950,8 +22950,8 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 	
 [Term]
 id: MS:4000136
-name: MS1 ion collection time - low outliers (<Q1-1.5*IQR)
-def: "From the distribution of ion injection times (MS:1000927) for MS1, the list of outliers below Q1-1.5*IQR" [PSI:MS]
+name: MS1 ion collection time - low outliers
+def: "From the distribution of ion injection times (MS:1000927) for MS1, the list of outliers below a in-file defined threshold" [PSI:MS]
 comment: Injection time distribution can be used to gauge the suitability of used instrument settings for the sample content used.
 is_a: MS:4000004 ! n-tuple
 relationship: has_metric_category MS:4000009 ! ID free metric
@@ -22963,8 +22963,8 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:4000137
-name: MS1 ion collection time - high outliers (>Q3+1.5*IQR)
-def: "From the distribution of ion injection times (MS:1000927) for MS1, the list of outliers above Q3+1.5*IQR" [PSI:MS]
+name: MS1 ion collection time - high outliers
+def: "From the distribution of ion injection times (MS:1000927) for MS1, the list of outliers above a in-file defined threshold" [PSI:MS]
 comment: Injection time distribution can be used to gauge the suitability of used instrument settings for the sample content used.
 is_a: MS:4000004 ! n-tuple
 relationship: has_metric_category MS:4000009 ! ID free metric
@@ -23010,8 +23010,8 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 	
 [Term]
 id: MS:4000141
-name: MS2 ion collection time - low outliers (<Q1-1.5*IQR)
-def: "From the distribution of ion injection times (MS:1000927) for MS2, the list of outliers below Q1-1.5*IQR" [PSI:MS]
+name: MS2 ion collection time - low outliers
+def: "From the distribution of ion injection times (MS:1000927) for MS2, the list of outliers below a in-file defined threshold" [PSI:MS]
 comment: Injection time distribution can be used to gauge the suitability of used instrument settings for the sample content used.
 is_a: MS:4000004 ! n-tuple
 relationship: has_metric_category MS:4000009 ! ID free metric
@@ -23023,8 +23023,8 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:4000142
-name: MS2 ion collection time - high outliers (>Q3+1.5*IQR)
-def: "From the distribution of ion injection times (MS:1000927) for MS2, the list of outliers above Q3+1.5*IQR" [PSI:MS]
+name: MS2 ion collection time - high outliers
+def: "From the distribution of ion injection times (MS:1000927) for MS2, the list of outliers above a in-file defined threshold" [PSI:MS]
 comment: Injection time distribution can be used to gauge the suitability of used instrument settings for the sample content used.
 is_a: MS:4000004 ! n-tuple
 relationship: has_metric_category MS:4000009 ! ID free metric

--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -22662,6 +22662,7 @@ def: "From the distribution of peak densities in MS1, the quartiles Q1, Q2, Q3" 
 comment: The distribution of peak densities in MS1 can provide insight into the presence of nuisance factors.
 is_a: MS:4000004 ! n-tuple
 relationship: has_metric_category MS:4000009 ! ID free metric
+relationship: has_metric_category MS:4000021 ! MS1 metric
 relationship: has_value_concept STATO:0000167 ! first quartile
 relationship: has_value_concept STATO:0000574 ! center value
 relationship: has_value_concept STATO:0000170 ! third quartile
@@ -22674,6 +22675,7 @@ def: "From the distribution of peak densities in MS1, the mean" [PSI:MS]
 comment: The distribution of peak densities in MS1 can provide insight into the presence of nuisance factors.
 is_a: MS:4000003 ! single value
 relationship: has_metric_category MS:4000009 ! ID free metric
+relationship: has_metric_category MS:4000021 ! MS1 metric
 relationship: has_value_concept STATO:0000401 ! sample mean
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 	
@@ -22684,6 +22686,7 @@ def: "From the distribution of peak densities in MS1, the sigma value" [PSI:MS]
 comment: The distribution of peak densities in MS1 can provide insight into the presence of nuisance factors.
 is_a: MS:4000003 ! single value
 relationship: has_metric_category MS:4000009 ! ID free metric
+relationship: has_metric_category MS:4000021 ! MS1 metric
 relationship: has_value_concept STATO:0000237 ! standard deviation
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 	
@@ -22692,8 +22695,9 @@ id: MS:4000111
 name: MS1 peak density distribution - low outliers (<Q1-1.5*IQR)
 def: "From the distribution of peak densities in MS1, the list of outliers below Q1-1.5*IQR" [PSI:MS]
 comment: The distribution of peak densities in MS1 can provide insight into the presence of nuisance factors.
-relationship: has_metric_category MS:4000009 ! ID free metric
 is_a: MS:4000004 ! n-tuple
+relationship: has_metric_category MS:4000009 ! ID free metric
+relationship: has_metric_category MS:4000021 ! MS1 metric
 relationship: has_value_concept STATO:0000036 ! outlier
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
@@ -22704,6 +22708,7 @@ def: "From the distribution of peak densities in MS1, the list of outliers above
 comment: The distribution of peak densities in MS1 can provide insight into the presence of nuisance factors.
 is_a: MS:4000004 ! n-tuple
 relationship: has_metric_category MS:4000009 ! ID free metric
+relationship: has_metric_category MS:4000021 ! MS1 metric
 relationship: has_value_concept STATO:0000036 ! outlier
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
@@ -22711,9 +22716,10 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 id: MS:4000113
 name: MS2 peak density distribution - Q1, Q2, Q3
 def: "From the distribution of peak densities in MS2, the quartiles Q1, Q2, Q3" [PSI:MS]
-comment: The distribution of peak densities in MS2 can provide insight into the instruments ion selction settings.
+comment: The distribution of peak densities in MS2 can provide insight into the instruments ion selection settings.
 is_a: MS:4000004 ! n-tuple
 relationship: has_metric_category MS:4000009 ! ID free metric
+relationship: has_metric_category MS:4000022 ! MS2 metric
 relationship: has_type STATO:0000167 ! first quartile
 relationship: has_type STATO:0000574 ! center value
 relationship: has_type STATO:0000170 ! third quartile
@@ -22723,9 +22729,10 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 id: MS:4000114
 name: MS2 peak density distribution - mean
 def: "From the distribution of peak densities in MS2, the mean" [PSI:MS]
-comment: The distribution of peak densities in MS2 can provide insight into the instruments ion selction settings.
+comment: The distribution of peak densities in MS2 can provide insight into the instruments ion selection settings.
 is_a: MS:4000003 ! single value
 relationship: has_metric_category MS:4000009 ! ID free metric
+relationship: has_metric_category MS:4000022 ! MS2 metric
 relationship: has_value_concept STATO:0000401 ! sample mean
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 	
@@ -22733,9 +22740,10 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 id: MS:4000115
 name: MS2 peak density distribution - sigma
 def: "From the distribution of peak densities in MS2, the sigma value" [PSI:MS]
-comment: The distribution of peak densities in MS2 can provide insight into the instruments ion selction settings.
+comment: The distribution of peak densities in MS2 can provide insight into the instruments ion selection settings.
 is_a: MS:4000003 ! single value
 relationship: has_metric_category MS:4000009 ! ID free metric
+relationship: has_metric_category MS:4000022 ! MS2 metric
 relationship: has_value_concept STATO:0000237 ! standard deviation
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 	
@@ -22743,9 +22751,10 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 id: MS:4000116
 name: MS2 peak density distribution - low outliers (<Q1-1.5*IQR)
 def: "From the distribution of peak densities in MS2, the list of outliers below Q1-1.5*IQR" [PSI:MS]
-comment: The distribution of peak densities in MS2 can provide insight into the instruments ion selction settings.
+comment: The distribution of peak densities in MS2 can provide insight into the instruments ion selection settings.
 is_a: MS:4000004 ! n-tuple
 relationship: has_metric_category MS:4000009 ! ID free metric
+relationship: has_metric_category MS:4000022 ! MS2 metric
 relationship: has_value_concept STATO:0000036 ! outlier
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
@@ -22753,9 +22762,10 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 id: MS:4000117
 name: MS2 peak density distribution - high outliers (>Q3+1.5*IQR)
 def: "From the distribution of peak densities in MS2, the list of outliers above Q3+1.5*IQR" [PSI:MS]
-comment: The distribution of peak densities in MS2 can provide insight into the instruments ion selction settings.
+comment: The distribution of peak densities in MS2 can provide insight into the instruments ion selection settings.
 is_a: MS:4000004 ! n-tuple
 relationship: has_metric_category MS:4000009 ! ID free metric
+relationship: has_metric_category MS:4000022 ! MS2 metric
 relationship: has_value_concept STATO:0000036 ! outlier
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
@@ -22766,6 +22776,7 @@ def: "From the distribution of precursor intensities, the quartiles Q1, Q2, Q3" 
 comment: The intensity distribution of the precursors informs about the dynamic range of the acquisition.
 is_a: MS:4000004 ! n-tuple
 relationship: has_metric_category MS:4000009 ! ID free metric
+relationship: has_metric_category MS:4000022 ! MS2 metric
 relationship: has_value_concept STATO:0000167 ! first quartile
 relationship: has_value_concept STATO:0000574 ! center value
 relationship: has_value_concept STATO:0000170 ! third quartile
@@ -22823,6 +22834,7 @@ def: "From the distribution of signal-to-noise ratio in MS1, the quartiles Q1, Q
 comment: The Signal-to-noise ratio in MS1 distribution can provide insight to the presence of nuisance factors.
 is_a: MS:4000004 ! n-tuple
 relationship: has_metric_category MS:4000009 ! ID free metric
+relationship: has_metric_category MS:4000021 ! MS1 metric
 relationship: has_value_concept STATO:0000167 ! first quartile
 relationship: has_value_concept STATO:0000574 ! center value
 relationship: has_value_concept STATO:0000170 ! third quartile
@@ -22835,6 +22847,7 @@ comment: The signal-to-noise ratio in MS1 distribution can provide insight into 
 def: "From the distribution of signal-to-noise ratio in MS1, the mean" [PSI:MS]
 is_a: MS:4000003 ! single value
 relationship: has_metric_category MS:4000009 ! ID free metric
+relationship: has_metric_category MS:4000021 ! MS1 metric
 relationship: has_value_concept STATO:0000401 ! sample mean
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 	
@@ -22845,6 +22858,7 @@ def: "From the distribution of signal-to-noise ratio in MS1, the sigma value" [P
 comment: The Signal-to-noise ratio in MS1 distribution can provide insight into the presence of nuisance factors. Comparisons will likely only make local sense where the same method of S/N calculation is applied (or overall the same software to calculate this metric, see mzQC 'analysisSoftware').
 is_a: MS:4000003 ! single value
 relationship: has_metric_category MS:4000009 ! ID free metric
+relationship: has_metric_category MS:4000021 ! MS1 metric
 relationship: has_value_concept STATO:0000237 ! standard deviation
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 	
@@ -22855,6 +22869,7 @@ def: "From the distribution of signal-to-noise ratio in MS1, the list of outlier
 comment: The Signal-to-noise ratio in MS1 distribution can provide insight into the presence of nuisance factors. Comparisons will likely only make local sense where the same method of S/N calculation is applied (or overall the same software to calculate this metric, see mzQC 'analysisSoftware').
 is_a: MS:4000004 ! n-tuple
 relationship: has_metric_category MS:4000009 ! ID free metric
+relationship: has_metric_category MS:4000021 ! MS1 metric
 relationship: has_value_concept STATO:0000036 ! outlier
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
@@ -22865,6 +22880,7 @@ def: "From the distribution of signal-to-noise ratio in MS1, the list of outlier
 comment: The Signal-to-noise ratio in MS1 distribution can provide insight into the presence of nuisance factors. Comparisons will likely only make local sense where the same method of S/N calculation is applied (or overall the same software to calculate this metric, see mzQC 'analysisSoftware').
 is_a: MS:4000004 ! n-tuple
 relationship: has_metric_category MS:4000009 ! ID free metric
+relationship: has_metric_category MS:4000021 ! MS1 metric
 relationship: has_value_concept STATO:0000036 ! outlier
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
@@ -22875,6 +22891,7 @@ def: "From the distribution of signal-to-noise ratio in MS2, the quartiles Q1, Q
 comment: A high signal-to-noise ratio in MS2 distribution can explain a high rate of unidentified spectra. Comparisons will likely only make local sense where the same method of S/N calculation is applied (or overall the same software to calculate this metric, see mzQC 'analysisSoftware').
 is_a: MS:4000004 ! n-tuple
 relationship: has_metric_category MS:4000009 ! ID free metric
+relationship: has_metric_category MS:4000022 ! MS2 metric
 relationship: has_value_concept STATO:0000167 ! first quartile
 relationship: has_value_concept STATO:0000574 ! center value
 relationship: has_value_concept STATO:0000170 ! third quartile
@@ -22887,6 +22904,7 @@ def: "From the distribution of signal-to-noise ratio in MS2, the mean" [PSI:MS]
 comment: A high signal-to-noise ratio in MS2 distribution can explain a high rate of unidentified spectra. Comparisons will likely only make local sense where the same method of S/N calculation is applied (or overall the same software to calculate this metric, see mzQC 'analysisSoftware').
 is_a: MS:4000003 ! single value
 relationship: has_metric_category MS:4000009 ! ID free metric
+relationship: has_metric_category MS:4000022 ! MS2 metric
 relationship: has_value_concept STATO:0000401 ! sample mean
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 	
@@ -22897,6 +22915,7 @@ def: "From the distribution of signal-to-noise ratio in MS2, the sigma value" [P
 comment: A high signal-to-noise ratio in MS2 distribution can explain a high rate of unidentified spectra. Comparisons will likely only make local sense where the same method of S/N calculation is applied (or overall the same software to calculate this metric, see mzQC 'analysisSoftware').
 is_a: MS:4000003 ! single value
 relationship: has_metric_category MS:4000009 ! ID free metric
+relationship: has_metric_category MS:4000022 ! MS2 metric
 relationship: has_value_concept STATO:0000237 ! standard deviation
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 	
@@ -22907,6 +22926,7 @@ def: "From the distribution of signal-to-noise ratio in MS2, the list of outlier
 comment: A high signal-to-noise ratio in MS2 distribution can explain a high rate of unidentified spectra. Comparisons will likely only make local sense where the same method of S/N calculation is applied (or overall the same software to calculate this metric, see mzQC 'analysisSoftware').
 is_a: MS:4000004 ! n-tuple
 relationship: has_metric_category MS:4000009 ! ID free metric
+relationship: has_metric_category MS:4000022 ! MS2 metric
 relationship: has_value_concept STATO:0000036 ! outlier
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
@@ -22917,6 +22937,7 @@ def: "From the distribution of signal-to-noise ratio in MS2, the list of outlier
 comment: A high signal-to-noise ratio in MS2 distribution can explain a high rate of unidentified spectra. Comparisons will likely only make local sense where the same method of S/N calculation is applied (or overall the same software to calculate this metric, see mzQC 'analysisSoftware').
 is_a: MS:4000004 ! n-tuple
 relationship: has_metric_category MS:4000009 ! ID free metric
+relationship: has_metric_category MS:4000022 ! MS2 metric
 relationship: has_value_concept STATO:0000036 ! outlier
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
@@ -22927,6 +22948,7 @@ def: "From the distribution of ion injection times (MS:1000927) for MS1, the qua
 comment: Injection time distribution can be used to gauge the suitability of used instrument settings for the sample content used.
 is_a: MS:4000004 ! n-tuple
 relationship: has_value_concept STATO:0000167 ! first quartile
+relationship: has_metric_category MS:4000021 ! MS1 metric
 relationship: has_value_concept STATO:0000574 ! center value
 relationship: has_value_concept STATO:0000170 ! third quartile
 relationship: has_units UO:0000028 ! millisecond
@@ -22939,6 +22961,7 @@ def: "From the distribution of ion injection times (MS:1000927) for MS1, the mea
 comment: Injection time distribution can be used to gauge the suitability of used instrument settings for the sample content used.
 is_a: MS:4000003 ! single value
 relationship: has_metric_category MS:4000009 ! ID free metric
+relationship: has_metric_category MS:4000021 ! MS1 metric
 relationship: has_value_concept STATO:0000401 ! sample mean
 relationship: has_units UO:0000028 ! millisecond
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
@@ -22950,6 +22973,7 @@ def: "From the distribution of ion injection times (MS:1000927) for MS1, the sig
 comment: Injection time distribution can be used to gauge the suitability of used instrument settings for the sample content used.
 is_a: MS:4000003 ! single value
 relationship: has_metric_category MS:4000009 ! ID free metric
+relationship: has_metric_category MS:4000021 ! MS1 metric
 relationship: has_value_concept STATO:0000237 ! standard deviation
 relationship: has_units UO:0000028 ! millisecond
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
@@ -22961,6 +22985,7 @@ def: "From the distribution of ion injection times (MS:1000927) for MS1, the lis
 comment: Injection time distribution can be used to gauge the suitability of used instrument settings for the sample content used.
 is_a: MS:4000004 ! n-tuple
 relationship: has_metric_category MS:4000009 ! ID free metric
+relationship: has_metric_category MS:4000021 ! MS1 metric
 relationship: has_value_concept STATO:0000036 ! outlier
 relationship: has_units UO:0000028 ! millisecond
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
@@ -22973,6 +22998,7 @@ def: "From the distribution of ion injection times (MS:1000927) for MS1, the lis
 comment: Injection time distribution can be used to gauge the suitability of used instrument settings for the sample content used.
 is_a: MS:4000004 ! n-tuple
 relationship: has_metric_category MS:4000009 ! ID free metric
+relationship: has_metric_category MS:4000021 ! MS1 metric
 relationship: has_value_concept STATO:0000036 ! outlier
 relationship: has_units UO:0000028 ! millisecond
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
@@ -22997,6 +23023,7 @@ def: "From the distribution of ion injection times (MS:1000927) for MS2, the mea
 comment: Injection time distribution can be used to gauge the suitability of used instrument settings for the sample content used.
 is_a: MS:4000003 ! single value
 relationship: has_metric_category MS:4000009 ! ID free metric
+relationship: has_metric_category MS:4000022 ! MS2 metric
 relationship: has_value_concept STATO:0000401 ! sample mean
 relationship: has_units UO:0000028 ! millisecond
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
@@ -23008,6 +23035,7 @@ def: "From the distribution of ion injection times (MS:1000927) for MS2, the sig
 comment: Injection time distribution can be used to gauge the suitability of used instrument settings for the sample content used.
 is_a: MS:4000003 ! single value
 relationship: has_metric_category MS:4000009 ! ID free metric
+relationship: has_metric_category MS:4000022 ! MS2 metric
 relationship: has_value_concept STATO:0000237 ! standard deviation
 relationship: has_units UO:0000028 ! millisecond
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
@@ -23019,6 +23047,7 @@ def: "From the distribution of ion injection times (MS:1000927) for MS2, the lis
 comment: Injection time distribution can be used to gauge the suitability of used instrument settings for the sample content used.
 is_a: MS:4000004 ! n-tuple
 relationship: has_metric_category MS:4000009 ! ID free metric
+relationship: has_metric_category MS:4000022 ! MS2 metric
 relationship: has_value_concept STATO:0000036 ! outlier
 relationship: has_units UO:0000028 ! millisecond
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
@@ -23031,6 +23060,7 @@ def: "From the distribution of ion injection times (MS:1000927) for MS2, the lis
 comment: Injection time distribution can be used to gauge the suitability of used instrument settings for the sample content used.
 is_a: MS:4000004 ! n-tuple
 relationship: has_metric_category MS:4000009 ! ID free metric
+relationship: has_metric_category MS:4000022 ! MS2 metric
 relationship: has_value_concept STATO:0000036 ! outlier
 relationship: has_units UO:0000028 ! millisecond
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term

--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -1,6 +1,6 @@
 format-version: 1.2
-data-version: 4.1.110
-date: 09:12:2022 12:01
+data-version: 4.1.112
+date: 30:01:2023 11:30
 saved-by: Mathias Walzer
 auto-generated-by: OBO-Edit 2.3.1
 import: http://purl.obolibrary.org/obo/pato.obo
@@ -22661,7 +22661,7 @@ relationship: has_units UO:0000189 ! count unit
 
 [Term]
 id: MS:4000108
-name: MS1 peak density distribution - mean
+name: MS1 peak density distribution mean
 def: "From the distribution of peak densities in MS1, the mean" [PSI:MS]
 comment: The distribution of peak densities in MS1 can provide insight into the presence of nuisance factors.
 is_a: MS:4000003 ! single value
@@ -22672,7 +22672,7 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 	
 [Term]
 id: MS:4000109
-name: MS1 peak density distribution - sigma
+name: MS1 peak density distribution sigma
 def: "From the distribution of peak densities in MS1, the sigma value" [PSI:MS]
 comment: The distribution of peak densities in MS1 can provide insight into the presence of nuisance factors.
 is_a: MS:4000003 ! single value
@@ -22683,7 +22683,7 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 	
 [Term]
 id: MS:4000110
-name: MS1 peak density distribution - low outliers
+name: MS1 peak density distribution low outliers
 def: "From the distribution of peak densities in MS1, the list of outliers below a in-file defined threshold" [PSI:MS]
 comment: The distribution of peak densities in MS1 can provide insight into the presence of nuisance factors.
 is_a: MS:4000004 ! n-tuple
@@ -22694,7 +22694,7 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:4000111
-name: MS1 peak density distribution - high outliers
+name: MS1 peak density distribution high outliers
 def: "From the distribution of peak densities in MS1, the list of outliers above a in-file defined threshold" [PSI:MS]
 comment: The distribution of peak densities in MS1 can provide insight into the presence of nuisance factors.
 is_a: MS:4000004 ! n-tuple
@@ -22705,7 +22705,7 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:4000112
-name: MS2 peak density distribution - mean
+name: MS2 peak density distribution mean
 def: "From the distribution of peak densities in MS2, the mean" [PSI:MS]
 comment: The distribution of peak densities in MS2 can provide insight into the instruments ion selection settings.
 is_a: MS:4000003 ! single value
@@ -22716,7 +22716,7 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 	
 [Term]
 id: MS:4000113
-name: MS2 peak density distribution - sigma
+name: MS2 peak density distribution sigma
 def: "From the distribution of peak densities in MS2, the sigma value" [PSI:MS]
 comment: The distribution of peak densities in MS2 can provide insight into the instruments ion selection settings.
 is_a: MS:4000003 ! single value
@@ -22727,7 +22727,7 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 	
 [Term]
 id: MS:4000114
-name: MS2 peak density distribution - low outliers
+name: MS2 peak density distribution low outliers
 def: "From the distribution of peak densities in MS2, the list of outliers below a in-file defined threshold" [PSI:MS]
 comment: The distribution of peak densities in MS2 can provide insight into the instruments ion selection settings.
 is_a: MS:4000004 ! n-tuple
@@ -22738,7 +22738,7 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:4000115
-name: MS2 peak density distribution - high outliers
+name: MS2 peak density distribution high outliers
 def: "From the distribution of peak densities in MS2, the list of outliers above a in-file defined threshold" [PSI:MS]
 comment: The distribution of peak densities in MS2 can provide insight into the instruments ion selection settings.
 is_a: MS:4000004 ! n-tuple
@@ -22749,7 +22749,7 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:4000116
-name: precursor intensity distribution - quantiles
+name: precursor intensity distribution quantiles
 def: "From the distribution of precursor intensities, the quantiles. I.e. a value triplet represents the quartiles Q1, Q2, Q3" [PSI:MS]
 comment: The intensity distribution of the precursors informs about the dynamic range of the acquisition.
 is_a: MS:4000004 ! n-tuple
@@ -22761,7 +22761,7 @@ relationship: has_units MS:1000043 ! intensity unit
 
 [Term]
 id: MS:4000117
-name: precursor intensity distribution - mean
+name: precursor intensity distribution mean
 def: "From the distribution of precursor intensities, the mean" [PSI:MS]
 comment: The intensity distribution of the precursors informs about the dynamic range of the acquisition.
 is_a: MS:4000003 ! single value
@@ -22772,7 +22772,7 @@ relationship: has_units MS:1000043 ! intensity unit
 
 [Term]
 id: MS:4000118
-name: precursor intensity distribution - sigma
+name: precursor intensity distribution sigma
 def: "From the distribution of precursor intensities, the sigma value" [PSI:MS]
 comment: The intensity distribution of the precursors informs about the dynamic range of the acquisition.
 is_a: MS:4000003 ! single value
@@ -22783,7 +22783,7 @@ relationship: has_units MS:1000043 ! intensity unit
 	
 [Term]
 id: MS:4000119
-name: precursor intensity distribution - low outliers
+name: precursor intensity distribution low outliers
 def: "From the distribution of precursor intensities, the list of outliers below a in-file defined threshold" [PSI:MS]
 comment: The intensity distribution of the precursors informs about the dynamic range of the acquisition.
 is_a: MS:4000004 ! n-tuple
@@ -22794,7 +22794,7 @@ relationship: has_units MS:1000043 ! intensity unit
 
 [Term]
 id: MS:4000120
-name: precursor intensity distribution - high outliers
+name: precursor intensity distribution high outliers
 def: "From the distribution of precursor intensities, the list of outliers above a in-file defined threshold" [PSI:MS]
 comment: The intensity distribution of the precursors informs about the dynamic range of the acquisition.
 is_a: MS:4000004 ! n-tuple
@@ -22805,7 +22805,7 @@ relationship: has_units MS:1000043 ! intensity unit
 
 [Term]
 id: MS:4000121
-name: MS1 signal-to-noise ratio - quantiles
+name: MS1 signal-to-noise ratio quantiles
 def: "From the distribution of signal-to-noise ratio in MS1, the quantiles. I.e. a value triplet represents the quartiles Q1, Q2, Q3" [PSI:MS]
 comment: The Signal-to-noise ratio in MS1 distribution can provide insight to the presence of nuisance factors.
 is_a: MS:4000004 ! n-tuple
@@ -22816,7 +22816,7 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:4000122
-name: MS1 signal-to-noise ratio - mean
+name: MS1 signal-to-noise ratio mean
 comment: The signal-to-noise ratio in MS1 distribution can provide insight into the presence of nuisance factors. Comparisons will likely only make local sense where the same method of S/N calculation is applied (or overall the same software to calculate this metric, see mzQC 'analysisSoftware').
 def: "From the distribution of signal-to-noise ratio in MS1, the mean" [PSI:MS]
 is_a: MS:4000003 ! single value
@@ -22827,7 +22827,7 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 	
 [Term]
 id: MS:4000123
-name: MS1 signal-to-noise ratio - sigma
+name: MS1 signal-to-noise ratio sigma
 def: "From the distribution of signal-to-noise ratio in MS1, the sigma value" [PSI:MS]
 comment: The Signal-to-noise ratio in MS1 distribution can provide insight into the presence of nuisance factors. Comparisons will likely only make local sense where the same method of S/N calculation is applied (or overall the same software to calculate this metric, see mzQC 'analysisSoftware').
 is_a: MS:4000003 ! single value
@@ -22838,7 +22838,7 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 	
 [Term]
 id: MS:4000124
-name: MS1 signal-to-noise ratio - low outliers
+name: MS1 signal-to-noise ratio low outliers
 def: "From the distribution of signal-to-noise ratio in MS1, the list of outliers below Q1-1.5IQR" [PSI:MS]
 comment: The Signal-to-noise ratio in MS1 distribution can provide insight into the presence of nuisance factors. Comparisons will likely only make local sense where the same method of S/N calculation is applied (or overall the same software to calculate this metric, see mzQC 'analysisSoftware').
 is_a: MS:4000004 ! n-tuple
@@ -22849,7 +22849,7 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:4000125
-name: MS1 signal-to-noise ratio - high outliers
+name: MS1 signal-to-noise ratio high outliers
 def: "From the distribution of signal-to-noise ratio in MS1, the list of outliers above Q3+1.5IQR" [PSI:MS]
 comment: The Signal-to-noise ratio in MS1 distribution can provide insight into the presence of nuisance factors. Comparisons will likely only make local sense where the same method of S/N calculation is applied (or overall the same software to calculate this metric, see mzQC 'analysisSoftware').
 is_a: MS:4000004 ! n-tuple
@@ -22860,7 +22860,7 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:4000126
-name: signal-to-noise ratio in MS2 - quantiles
+name: MS2 signal-to-noise ratio quantiles
 def: "From the distribution of signal-to-noise ratio in MS2, the quantiles. I.e. a value triplet represents the quartiles Q1, Q2, Q3" [PSI:MS]
 comment: A high signal-to-noise ratio in MS2 distribution can explain a high rate of unidentified spectra. Comparisons will likely only make local sense where the same method of S/N calculation is applied (or overall the same software to calculate this metric, see mzQC 'analysisSoftware').
 is_a: MS:4000004 ! n-tuple
@@ -22871,7 +22871,7 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 	
 [Term]
 id: MS:4000127
-name: signal-to-noise ratio in MS2 - mean
+name: MS2 signal-to-noise ratio mean
 def: "From the distribution of signal-to-noise ratio in MS2, the mean" [PSI:MS]
 comment: A high signal-to-noise ratio in MS2 distribution can explain a high rate of unidentified spectra. Comparisons will likely only make local sense where the same method of S/N calculation is applied (or overall the same software to calculate this metric, see mzQC 'analysisSoftware').
 is_a: MS:4000003 ! single value
@@ -22882,7 +22882,7 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 	
 [Term]
 id: MS:4000128
-name: signal-to-noise ratio in MS2 - sigma
+name: MS2 signal-to-noise ratio sigma
 def: "From the distribution of signal-to-noise ratio in MS2, the sigma value" [PSI:MS]
 comment: A high signal-to-noise ratio in MS2 distribution can explain a high rate of unidentified spectra. Comparisons will likely only make local sense where the same method of S/N calculation is applied (or overall the same software to calculate this metric, see mzQC 'analysisSoftware').
 is_a: MS:4000003 ! single value
@@ -22893,7 +22893,7 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 	
 [Term]
 id: MS:4000129
-name: signal-to-noise ratio in MS2 - low outliers
+name: MS2 signal-to-noise ratio low outliers
 def: "From the distribution of signal-to-noise ratio in MS2, the list of outliers below Q1-1.5IQR" [PSI:MS]
 comment: A high signal-to-noise ratio in MS2 distribution can explain a high rate of unidentified spectra. Comparisons will likely only make local sense where the same method of S/N calculation is applied (or overall the same software to calculate this metric, see mzQC 'analysisSoftware').
 is_a: MS:4000004 ! n-tuple
@@ -22904,7 +22904,7 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:4000130
-name: signal-to-noise ratio in MS2 - high outliers
+name: MS2 signal-to-noise ratio high outliers
 def: "From the distribution of signal-to-noise ratio in MS2, the list of outliers above Q3+1.5IQR" [PSI:MS]
 comment: A high signal-to-noise ratio in MS2 distribution can explain a high rate of unidentified spectra. Comparisons will likely only make local sense where the same method of S/N calculation is applied (or overall the same software to calculate this metric, see mzQC 'analysisSoftware').
 is_a: MS:4000004 ! n-tuple
@@ -22915,7 +22915,7 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:4000131
-name: MS1 ion collection time - quantiles
+name: MS1 ion collection time quantiles
 def: "From the distribution of ion injection times (MS:1000927) for MS1, the quantiles. I.e. a value triplet represents the quartiles Q1, Q2, Q3" [PSI:MS]
 comment: Injection time distribution can be used to gauge the suitability of used instrument settings for the sample content used.
 is_a: MS:4000004 ! n-tuple
@@ -22926,7 +22926,7 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:4000132
-name: MS1 ion collection time - mean
+name: MS1 ion collection time mean
 def: "From the distribution of ion injection times (MS:1000927) for MS1, the mean" [PSI:MS]
 comment: Injection time distribution can be used to gauge the suitability of used instrument settings for the sample content used.
 is_a: MS:4000003 ! single value
@@ -22938,7 +22938,7 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 	
 [Term]
 id: MS:4000133
-name: MS1 ion collection time - sigma
+name: MS1 ion collection time sigma
 def: "From the distribution of ion injection times (MS:1000927) for MS1, the sigma value" [PSI:MS]
 comment: Injection time distribution can be used to gauge the suitability of used instrument settings for the sample content used.
 is_a: MS:4000003 ! single value
@@ -22950,7 +22950,7 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 	
 [Term]
 id: MS:4000134
-name: MS1 ion collection time - low outliers
+name: MS1 ion collection time low outliers
 def: "From the distribution of ion injection times (MS:1000927) for MS1, the list of outliers below a in-file defined threshold" [PSI:MS]
 comment: Injection time distribution can be used to gauge the suitability of used instrument settings for the sample content used.
 is_a: MS:4000004 ! n-tuple
@@ -22962,7 +22962,7 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:4000135
-name: MS1 ion collection time - high outliers
+name: MS1 ion collection time high outliers
 def: "From the distribution of ion injection times (MS:1000927) for MS1, the list of outliers above a in-file defined threshold" [PSI:MS]
 comment: Injection time distribution can be used to gauge the suitability of used instrument settings for the sample content used.
 is_a: MS:4000004 ! n-tuple
@@ -22974,7 +22974,7 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:4000136
-name: MS2 ion collection time - quantiles
+name: MS2 ion collection time quantiles
 def: "From the distribution of ion injection times (MS:1000927) for MS2, the quantiles. I.e. a value triplet represents the quartiles Q1, Q2, Q3" [PSI:MS]
 comment: Injection time distribution can be used to gauge the suitability of used instrument settings for the sample content used.
 is_a: MS:4000004 ! n-tuple
@@ -22985,7 +22985,7 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 	
 [Term]
 id: MS:4000137
-name: MS2 ion collection time - mean
+name: MS2 ion collection time mean
 def: "From the distribution of ion injection times (MS:1000927) for MS2, the mean" [PSI:MS]
 comment: Injection time distribution can be used to gauge the suitability of used instrument settings for the sample content used.
 is_a: MS:4000003 ! single value
@@ -22997,7 +22997,7 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 	
 [Term]
 id: MS:4000138
-name: MS2 ion collection time - sigma
+name: MS2 ion collection time sigma
 def: "From the distribution of ion injection times (MS:1000927) for MS2, the sigma value" [PSI:MS]
 comment: Injection time distribution can be used to gauge the suitability of used instrument settings for the sample content used.
 is_a: MS:4000003 ! single value
@@ -23009,7 +23009,7 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 	
 [Term]
 id: MS:4000139
-name: MS2 ion collection time - low outliers
+name: MS2 ion collection time low outliers
 def: "From the distribution of ion injection times (MS:1000927) for MS2, the list of outliers below a in-file defined threshold" [PSI:MS]
 comment: Injection time distribution can be used to gauge the suitability of used instrument settings for the sample content used.
 is_a: MS:4000004 ! n-tuple
@@ -23021,7 +23021,7 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:4000140
-name: MS2 ion collection time - high outliers
+name: MS2 ion collection time high outliers
 def: "From the distribution of ion injection times (MS:1000927) for MS2, the list of outliers above a in-file defined threshold" [PSI:MS]
 comment: Injection time distribution can be used to gauge the suitability of used instrument settings for the sample content used.
 is_a: MS:4000004 ! n-tuple
@@ -23044,13 +23044,13 @@ is_a: MS:4000141 ! outlier threshold criterion
 
 [Term]
 id: MS:4000143
-name: Tukey's fence - high outliers
+name: Tukey's fence high outliers
 def: "Defines high outliers with Tuckey's fence as >(Q3+x*IQR) for high outliers, where x is defined by the term's value. The default is x=1.5" [PSI:MS]
 is_a: MS:4000141 ! outlier threshold criterion
 
 [Term]
 id: MS:4000144
-name: Tukey's fence - low outliers
+name: Tukey's fence low outliers
 def: "Defines low outliers with Tuckey's fence as <(Q1-x*IQR) for low outliers, where x is defined by the term's value. The default is x=1.5" [PSI:MS]
 is_a: MS:4000141 ! outlier threshold criterion
 
@@ -23062,13 +23062,13 @@ is_a: MS:4000141 ! outlier threshold criterion
 
 [Term]
 id: MS:4000146
-name: Z-score threshold - high outliers
+name: Z-score threshold high outliers
 def: "Defines outliers with a Z-score threshold as <(-x) for low outliers and >(+x) for high outliers, where x is defined by the term's value. The default is x=3" [PSI:MS]
 is_a: MS:4000141 ! outlier threshold criterion
 
 [Term]
 id: MS:4000147
-name: Z-score threshold - low outliers
+name: Z-score threshold low outliers
 def: "Defines outliers with a Z-score threshold as <(-x) for low outliers and >(+x) for high outliers, where x is defined by the term's value. The default is x=3" [PSI:MS]
 is_a: MS:4000141 ! outlier threshold criterion
 

--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -22656,7 +22656,7 @@ relationship: has_value_type xsd:int ! The allowed value-type for this CV term
 relationship: has_units UO:0000189 ! count unit
 
 [Term]
-id: QC:4000108
+id: MS:4000108
 name: Peak density distribution MS1 Q1, Q2, Q3
 def: "From the distribution of peak densities in MS1, the quartiles Q1, Q2, Q3" [PSI:MS]
 comment: The distribution of peak densities in MS1 can provide insight into the presence of nuisance factors.
@@ -22668,7 +22668,7 @@ relationship: has_value_concept STATO:0000170 ! third quartile
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 	
 [Term]
-id: QC:4000158
+id: MS:4000109
 name: Peak density distribution MS1 mean
 def: "From the distribution of peak densities in MS1, the mean" [PSI:MS]
 comment: The distribution of peak densities in MS1 can provide insight into the presence of nuisance factors.
@@ -22678,7 +22678,7 @@ relationship: has_value_concept STATO:0000401 ! sample mean
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 	
 [Term]
-id: QC:4000159
+id: MS:4000110
 name: Peak density distribution MS1 sigma
 def: "From the distribution of peak densities in MS1, the sigma value" [PSI:MS]
 comment: The distribution of peak densities in MS1 can provide insight into the presence of nuisance factors.
@@ -22688,7 +22688,7 @@ relationship: has_value_concept STATO:0000237 ! standard deviation
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 	
 [Term]
-id: QC:4000160
+id: MS:4000111
 name: Peak density distribution MS1 low outliers (<Q1-1.5*IQR)
 def: "From the distribution of peak densities in MS1, the list of outliers below Q1-1.5*IQR" [PSI:MS]
 comment: The distribution of peak densities in MS1 can provide insight into the presence of nuisance factors.
@@ -22698,7 +22698,7 @@ relationship: has_value_concept STATO:0000036 ! outlier
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
-id: QC:4000161
+id: MS:4000112
 name: Peak density distribution MS1 high outliers (>Q3+1.5*IQR)
 def: "From the distribution of peak densities in MS1, the list of outliers above Q3+1.5*IQR" [PSI:MS]
 comment: The distribution of peak densities in MS1 can provide insight into the presence of nuisance factors.
@@ -22708,7 +22708,7 @@ relationship: has_value_concept STATO:0000036 ! outlier
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
-id: QC:4000162
+id: MS:4000113
 name: Peak density distribution MS2 Q1, Q2, Q3
 def: "From the distribution of peak densities in MS2, the quartiles Q1, Q2, Q3" [PSI:MS]
 comment: The distribution of peak densities in MS2 can provide insight into the instruments ion selction settings.
@@ -22720,7 +22720,7 @@ relationship: has_type STATO:0000170 ! third quartile
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 	
 [Term]
-id: QC:4000163
+id: MS:4000114
 name: Peak density distribution MS2 mean
 def: "From the distribution of peak densities in MS2, the mean" [PSI:MS]
 comment: The distribution of peak densities in MS2 can provide insight into the instruments ion selction settings.
@@ -22730,7 +22730,7 @@ relationship: has_value_concept STATO:0000401 ! sample mean
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 	
 [Term]
-id: QC:4000164
+id: MS:4000115
 name: Peak density distribution MS2 sigma
 def: "From the distribution of peak densities in MS2, the sigma value" [PSI:MS]
 comment: The distribution of peak densities in MS2 can provide insight into the instruments ion selction settings.
@@ -22740,7 +22740,7 @@ relationship: has_value_concept STATO:0000237 ! standard deviation
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 	
 [Term]
-id: QC:4000165
+id: MS:4000116
 name: Peak density distribution MS2 low outliers (<Q1-1.5*IQR)
 def: "From the distribution of peak densities in MS2, the list of outliers below Q1-1.5*IQR" [PSI:MS]
 comment: The distribution of peak densities in MS2 can provide insight into the instruments ion selction settings.
@@ -22750,7 +22750,7 @@ relationship: has_value_concept STATO:0000036 ! outlier
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
-id: QC:4000166
+id: MS:4000117
 name: Peak density distribution MS2 high outliers (>Q3+1.5*IQR)
 def: "From the distribution of peak densities in MS2, the list of outliers above Q3+1.5*IQR" [PSI:MS]
 comment: The distribution of peak densities in MS2 can provide insight into the instruments ion selction settings.
@@ -22760,7 +22760,7 @@ relationship: has_value_concept STATO:0000036 ! outlier
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
-id: QC:4000167
+id: MS:4000118
 name: Precursor intensity distribution Q1, Q2, Q3
 def: "From the distribution of precursor intensities, the quartiles Q1, Q2, Q3" [PSI:MS]
 comment: The intensity distribution of the precursors informs about the dynamic range of the acquisition.
@@ -22770,9 +22770,10 @@ relationship: has_value_concept STATO:0000167 ! first quartile
 relationship: has_value_concept STATO:0000574 ! center value
 relationship: has_value_concept STATO:0000170 ! third quartile
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
-	
+relationship: has_units MS:1000043 ! intensity unit
+
 [Term]
-id: QC:4000168
+id: MS:4000119
 name: Precursor intensity distribution mean
 def: "From the distribution of precursor intensities, the mean" [PSI:MS]
 comment: The intensity distribution of the precursors informs about the dynamic range of the acquisition.
@@ -22780,9 +22781,10 @@ is_a: MS:4000003 ! single value
 relationship: has_metric_category MS:4000009 ! ID free metric
 relationship: has_value_concept STATO:0000401 ! sample mean
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
-	
+relationship: has_units MS:1000043 ! intensity unit
+
 [Term]
-id: QC:4000169
+id: MS:4000120
 name: Precursor intensity distribution sigma
 def: "From the distribution of precursor intensities, the sigma value" [PSI:MS]
 comment: The intensity distribution of the precursors informs about the dynamic range of the acquisition.
@@ -22790,9 +22792,10 @@ is_a: MS:4000003 ! single value
 relationship: has_metric_category MS:4000009 ! ID free metric
 relationship: has_value_concept STATO:0000237 ! standard deviation
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
+relationship: has_units MS:1000043 ! intensity unit
 	
 [Term]
-id: QC:4000170
+id: MS:4000121
 name: Precursor intensity distribution low outliers (<Q1-1.5*IQR)
 def: "From the distribution of precursor intensities, the list of outliers below Q1-1.5*IQR" [PSI:MS]
 comment: The intensity distribution of the precursors informs about the dynamic range of the acquisition.
@@ -22800,9 +22803,10 @@ is_a: MS:4000004 ! n-tuple
 relationship: has_metric_category MS:4000009 ! ID free metric
 relationship: has_value_concept STATO:0000036 ! outlier
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
+relationship: has_units MS:1000043 ! intensity unit
 
 [Term]
-id: QC:4000171
+id: MS:4000122
 name: Precursor intensity distribution high outliers (>Q3+1.5*IQR)
 def: "From the distribution of precursor intensities, the list of outliers above Q3+1.5*IQR" [PSI:MS]
 comment: The intensity distribution of the precursors informs about the dynamic range of the acquisition.
@@ -22810,9 +22814,10 @@ is_a: MS:4000004 ! n-tuple
 relationship: has_metric_category MS:4000009 ! ID free metric
 relationship: has_value_concept STATO:0000036 ! outlier
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
+relationship: has_units MS:1000043 ! intensity unit
 
 [Term]
-id: QC:4000218
+id: MS:4000123
 name: Signal-to-noise ratio in MS1 - Q1, Q2, Q3
 def: "From the distribution of signal-to-noise ratio in MS1, the quartiles Q1, Q2, Q3 value" [PSI:MS]
 comment: The Signal-to-noise ratio in MS1 distribution can provide insight to the presence of nuisance factors.
@@ -22822,9 +22827,9 @@ relationship: has_value_concept STATO:0000167 ! first quartile
 relationship: has_value_concept STATO:0000574 ! center value
 relationship: has_value_concept STATO:0000170 ! third quartile
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
-	
+
 [Term]
-id: QC:4000219
+id: MS:4000124
 name: Signal-to-noise ratio in MS1 - mean
 comment: The signal-to-noise ratio in MS1 distribution can provide insight into the presence of nuisance factors. Comparisons will likely only make local sense where the same method of S/N calculation is applied (or overall the same software to calculate this metric, see mzQC 'analysisSoftware').
 def: "From the distribution of signal-to-noise ratio in MS1, the mean" [PSI:MS]
@@ -22834,7 +22839,7 @@ relationship: has_value_concept STATO:0000401 ! sample mean
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 	
 [Term]
-id: QC:4000220
+id: MS:4000125
 name: Signal-to-noise ratio in MS1 - sigma
 def: "From the distribution of signal-to-noise ratio in MS1, the sigma value" [PSI:MS]
 comment: The Signal-to-noise ratio in MS1 distribution can provide insight into the presence of nuisance factors. Comparisons will likely only make local sense where the same method of S/N calculation is applied (or overall the same software to calculate this metric, see mzQC 'analysisSoftware').
@@ -22844,7 +22849,7 @@ relationship: has_value_concept STATO:0000237 ! standard deviation
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 	
 [Term]
-id: QC:4000221
+id: MS:4000126
 name: Signal-to-noise ratio in MS1 - low outliers (<Q1-1.5*IQR)
 def: "From the distribution of signal-to-noise ratio in MS1, the list of outliers below Q1-1.5IQR" [PSI:MS]
 comment: The Signal-to-noise ratio in MS1 distribution can provide insight into the presence of nuisance factors. Comparisons will likely only make local sense where the same method of S/N calculation is applied (or overall the same software to calculate this metric, see mzQC 'analysisSoftware').
@@ -22854,7 +22859,7 @@ relationship: has_value_concept STATO:0000036 ! outlier
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
-id: QC:4000222
+id: MS:4000127
 name: Signal-to-noise ratio in MS1 - high outliers (>Q3+1.5*IQR)
 def: "From the distribution of signal-to-noise ratio in MS1, the list of outliers above Q3+1.5IQR" [PSI:MS]
 comment: The Signal-to-noise ratio in MS1 distribution can provide insight into the presence of nuisance factors. Comparisons will likely only make local sense where the same method of S/N calculation is applied (or overall the same software to calculate this metric, see mzQC 'analysisSoftware').
@@ -22864,7 +22869,7 @@ relationship: has_value_concept STATO:0000036 ! outlier
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
-id: QC:4000223
+id: MS:4000128
 name: Signal-to-noise ratio in MS2 - Q1, Q2, Q3
 def: "From the distribution of signal-to-noise ratio in MS2, the quartiles Q1, Q2, Q3 value" [PSI:MS]
 comment: A high signal-to-noise ratio in MS2 distribution can explain a high rate of unidentified spectra. Comparisons will likely only make local sense where the same method of S/N calculation is applied (or overall the same software to calculate this metric, see mzQC 'analysisSoftware').
@@ -22876,7 +22881,7 @@ relationship: has_value_concept STATO:0000170 ! third quartile
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 	
 [Term]
-id: QC:4000224
+id: MS:4000129
 name: Signal-to-noise ratio in MS2 - mean
 def: "From the distribution of signal-to-noise ratio in MS2, the mean" [PSI:MS]
 comment: A high signal-to-noise ratio in MS2 distribution can explain a high rate of unidentified spectra. Comparisons will likely only make local sense where the same method of S/N calculation is applied (or overall the same software to calculate this metric, see mzQC 'analysisSoftware').
@@ -22886,7 +22891,7 @@ relationship: has_value_concept STATO:0000401 ! sample mean
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 	
 [Term]
-id: QC:4000225
+id: MS:4000130
 name: Signal-to-noise ratio in MS2 - sigma
 def: "From the distribution of signal-to-noise ratio in MS2, the sigma value" [PSI:MS]
 comment: A high signal-to-noise ratio in MS2 distribution can explain a high rate of unidentified spectra. Comparisons will likely only make local sense where the same method of S/N calculation is applied (or overall the same software to calculate this metric, see mzQC 'analysisSoftware').
@@ -22896,7 +22901,7 @@ relationship: has_value_concept STATO:0000237 ! standard deviation
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 	
 [Term]
-id: QC:4000226
+id: MS:4000131
 name: Signal-to-noise ratio in MS2 - low outliers (<Q1-1.5*IQR)
 def: "From the distribution of signal-to-noise ratio in MS2, the list of outliers below Q1-1.5IQR" [PSI:MS]
 comment: A high signal-to-noise ratio in MS2 distribution can explain a high rate of unidentified spectra. Comparisons will likely only make local sense where the same method of S/N calculation is applied (or overall the same software to calculate this metric, see mzQC 'analysisSoftware').
@@ -22906,7 +22911,7 @@ relationship: has_value_concept STATO:0000036 ! outlier
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
-id: QC:4000227
+id: MS:4000132
 name: Signal-to-noise ratio in MS2 - high outliers (>Q3+1.5*IQR)
 def: "From the distribution of signal-to-noise ratio in MS2, the list of outliers above Q3+1.5IQR" [PSI:MS]
 comment: A high signal-to-noise ratio in MS2 distribution can explain a high rate of unidentified spectra. Comparisons will likely only make local sense where the same method of S/N calculation is applied (or overall the same software to calculate this metric, see mzQC 'analysisSoftware').
@@ -22916,7 +22921,7 @@ relationship: has_value_concept STATO:0000036 ! outlier
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
-id: QC:4000147
+id: MS:4000133
 name: MS1 ion collection time Q1, Q2, Q3
 def: "From the distribution of ion injection times (MS:1000927) for MS1, the quartiles Q1, Q2, Q3" [PSI:MS]
 comment: Injection time distribution can be used to gauge the suitability of used instrument settings for the sample content used.
@@ -22928,7 +22933,7 @@ relationship: has_units UO:0000028 ! millisecond
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
-id: QC:4000148
+id: MS:4000134
 name: MS1 ion collection time mean
 def: "From the distribution of ion injection times (MS:1000927) for MS1, the mean" [PSI:MS]
 comment: Injection time distribution can be used to gauge the suitability of used instrument settings for the sample content used.
@@ -22939,7 +22944,7 @@ relationship: has_units UO:0000028 ! millisecond
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 	
 [Term]
-id: QC:4000149
+id: MS:4000135
 name: MS1 ion collection time sigma
 def: "From the distribution of ion injection times (MS:1000927) for MS1, the sigma value" [PSI:MS]
 comment: Injection time distribution can be used to gauge the suitability of used instrument settings for the sample content used.
@@ -22950,7 +22955,7 @@ relationship: has_units UO:0000028 ! millisecond
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 	
 [Term]
-id: QC:4000150
+id: MS:4000136
 name: MS1 ion collection time low outliers (<Q1-1.5*IQR)
 def: "From the distribution of ion injection times (MS:1000927) for MS1, the list of outliers below Q1-1.5*IQR" [PSI:MS]
 comment: Injection time distribution can be used to gauge the suitability of used instrument settings for the sample content used.
@@ -22962,7 +22967,7 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 
 [Term]
-id: QC:4000151
+id: MS:4000137
 name: MS1 ion collection time high outliers (>Q3+1.5*IQR)
 def: "From the distribution of ion injection times (MS:1000927) for MS1, the list of outliers above Q3+1.5*IQR" [PSI:MS]
 comment: Injection time distribution can be used to gauge the suitability of used instrument settings for the sample content used.
@@ -22973,7 +22978,7 @@ relationship: has_units UO:0000028 ! millisecond
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
-id: QC:4000152
+id: MS:4000138
 name: MS2 ion collection time Q1, Q2, Q3
 def: "From the distribution of ion injection times (MS:1000927) for MS2, the quartiles Q1, Q2, Q3" [PSI:MS]
 comment: Injection time distribution can be used to gauge the suitability of used instrument settings for the sample content used.
@@ -22986,7 +22991,7 @@ relationship: has_units UO:0000028 ! millisecond
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 	
 [Term]
-id: QC:4000153
+id: MS:4000139
 name: MS2 ion collection time mean
 def: "From the distribution of ion injection times (MS:1000927) for MS2, the mean" [PSI:MS]
 comment: Injection time distribution can be used to gauge the suitability of used instrument settings for the sample content used.
@@ -22997,7 +23002,7 @@ relationship: has_units UO:0000028 ! millisecond
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 	
 [Term]
-id: QC:4000154
+id: MS:4000140
 name: MS2 ion collection time sigma
 def: "From the distribution of ion injection times (MS:1000927) for MS2, the sigma value" [PSI:MS]
 comment: Injection time distribution can be used to gauge the suitability of used instrument settings for the sample content used.
@@ -23008,7 +23013,7 @@ relationship: has_units UO:0000028 ! millisecond
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 	
 [Term]
-id: QC:4000155
+id: MS:4000141
 name: MS2 ion collection time low outliers (<Q1-1.5*IQR)
 def: "From the distribution of ion injection times (MS:1000927) for MS2, the list of outliers below Q1-1.5*IQR" [PSI:MS]
 comment: Injection time distribution can be used to gauge the suitability of used instrument settings for the sample content used.
@@ -23020,7 +23025,7 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 
 [Term]
-id: QC:4000156
+id: MS:4000142
 name: MS2 ion collection time high outliers (>Q3+1.5*IQR)
 def: "From the distribution of ion injection times (MS:1000927) for MS2, the list of outliers above Q3+1.5*IQR" [PSI:MS]
 comment: Injection time distribution can be used to gauge the suitability of used instrument settings for the sample content used.

--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -22199,6 +22199,7 @@ relationship: has_metric_category MS:4000012 ! single run based metric
 relationship: has_metric_category MS:4000021 ! MS1 metric
 relationship: has_value_type xsd:int ! The allowed value-type for this CV term
 relationship: has_value_concept NCIT:C45781 ! Density
+relationship: has_value_concept STATO:0000291 ! quantile
 relationship: has_units UO:0000189 ! count unit
 
 [Term]
@@ -22208,13 +22209,14 @@ def: "The first to n-th quantile of MS2 peak density (scan peak counts). A value
 synonym: "MS2-Density-Q1" RELATED [PMID:24494671]
 synonym: "MS2-Density-Q2" RELATED [PMID:24494671]
 synonym: "MS2-Density-Q3" RELATED [PMID:24494671]
-synonym: "MS1 peak density distribution - quantiles" EXACT []
+synonym: "MS2 peak density distribution - quantiles" EXACT []
 is_a: MS:4000004 ! n-tuple
 relationship: has_metric_category MS:4000009 ! ID free metric
 relationship: has_metric_category MS:4000012 ! single run based metric
 relationship: has_metric_category MS:4000022 ! MS2 metric
 relationship: has_value_type xsd:int ! The allowed value-type for this CV term
 relationship: has_value_concept NCIT:C45781 ! Density
+relationship: has_value_concept STATO:0000291 ! quantile
 relationship: has_units UO:0000189 ! count unit
 
 [Term]

--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -22657,7 +22657,7 @@ relationship: has_units UO:0000189 ! count unit
 
 [Term]
 id: MS:4000108
-name: peak density distribution MS1 Q1, Q2, Q3
+name: MS1 peak density distribution - Q1, Q2, Q3
 def: "From the distribution of peak densities in MS1, the quartiles Q1, Q2, Q3" [PSI:MS]
 comment: The distribution of peak densities in MS1 can provide insight into the presence of nuisance factors.
 is_a: MS:4000004 ! n-tuple
@@ -22669,7 +22669,7 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 	
 [Term]
 id: MS:4000109
-name: peak density distribution MS1 mean
+name: MS1 peak density distribution - mean
 def: "From the distribution of peak densities in MS1, the mean" [PSI:MS]
 comment: The distribution of peak densities in MS1 can provide insight into the presence of nuisance factors.
 is_a: MS:4000003 ! single value
@@ -22679,7 +22679,7 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 	
 [Term]
 id: MS:4000110
-name: peak density distribution MS1 sigma
+name: MS1 peak density distribution - sigma
 def: "From the distribution of peak densities in MS1, the sigma value" [PSI:MS]
 comment: The distribution of peak densities in MS1 can provide insight into the presence of nuisance factors.
 is_a: MS:4000003 ! single value
@@ -22689,7 +22689,7 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 	
 [Term]
 id: MS:4000111
-name: peak density distribution MS1 low outliers (<Q1-1.5*IQR)
+name: MS1 peak density distribution - low outliers (<Q1-1.5*IQR)
 def: "From the distribution of peak densities in MS1, the list of outliers below Q1-1.5*IQR" [PSI:MS]
 comment: The distribution of peak densities in MS1 can provide insight into the presence of nuisance factors.
 relationship: has_metric_category MS:4000009 ! ID free metric
@@ -22699,7 +22699,7 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:4000112
-name: peak density distribution MS1 high outliers (>Q3+1.5*IQR)
+name: MS1 peak density distribution - high outliers (>Q3+1.5*IQR)
 def: "From the distribution of peak densities in MS1, the list of outliers above Q3+1.5*IQR" [PSI:MS]
 comment: The distribution of peak densities in MS1 can provide insight into the presence of nuisance factors.
 is_a: MS:4000004 ! n-tuple
@@ -22709,7 +22709,7 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:4000113
-name: peak density distribution MS2 Q1, Q2, Q3
+name: MS2 peak density distribution - Q1, Q2, Q3
 def: "From the distribution of peak densities in MS2, the quartiles Q1, Q2, Q3" [PSI:MS]
 comment: The distribution of peak densities in MS2 can provide insight into the instruments ion selction settings.
 is_a: MS:4000004 ! n-tuple
@@ -22721,7 +22721,7 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 	
 [Term]
 id: MS:4000114
-name: peak density distribution MS2 mean
+name: MS2 peak density distribution - mean
 def: "From the distribution of peak densities in MS2, the mean" [PSI:MS]
 comment: The distribution of peak densities in MS2 can provide insight into the instruments ion selction settings.
 is_a: MS:4000003 ! single value
@@ -22731,7 +22731,7 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 	
 [Term]
 id: MS:4000115
-name: peak density distribution MS2 sigma
+name: MS2 peak density distribution - sigma
 def: "From the distribution of peak densities in MS2, the sigma value" [PSI:MS]
 comment: The distribution of peak densities in MS2 can provide insight into the instruments ion selction settings.
 is_a: MS:4000003 ! single value
@@ -22741,7 +22741,7 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 	
 [Term]
 id: MS:4000116
-name: peak density distribution MS2 low outliers (<Q1-1.5*IQR)
+name: MS2 peak density distribution - low outliers (<Q1-1.5*IQR)
 def: "From the distribution of peak densities in MS2, the list of outliers below Q1-1.5*IQR" [PSI:MS]
 comment: The distribution of peak densities in MS2 can provide insight into the instruments ion selction settings.
 is_a: MS:4000004 ! n-tuple
@@ -22751,7 +22751,7 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:4000117
-name: peak density distribution MS2 high outliers (>Q3+1.5*IQR)
+name: MS2 peak density distribution - high outliers (>Q3+1.5*IQR)
 def: "From the distribution of peak densities in MS2, the list of outliers above Q3+1.5*IQR" [PSI:MS]
 comment: The distribution of peak densities in MS2 can provide insight into the instruments ion selction settings.
 is_a: MS:4000004 ! n-tuple
@@ -22761,7 +22761,7 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:4000118
-name: precursor intensity distribution Q1, Q2, Q3
+name: precursor intensity distribution - Q1, Q2, Q3
 def: "From the distribution of precursor intensities, the quartiles Q1, Q2, Q3" [PSI:MS]
 comment: The intensity distribution of the precursors informs about the dynamic range of the acquisition.
 is_a: MS:4000004 ! n-tuple
@@ -22774,7 +22774,7 @@ relationship: has_units MS:1000043 ! intensity unit
 
 [Term]
 id: MS:4000119
-name: precursor intensity distribution mean
+name: precursor intensity distribution - mean
 def: "From the distribution of precursor intensities, the mean" [PSI:MS]
 comment: The intensity distribution of the precursors informs about the dynamic range of the acquisition.
 is_a: MS:4000003 ! single value
@@ -22785,7 +22785,7 @@ relationship: has_units MS:1000043 ! intensity unit
 
 [Term]
 id: MS:4000120
-name: precursor intensity distribution sigma
+name: precursor intensity distribution - sigma
 def: "From the distribution of precursor intensities, the sigma value" [PSI:MS]
 comment: The intensity distribution of the precursors informs about the dynamic range of the acquisition.
 is_a: MS:4000003 ! single value
@@ -22796,7 +22796,7 @@ relationship: has_units MS:1000043 ! intensity unit
 	
 [Term]
 id: MS:4000121
-name: precursor intensity distribution low outliers (<Q1-1.5*IQR)
+name: precursor intensity distribution - low outliers (<Q1-1.5*IQR)
 def: "From the distribution of precursor intensities, the list of outliers below Q1-1.5*IQR" [PSI:MS]
 comment: The intensity distribution of the precursors informs about the dynamic range of the acquisition.
 is_a: MS:4000004 ! n-tuple
@@ -22807,7 +22807,7 @@ relationship: has_units MS:1000043 ! intensity unit
 
 [Term]
 id: MS:4000122
-name: precursor intensity distribution high outliers (>Q3+1.5*IQR)
+name: precursor intensity distribution - high outliers (>Q3+1.5*IQR)
 def: "From the distribution of precursor intensities, the list of outliers above Q3+1.5*IQR" [PSI:MS]
 comment: The intensity distribution of the precursors informs about the dynamic range of the acquisition.
 is_a: MS:4000004 ! n-tuple
@@ -22818,7 +22818,7 @@ relationship: has_units MS:1000043 ! intensity unit
 
 [Term]
 id: MS:4000123
-name: signal-to-noise ratio in MS1 - Q1, Q2, Q3
+name: MS1 signal-to-noise ratio - Q1, Q2, Q3
 def: "From the distribution of signal-to-noise ratio in MS1, the quartiles Q1, Q2, Q3 value" [PSI:MS]
 comment: The Signal-to-noise ratio in MS1 distribution can provide insight to the presence of nuisance factors.
 is_a: MS:4000004 ! n-tuple
@@ -22830,7 +22830,7 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:4000124
-name: signal-to-noise ratio in MS1 - mean
+name: MS1 signal-to-noise ratio - mean
 comment: The signal-to-noise ratio in MS1 distribution can provide insight into the presence of nuisance factors. Comparisons will likely only make local sense where the same method of S/N calculation is applied (or overall the same software to calculate this metric, see mzQC 'analysisSoftware').
 def: "From the distribution of signal-to-noise ratio in MS1, the mean" [PSI:MS]
 is_a: MS:4000003 ! single value
@@ -22840,7 +22840,7 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 	
 [Term]
 id: MS:4000125
-name: signal-to-noise ratio in MS1 - sigma
+name: MS1 signal-to-noise ratio - sigma
 def: "From the distribution of signal-to-noise ratio in MS1, the sigma value" [PSI:MS]
 comment: The Signal-to-noise ratio in MS1 distribution can provide insight into the presence of nuisance factors. Comparisons will likely only make local sense where the same method of S/N calculation is applied (or overall the same software to calculate this metric, see mzQC 'analysisSoftware').
 is_a: MS:4000003 ! single value
@@ -22850,7 +22850,7 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 	
 [Term]
 id: MS:4000126
-name: signal-to-noise ratio in MS1 - low outliers (<Q1-1.5*IQR)
+name: MS1 signal-to-noise ratio - low outliers (<Q1-1.5*IQR)
 def: "From the distribution of signal-to-noise ratio in MS1, the list of outliers below Q1-1.5IQR" [PSI:MS]
 comment: The Signal-to-noise ratio in MS1 distribution can provide insight into the presence of nuisance factors. Comparisons will likely only make local sense where the same method of S/N calculation is applied (or overall the same software to calculate this metric, see mzQC 'analysisSoftware').
 is_a: MS:4000004 ! n-tuple
@@ -22860,7 +22860,7 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:4000127
-name: signal-to-noise ratio in MS1 - high outliers (>Q3+1.5*IQR)
+name: MS1 signal-to-noise ratio - high outliers (>Q3+1.5*IQR)
 def: "From the distribution of signal-to-noise ratio in MS1, the list of outliers above Q3+1.5IQR" [PSI:MS]
 comment: The Signal-to-noise ratio in MS1 distribution can provide insight into the presence of nuisance factors. Comparisons will likely only make local sense where the same method of S/N calculation is applied (or overall the same software to calculate this metric, see mzQC 'analysisSoftware').
 is_a: MS:4000004 ! n-tuple
@@ -22922,7 +22922,7 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:4000133
-name: MS1 ion collection time Q1, Q2, Q3
+name: MS1 ion collection time - Q1, Q2, Q3
 def: "From the distribution of ion injection times (MS:1000927) for MS1, the quartiles Q1, Q2, Q3" [PSI:MS]
 comment: Injection time distribution can be used to gauge the suitability of used instrument settings for the sample content used.
 is_a: MS:4000004 ! n-tuple
@@ -22934,7 +22934,7 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:4000134
-name: MS1 ion collection time mean
+name: MS1 ion collection time - mean
 def: "From the distribution of ion injection times (MS:1000927) for MS1, the mean" [PSI:MS]
 comment: Injection time distribution can be used to gauge the suitability of used instrument settings for the sample content used.
 is_a: MS:4000003 ! single value
@@ -22945,7 +22945,7 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 	
 [Term]
 id: MS:4000135
-name: MS1 ion collection time sigma
+name: MS1 ion collection time - sigma
 def: "From the distribution of ion injection times (MS:1000927) for MS1, the sigma value" [PSI:MS]
 comment: Injection time distribution can be used to gauge the suitability of used instrument settings for the sample content used.
 is_a: MS:4000003 ! single value
@@ -22956,7 +22956,7 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 	
 [Term]
 id: MS:4000136
-name: MS1 ion collection time low outliers (<Q1-1.5*IQR)
+name: MS1 ion collection time - low outliers (<Q1-1.5*IQR)
 def: "From the distribution of ion injection times (MS:1000927) for MS1, the list of outliers below Q1-1.5*IQR" [PSI:MS]
 comment: Injection time distribution can be used to gauge the suitability of used instrument settings for the sample content used.
 is_a: MS:4000004 ! n-tuple
@@ -22968,7 +22968,7 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:4000137
-name: MS1 ion collection time high outliers (>Q3+1.5*IQR)
+name: MS1 ion collection time - high outliers (>Q3+1.5*IQR)
 def: "From the distribution of ion injection times (MS:1000927) for MS1, the list of outliers above Q3+1.5*IQR" [PSI:MS]
 comment: Injection time distribution can be used to gauge the suitability of used instrument settings for the sample content used.
 is_a: MS:4000004 ! n-tuple
@@ -22979,7 +22979,7 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:4000138
-name: MS2 ion collection time Q1, Q2, Q3
+name: MS2 ion collection time - Q1, Q2, Q3
 def: "From the distribution of ion injection times (MS:1000927) for MS2, the quartiles Q1, Q2, Q3" [PSI:MS]
 comment: Injection time distribution can be used to gauge the suitability of used instrument settings for the sample content used.
 is_a: MS:4000004 ! n-tuple
@@ -22992,7 +22992,7 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 	
 [Term]
 id: MS:4000139
-name: MS2 ion collection time mean
+name: MS2 ion collection time - mean
 def: "From the distribution of ion injection times (MS:1000927) for MS2, the mean" [PSI:MS]
 comment: Injection time distribution can be used to gauge the suitability of used instrument settings for the sample content used.
 is_a: MS:4000003 ! single value
@@ -23003,7 +23003,7 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 	
 [Term]
 id: MS:4000140
-name: MS2 ion collection time sigma
+name: MS2 ion collection time - sigma
 def: "From the distribution of ion injection times (MS:1000927) for MS2, the sigma value" [PSI:MS]
 comment: Injection time distribution can be used to gauge the suitability of used instrument settings for the sample content used.
 is_a: MS:4000003 ! single value
@@ -23014,7 +23014,7 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 	
 [Term]
 id: MS:4000141
-name: MS2 ion collection time low outliers (<Q1-1.5*IQR)
+name: MS2 ion collection time - low outliers (<Q1-1.5*IQR)
 def: "From the distribution of ion injection times (MS:1000927) for MS2, the list of outliers below Q1-1.5*IQR" [PSI:MS]
 comment: Injection time distribution can be used to gauge the suitability of used instrument settings for the sample content used.
 is_a: MS:4000004 ! n-tuple
@@ -23026,7 +23026,7 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:4000142
-name: MS2 ion collection time high outliers (>Q3+1.5*IQR)
+name: MS2 ion collection time - high outliers (>Q3+1.5*IQR)
 def: "From the distribution of ion injection times (MS:1000927) for MS2, the list of outliers above Q3+1.5*IQR" [PSI:MS]
 comment: Injection time distribution can be used to gauge the suitability of used instrument settings for the sample content used.
 is_a: MS:4000004 ! n-tuple

--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -22896,8 +22896,8 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 [Term]
 id: MS:4000122
 name: MS1 signal-to-noise ratio mean
-comment: The signal-to-noise ratio in MS1 distribution can provide insight into the presence of nuisance factors. Comparisons will likely only make local sense where the same method of S/N calculation is applied (or overall the same software to calculate this metric, see mzQC 'analysisSoftware').
 def: "From the distribution of signal-to-noise ratio in MS1, the mean" [PSI:MS]
+comment: The signal-to-noise ratio in MS1 distribution can provide insight into the presence of nuisance factors. Comparisons will likely only make local sense where the same method of S/N calculation is applied (or overall the same software to calculate this metric, see mzQC 'analysisSoftware').
 is_a: MS:4000003 ! single value
 relationship: has_metric_category MS:4000009 ! ID free metric
 relationship: has_metric_category MS:4000021 ! MS1 metric
@@ -22918,7 +22918,7 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 [Term]
 id: MS:4000124
 name: MS1 signal-to-noise ratio low outliers
-def: "From the distribution of signal-to-noise ratio in MS1, the list of outliers below Q1-1.5IQR" [PSI:MS]
+def: "From the distribution of signal-to-noise ratio in MS1, the list of outliers below a in-file defined threshold" [PSI:MS]
 comment: The Signal-to-noise ratio in MS1 distribution can provide insight into the presence of nuisance factors. Comparisons will likely only make local sense where the same method of S/N calculation is applied (or overall the same software to calculate this metric, see mzQC 'analysisSoftware').
 is_a: MS:4000004 ! n-tuple
 relationship: has_metric_category MS:4000009 ! ID free metric
@@ -22929,7 +22929,7 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 [Term]
 id: MS:4000125
 name: MS1 signal-to-noise ratio high outliers
-def: "From the distribution of signal-to-noise ratio in MS1, the list of outliers above Q3+1.5IQR" [PSI:MS]
+def: "From the distribution of signal-to-noise ratio in MS1, the list of outliers above a in-file defined threshold" [PSI:MS]
 comment: The Signal-to-noise ratio in MS1 distribution can provide insight into the presence of nuisance factors. Comparisons will likely only make local sense where the same method of S/N calculation is applied (or overall the same software to calculate this metric, see mzQC 'analysisSoftware').
 is_a: MS:4000004 ! n-tuple
 relationship: has_metric_category MS:4000009 ! ID free metric
@@ -22973,7 +22973,7 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 [Term]
 id: MS:4000129
 name: MS2 signal-to-noise ratio low outliers
-def: "From the distribution of signal-to-noise ratio in MS2, the list of outliers below Q1-1.5IQR" [PSI:MS]
+def: "From the distribution of signal-to-noise ratio in MS2, the list of outliers below a in-file defined threshold" [PSI:MS]
 comment: A high signal-to-noise ratio in MS2 distribution can explain a high rate of unidentified spectra. Comparisons will likely only make local sense where the same method of S/N calculation is applied (or overall the same software to calculate this metric, see mzQC 'analysisSoftware').
 is_a: MS:4000004 ! n-tuple
 relationship: has_metric_category MS:4000009 ! ID free metric
@@ -22984,7 +22984,7 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 [Term]
 id: MS:4000130
 name: MS2 signal-to-noise ratio high outliers
-def: "From the distribution of signal-to-noise ratio in MS2, the list of outliers above Q3+1.5IQR" [PSI:MS]
+def: "From the distribution of signal-to-noise ratio in MS2, the list of outliers above a in-file defined threshold" [PSI:MS]
 comment: A high signal-to-noise ratio in MS2 distribution can explain a high rate of unidentified spectra. Comparisons will likely only make local sense where the same method of S/N calculation is applied (or overall the same software to calculate this metric, see mzQC 'analysisSoftware').
 is_a: MS:4000004 ! n-tuple
 relationship: has_metric_category MS:4000009 ! ID free metric
@@ -23118,19 +23118,19 @@ def: "The definition of the outlier criteria applied." [PSI:MS]
 [Term]
 id: MS:4000142
 name: Tukey's fence
-def: "Defines outliers with Tuckey's fence as <(Q1-x*IQR) for low outliers and >(Q3+x*IQR) for high outliers, where x is defined by the term's value. The default is x=1.5" [PSI:MS]
+def: "Defines outliers with Tukey's fence as <(Q1-x*IQR) for low outliers and >(Q3+x*IQR) for high outliers, where x is defined by the term's value. The default is x=1.5" [PSI:MS]
 is_a: MS:4000141 ! outlier threshold criterion
 
 [Term]
 id: MS:4000143
 name: Tukey's fence high outliers
-def: "Defines high outliers with Tuckey's fence as >(Q3+x*IQR) for high outliers, where x is defined by the term's value. The default is x=1.5" [PSI:MS]
+def: "Defines high outliers with Tukey's fence as >(Q3+x*IQR) for high outliers, where x is defined by the term's value. The default is x=1.5" [PSI:MS]
 is_a: MS:4000141 ! outlier threshold criterion
 
 [Term]
 id: MS:4000144
 name: Tukey's fence low outliers
-def: "Defines low outliers with Tuckey's fence as <(Q1-x*IQR) for low outliers, where x is defined by the term's value. The default is x=1.5" [PSI:MS]
+def: "Defines low outliers with Tukey's fence as <(Q1-x*IQR) for low outliers, where x is defined by the term's value. The default is x=1.5" [PSI:MS]
 is_a: MS:4000141 ! outlier threshold criterion
 
 [Term]

--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -22192,6 +22192,7 @@ def: "The first to n-th quantile of MS1 peak density (scan peak counts). A value
 synonym: "MS1-Density-Q1" RELATED [PMID:24494671]
 synonym: "MS1-Density-Q2" RELATED [PMID:24494671]
 synonym: "MS1-Density-Q3" RELATED [PMID:24494671]
+synonym: "MS1 peak density distribution - quantiles" EXACT []
 is_a: MS:4000004 ! n-tuple
 relationship: has_metric_category MS:4000009 ! ID free metric
 relationship: has_metric_category MS:4000012 ! single run based metric
@@ -22207,6 +22208,7 @@ def: "The first to n-th quantile of MS2 peak density (scan peak counts). A value
 synonym: "MS2-Density-Q1" RELATED [PMID:24494671]
 synonym: "MS2-Density-Q2" RELATED [PMID:24494671]
 synonym: "MS2-Density-Q3" RELATED [PMID:24494671]
+synonym: "MS1 peak density distribution - quantiles" EXACT []
 is_a: MS:4000004 ! n-tuple
 relationship: has_metric_category MS:4000009 ! ID free metric
 relationship: has_metric_category MS:4000012 ! single run based metric
@@ -22656,17 +22658,6 @@ relationship: has_value_type xsd:int ! The allowed value-type for this CV term
 relationship: has_units UO:0000189 ! count unit
 
 [Term]
-id: MS:4000108
-name: MS1 peak density distribution - quantiles
-def: "From the distribution of peak densities in MS1, the quantiles. I.e. a value triplet represents the quartiles Q1, Q2, Q3" [PSI:MS]
-comment: The distribution of peak densities in MS1 can provide insight into the presence of nuisance factors.
-is_a: MS:4000004 ! n-tuple
-relationship: has_metric_category MS:4000009 ! ID free metric
-relationship: has_metric_category MS:4000021 ! MS1 metric
-relationship: has_value_concept STATO:0000291 ! quantile
-relationship: has_value_type xsd:float ! The allowed value-type for this CV term
-	
-[Term]
 id: MS:4000109
 name: MS1 peak density distribution - mean
 def: "From the distribution of peak densities in MS1, the mean" [PSI:MS]
@@ -22710,19 +22701,6 @@ relationship: has_metric_category MS:4000021 ! MS1 metric
 relationship: has_value_concept STATO:0000036 ! outlier
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
-[Term]
-id: MS:4000113
-name: MS2 peak density distribution - quantiles
-def: "From the distribution of peak densities in MS2, the quantiles. I.e. a value triplet represents the quartiles Q1, Q2, Q3" [PSI:MS]
-comment: The distribution of peak densities in MS2 can provide insight into the instruments ion selection settings.
-is_a: MS:4000004 ! n-tuple
-relationship: has_metric_category MS:4000009 ! ID free metric
-relationship: has_metric_category MS:4000022 ! MS2 metric
-relationship: has_type STATO:0000167 ! first quartile
-relationship: has_type STATO:0000574 ! center value
-relationship: has_type STATO:0000170 ! third quartile
-relationship: has_value_type xsd:float ! The allowed value-type for this CV term
-	
 [Term]
 id: MS:4000114
 name: MS2 peak density distribution - mean

--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -22657,7 +22657,7 @@ relationship: has_units UO:0000189 ! count unit
 
 [Term]
 id: MS:4000108
-name: Peak density distribution MS1 Q1, Q2, Q3
+name: peak density distribution MS1 Q1, Q2, Q3
 def: "From the distribution of peak densities in MS1, the quartiles Q1, Q2, Q3" [PSI:MS]
 comment: The distribution of peak densities in MS1 can provide insight into the presence of nuisance factors.
 is_a: MS:4000004 ! n-tuple
@@ -22669,7 +22669,7 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 	
 [Term]
 id: MS:4000109
-name: Peak density distribution MS1 mean
+name: peak density distribution MS1 mean
 def: "From the distribution of peak densities in MS1, the mean" [PSI:MS]
 comment: The distribution of peak densities in MS1 can provide insight into the presence of nuisance factors.
 is_a: MS:4000003 ! single value
@@ -22679,7 +22679,7 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 	
 [Term]
 id: MS:4000110
-name: Peak density distribution MS1 sigma
+name: peak density distribution MS1 sigma
 def: "From the distribution of peak densities in MS1, the sigma value" [PSI:MS]
 comment: The distribution of peak densities in MS1 can provide insight into the presence of nuisance factors.
 is_a: MS:4000003 ! single value
@@ -22689,7 +22689,7 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 	
 [Term]
 id: MS:4000111
-name: Peak density distribution MS1 low outliers (<Q1-1.5*IQR)
+name: peak density distribution MS1 low outliers (<Q1-1.5*IQR)
 def: "From the distribution of peak densities in MS1, the list of outliers below Q1-1.5*IQR" [PSI:MS]
 comment: The distribution of peak densities in MS1 can provide insight into the presence of nuisance factors.
 relationship: has_metric_category MS:4000009 ! ID free metric
@@ -22699,7 +22699,7 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:4000112
-name: Peak density distribution MS1 high outliers (>Q3+1.5*IQR)
+name: peak density distribution MS1 high outliers (>Q3+1.5*IQR)
 def: "From the distribution of peak densities in MS1, the list of outliers above Q3+1.5*IQR" [PSI:MS]
 comment: The distribution of peak densities in MS1 can provide insight into the presence of nuisance factors.
 is_a: MS:4000004 ! n-tuple
@@ -22709,7 +22709,7 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:4000113
-name: Peak density distribution MS2 Q1, Q2, Q3
+name: peak density distribution MS2 Q1, Q2, Q3
 def: "From the distribution of peak densities in MS2, the quartiles Q1, Q2, Q3" [PSI:MS]
 comment: The distribution of peak densities in MS2 can provide insight into the instruments ion selction settings.
 is_a: MS:4000004 ! n-tuple
@@ -22721,7 +22721,7 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 	
 [Term]
 id: MS:4000114
-name: Peak density distribution MS2 mean
+name: peak density distribution MS2 mean
 def: "From the distribution of peak densities in MS2, the mean" [PSI:MS]
 comment: The distribution of peak densities in MS2 can provide insight into the instruments ion selction settings.
 is_a: MS:4000003 ! single value
@@ -22731,7 +22731,7 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 	
 [Term]
 id: MS:4000115
-name: Peak density distribution MS2 sigma
+name: peak density distribution MS2 sigma
 def: "From the distribution of peak densities in MS2, the sigma value" [PSI:MS]
 comment: The distribution of peak densities in MS2 can provide insight into the instruments ion selction settings.
 is_a: MS:4000003 ! single value
@@ -22741,7 +22741,7 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 	
 [Term]
 id: MS:4000116
-name: Peak density distribution MS2 low outliers (<Q1-1.5*IQR)
+name: peak density distribution MS2 low outliers (<Q1-1.5*IQR)
 def: "From the distribution of peak densities in MS2, the list of outliers below Q1-1.5*IQR" [PSI:MS]
 comment: The distribution of peak densities in MS2 can provide insight into the instruments ion selction settings.
 is_a: MS:4000004 ! n-tuple
@@ -22751,7 +22751,7 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:4000117
-name: Peak density distribution MS2 high outliers (>Q3+1.5*IQR)
+name: peak density distribution MS2 high outliers (>Q3+1.5*IQR)
 def: "From the distribution of peak densities in MS2, the list of outliers above Q3+1.5*IQR" [PSI:MS]
 comment: The distribution of peak densities in MS2 can provide insight into the instruments ion selction settings.
 is_a: MS:4000004 ! n-tuple
@@ -22761,7 +22761,7 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:4000118
-name: Precursor intensity distribution Q1, Q2, Q3
+name: precursor intensity distribution Q1, Q2, Q3
 def: "From the distribution of precursor intensities, the quartiles Q1, Q2, Q3" [PSI:MS]
 comment: The intensity distribution of the precursors informs about the dynamic range of the acquisition.
 is_a: MS:4000004 ! n-tuple
@@ -22774,7 +22774,7 @@ relationship: has_units MS:1000043 ! intensity unit
 
 [Term]
 id: MS:4000119
-name: Precursor intensity distribution mean
+name: precursor intensity distribution mean
 def: "From the distribution of precursor intensities, the mean" [PSI:MS]
 comment: The intensity distribution of the precursors informs about the dynamic range of the acquisition.
 is_a: MS:4000003 ! single value
@@ -22785,7 +22785,7 @@ relationship: has_units MS:1000043 ! intensity unit
 
 [Term]
 id: MS:4000120
-name: Precursor intensity distribution sigma
+name: precursor intensity distribution sigma
 def: "From the distribution of precursor intensities, the sigma value" [PSI:MS]
 comment: The intensity distribution of the precursors informs about the dynamic range of the acquisition.
 is_a: MS:4000003 ! single value
@@ -22796,7 +22796,7 @@ relationship: has_units MS:1000043 ! intensity unit
 	
 [Term]
 id: MS:4000121
-name: Precursor intensity distribution low outliers (<Q1-1.5*IQR)
+name: precursor intensity distribution low outliers (<Q1-1.5*IQR)
 def: "From the distribution of precursor intensities, the list of outliers below Q1-1.5*IQR" [PSI:MS]
 comment: The intensity distribution of the precursors informs about the dynamic range of the acquisition.
 is_a: MS:4000004 ! n-tuple
@@ -22807,7 +22807,7 @@ relationship: has_units MS:1000043 ! intensity unit
 
 [Term]
 id: MS:4000122
-name: Precursor intensity distribution high outliers (>Q3+1.5*IQR)
+name: precursor intensity distribution high outliers (>Q3+1.5*IQR)
 def: "From the distribution of precursor intensities, the list of outliers above Q3+1.5*IQR" [PSI:MS]
 comment: The intensity distribution of the precursors informs about the dynamic range of the acquisition.
 is_a: MS:4000004 ! n-tuple
@@ -22818,7 +22818,7 @@ relationship: has_units MS:1000043 ! intensity unit
 
 [Term]
 id: MS:4000123
-name: Signal-to-noise ratio in MS1 - Q1, Q2, Q3
+name: signal-to-noise ratio in MS1 - Q1, Q2, Q3
 def: "From the distribution of signal-to-noise ratio in MS1, the quartiles Q1, Q2, Q3 value" [PSI:MS]
 comment: The Signal-to-noise ratio in MS1 distribution can provide insight to the presence of nuisance factors.
 is_a: MS:4000004 ! n-tuple
@@ -22830,7 +22830,7 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:4000124
-name: Signal-to-noise ratio in MS1 - mean
+name: signal-to-noise ratio in MS1 - mean
 comment: The signal-to-noise ratio in MS1 distribution can provide insight into the presence of nuisance factors. Comparisons will likely only make local sense where the same method of S/N calculation is applied (or overall the same software to calculate this metric, see mzQC 'analysisSoftware').
 def: "From the distribution of signal-to-noise ratio in MS1, the mean" [PSI:MS]
 is_a: MS:4000003 ! single value
@@ -22840,7 +22840,7 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 	
 [Term]
 id: MS:4000125
-name: Signal-to-noise ratio in MS1 - sigma
+name: signal-to-noise ratio in MS1 - sigma
 def: "From the distribution of signal-to-noise ratio in MS1, the sigma value" [PSI:MS]
 comment: The Signal-to-noise ratio in MS1 distribution can provide insight into the presence of nuisance factors. Comparisons will likely only make local sense where the same method of S/N calculation is applied (or overall the same software to calculate this metric, see mzQC 'analysisSoftware').
 is_a: MS:4000003 ! single value
@@ -22850,7 +22850,7 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 	
 [Term]
 id: MS:4000126
-name: Signal-to-noise ratio in MS1 - low outliers (<Q1-1.5*IQR)
+name: signal-to-noise ratio in MS1 - low outliers (<Q1-1.5*IQR)
 def: "From the distribution of signal-to-noise ratio in MS1, the list of outliers below Q1-1.5IQR" [PSI:MS]
 comment: The Signal-to-noise ratio in MS1 distribution can provide insight into the presence of nuisance factors. Comparisons will likely only make local sense where the same method of S/N calculation is applied (or overall the same software to calculate this metric, see mzQC 'analysisSoftware').
 is_a: MS:4000004 ! n-tuple
@@ -22860,7 +22860,7 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:4000127
-name: Signal-to-noise ratio in MS1 - high outliers (>Q3+1.5*IQR)
+name: signal-to-noise ratio in MS1 - high outliers (>Q3+1.5*IQR)
 def: "From the distribution of signal-to-noise ratio in MS1, the list of outliers above Q3+1.5IQR" [PSI:MS]
 comment: The Signal-to-noise ratio in MS1 distribution can provide insight into the presence of nuisance factors. Comparisons will likely only make local sense where the same method of S/N calculation is applied (or overall the same software to calculate this metric, see mzQC 'analysisSoftware').
 is_a: MS:4000004 ! n-tuple
@@ -22870,7 +22870,7 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:4000128
-name: Signal-to-noise ratio in MS2 - Q1, Q2, Q3
+name: signal-to-noise ratio in MS2 - Q1, Q2, Q3
 def: "From the distribution of signal-to-noise ratio in MS2, the quartiles Q1, Q2, Q3 value" [PSI:MS]
 comment: A high signal-to-noise ratio in MS2 distribution can explain a high rate of unidentified spectra. Comparisons will likely only make local sense where the same method of S/N calculation is applied (or overall the same software to calculate this metric, see mzQC 'analysisSoftware').
 is_a: MS:4000004 ! n-tuple
@@ -22882,7 +22882,7 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 	
 [Term]
 id: MS:4000129
-name: Signal-to-noise ratio in MS2 - mean
+name: signal-to-noise ratio in MS2 - mean
 def: "From the distribution of signal-to-noise ratio in MS2, the mean" [PSI:MS]
 comment: A high signal-to-noise ratio in MS2 distribution can explain a high rate of unidentified spectra. Comparisons will likely only make local sense where the same method of S/N calculation is applied (or overall the same software to calculate this metric, see mzQC 'analysisSoftware').
 is_a: MS:4000003 ! single value
@@ -22892,7 +22892,7 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 	
 [Term]
 id: MS:4000130
-name: Signal-to-noise ratio in MS2 - sigma
+name: signal-to-noise ratio in MS2 - sigma
 def: "From the distribution of signal-to-noise ratio in MS2, the sigma value" [PSI:MS]
 comment: A high signal-to-noise ratio in MS2 distribution can explain a high rate of unidentified spectra. Comparisons will likely only make local sense where the same method of S/N calculation is applied (or overall the same software to calculate this metric, see mzQC 'analysisSoftware').
 is_a: MS:4000003 ! single value
@@ -22902,7 +22902,7 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 	
 [Term]
 id: MS:4000131
-name: Signal-to-noise ratio in MS2 - low outliers (<Q1-1.5*IQR)
+name: signal-to-noise ratio in MS2 - low outliers (<Q1-1.5*IQR)
 def: "From the distribution of signal-to-noise ratio in MS2, the list of outliers below Q1-1.5IQR" [PSI:MS]
 comment: A high signal-to-noise ratio in MS2 distribution can explain a high rate of unidentified spectra. Comparisons will likely only make local sense where the same method of S/N calculation is applied (or overall the same software to calculate this metric, see mzQC 'analysisSoftware').
 is_a: MS:4000004 ! n-tuple
@@ -22912,7 +22912,7 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
 id: MS:4000132
-name: Signal-to-noise ratio in MS2 - high outliers (>Q3+1.5*IQR)
+name: signal-to-noise ratio in MS2 - high outliers (>Q3+1.5*IQR)
 def: "From the distribution of signal-to-noise ratio in MS2, the list of outliers above Q3+1.5IQR" [PSI:MS]
 comment: A high signal-to-noise ratio in MS2 distribution can explain a high rate of unidentified spectra. Comparisons will likely only make local sense where the same method of S/N calculation is applied (or overall the same software to calculate this metric, see mzQC 'analysisSoftware').
 is_a: MS:4000004 ! n-tuple


### PR DESCRIPTION
This PR introduces descriptive statistic metrics terms. Some (though not all of the included) items can already be represented with existing terms, this however an alternative/more condensed and flexible representation version of metrics.
Each distribution is represented by a term for the quartiles, for the standard deviation, the mean, and 'outliers' below or above 1.5*IQR. 
Adds terms for:
* peak densities
* S/N
* ion-collection times
