### PR TITLE
Add specific mass array types for top-down MS encoding

### DIFF
--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -1,5 +1,5 @@
 format-version: 1.2
-data-version: 4.1.118
+data-version: 4.1.119
 date: 31:03:2023 11:30
 saved-by: Joshua Klein
 auto-generated-by: OBO-Edit 2.3.1
@@ -22187,6 +22187,33 @@ name: tailor score
 def: "A calibrated version of the XCorr score, computed by dividing the XCorr by the 99th percentile of the distribution of all scores for a particular spectrum." [PMID:32175744]
 is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_value_type xsd:double ! The allowed value-type for this CV term
+
+[Term]
+id: MS:1003367
+name: monoisotopic mass array
+def: "A data array of deisotoped neutral mass values corresponding to the estimated monoisotopic masses of the measured ions." [PSI:MS]
+xref: binary-data-type:MS\:1000521 "32-bit float"
+xref: binary-data-type:MS\:1000523 "64-bit float"
+is_a: MS:1003143 ! mass array
+relationship: has_units UO:0000221 ! dalton
+
+[Term]
+id: MS:1003368
+name: most abundant mass array
+def: "A data array of deisotoped neutral mass values corresponding to the mass of the most abundant isotopic peak of the measured ions." [PSI:MS]
+xref: binary-data-type:MS\:1000521 "32-bit float"
+xref: binary-data-type:MS\:1000523 "64-bit float"
+is_a: MS:1003143 ! mass array
+relationship: has_units UO:0000221 ! dalton
+
+[Term]
+id: MS:1003369
+name: average mass array
+def: "A data array of deisotoped neutral mass values corresponding to the mass of the most average mass of the measured ions." [PSI:MS]
+xref: binary-data-type:MS\:1000521 "32-bit float"
+xref: binary-data-type:MS\:1000523 "64-bit float"
+is_a: MS:1003143 ! mass array
+relationship: has_units UO:0000221 ! dalton
 
 [Term]
 id: MS:4000000

--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -424,7 +424,7 @@ relationship: has_value_type xsd:string ! The allowed value-type for this CV ter
 [Term]
 id: MS:1000033
 name: deisotoping
-def: "The removal of isotope peaks to represent the fragment ion as one data point and is commonly done to reduce complexity. It is done in conjunction with the charge state deconvolution." [PSI:MS]
+def: "The removal of isotope peaks to represent the ion as one data point and is commonly done to reduce complexity. It is done in conjunction with the charge state deconvolution." [PSI:MS]
 is_a: MS:1000543 ! data processing action
 
 [Term]
@@ -22190,34 +22190,25 @@ relationship: has_value_type xsd:double ! The allowed value-type for this CV ter
 
 [Term]
 id: MS:1003367
-name: monoisotopic mass array
-def: "A data array of deisotoped neutral mass values corresponding to the estimated monoisotopic masses of the measured ions." [PSI:MS]
-xref: binary-data-type:MS\:1000521 "32-bit float"
-xref: binary-data-type:MS\:1000523 "64-bit float"
-is_a: MS:1003143 ! mass array
-relationship: has_units UO:0000221 ! dalton
+name: monoisotopic mass deisotoping
+def: "The removal of isotope peaks to represent each ion as one data point corresponding to the ion's monoisotopic mass. It is done in conjunction with the charge state deconvolution." [PSI:MS]
+is_a: MS:1000033 ! deisotoping
 
 [Term]
 id: MS:1003368
-name: most abundant mass array
-def: "A data array of deisotoped neutral mass values corresponding to the mass of the most abundant isotopic peak of the measured ions." [PSI:MS]
-xref: binary-data-type:MS\:1000521 "32-bit float"
-xref: binary-data-type:MS\:1000523 "64-bit float"
-is_a: MS:1003143 ! mass array
-relationship: has_units UO:0000221 ! dalton
+name: most abundant mass deisotoping
+def: "The removal of isotope peaks to represent each ion as one data point corresponding to the ion's most abundant isotopic mass. It is done in conjunction with the charge state deconvolution." [PSI:MS]
+is_a: MS:1000033 ! deisotoping
 
 [Term]
 id: MS:1003369
-name: average mass array
-def: "A data array of deisotoped neutral mass values corresponding to the mass of the most average mass of the measured ions." [PSI:MS]
-xref: binary-data-type:MS\:1000521 "32-bit float"
-xref: binary-data-type:MS\:1000523 "64-bit float"
-is_a: MS:1003143 ! mass array
-relationship: has_units UO:0000221 ! dalton
+name: average mass deisotoping
+def: "The removal of isotope peaks to represent each ion as one data point corresponding to the ion's average mass. It is done in conjunction with the charge state deconvolution." [PSI:MS]
+is_a: MS:1000033 ! deisotoping
 
 [Term]
 id: MS:1003370
-name: reduction to summed singly charged peak list
+name: decharging
 def: "The summing of peaks corresponding to the same mass at multiple charge states and presented as singly charged m/z." [PSI:MS]
 is_a: MS:1000543 ! data processing action
 

--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -22216,6 +22216,12 @@ is_a: MS:1003143 ! mass array
 relationship: has_units UO:0000221 ! dalton
 
 [Term]
+id: MS:1003370
+name: reduction to summed singly charged peak list
+def: "The summing of peaks corresponding to the same mass at multiple charge states and presented as singly charged m/z." [PSI:MS]
+is_a: MS:1000543 ! data processing action
+
+[Term]
 id: MS:4000000
 name: PSI-MS CV Quality Control Vocabulary
 def: "PSI Quality Control controlled vocabulary term." [PSI:MS]

--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -22208,7 +22208,7 @@ is_a: MS:1000033 ! deisotoping
 
 [Term]
 id: MS:1003370
-name: decharging
+name: reduction to summed singly charged peak list
 def: "The summing of peaks corresponding to the same mass at multiple charge states and presented as singly charged m/z." [PSI:MS]
 is_a: MS:1000543 ! data processing action
 


### PR DESCRIPTION
Discussion last year that @dtabb73 initiated suggested that the neutral mass array type is insufficient to describe the range of data types for top-down MS. Sometimes we may want to talk about monoisotopic mass, while in other scenarios we may want to describe the most abundant isotope's mass and there was no way to express this.

Alternatives:
Different units?
```xml
<binaryDataArray>
     <cvParam accession="MS:1000514" cvRef="PSI-MS" name="m/z array" unitAccession="MS:1000???" unitCvRef="PSI-MS" unitName="monoisotopic m/z" value=""/>
     ...
</binaryDataArray>  
```
Extra CV term?
```xml
<binaryDataArray>
     <cvParam accession="MS:1000???" cvRef="PSI-MS" name="most abundant m/z summarization" />
     <cvParam accession="MS:1000514" cvRef="PSI-MS" name="m/z array" unitAccession="MS:1000040" unitCvRef="PSI-MS" unitName="m/z" value=""/>
     ...
</binaryDataArray>
```

There are more complex array types to be discussed later.