### PR TITLE
Add extension document versioning

### DIFF
--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -22222,7 +22222,7 @@ relationship: part_of MS:0000000 ! Proteomics Standards Initiative Mass Spectrom
 id: MS:1003373
 name: mzIdentML extension version
 def: "The versioning of an mzIdentML extension document." [PSI:PI]
-relationship: part_of MS:0000000 ! Proteomics Standards Initiative Mass Spectrometry Vocabularies
+is_a: MS:1003372 ! mzIdentML extension version
 relationship: part_of MS:1002073 ! mzIdentML format
 relationship: has_value_type xsd:string
 

--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -1,6 +1,6 @@
 format-version: 1.2
-data-version: 4.1.119
-date: 31:03:2023 11:30
+data-version: 4.1.121
+date: 04:05:2023 11:30
 saved-by: Joshua Klein
 auto-generated-by: OBO-Edit 2.3.1
 import: http://purl.obolibrary.org/obo/pato.obo
@@ -22211,6 +22211,20 @@ id: MS:1003370
 name: reduction to summed singly charged peak list
 def: "The summing of peaks corresponding to the same mass at multiple charge states and presented as singly charged m/z." [PSI:MS]
 is_a: MS:1000543 ! data processing action
+
+[Term]
+id: MS:1003372
+name: specification document extension version
+def: "The versioning of a an extension to a specification document that the current file requires to be read correctly. The version should encode the name of the extension, and some ordinal expression of its revision, preferably in semantic versioning notation. Signals that readers that do not know this extension should return an appropriately informative error if they do not think they can or should try to interpret the file." [PSI:MS]
+relationship: part_of MS:0000000 ! Proteomics Standards Initiative Mass Spectrometry Vocabularies
+
+[Term]
+id: MS:1003373
+name: mzIdentML extension version
+def: "The versioning of an mzIdentML extension document." [PSI:PI]
+relationship: part_of MS:0000000 ! Proteomics Standards Initiative Mass Spectrometry Vocabularies
+relationship: part_of MS:1002073 ! mzIdentML format
+relationship: has_value_type xsd:string
 
 [Term]
 id: MS:4000000

--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -22222,7 +22222,7 @@ relationship: part_of MS:0000000 ! Proteomics Standards Initiative Mass Spectrom
 id: MS:1003373
 name: mzIdentML extension version
 def: "The versioning of an mzIdentML extension document." [PSI:PI]
-is_a: MS:1003372 ! mzIdentML extension version
+is_a: MS:1003372 ! specification document extension version
 relationship: part_of MS:1002073 ! mzIdentML format
 relationship: has_value_type xsd:string
 


### PR DESCRIPTION
Adds a new set of terms for expressing that a particular file conforming to a specification requires a specific extension document also be supported in order to be read properly.

This is in support of the extension documents under revision for mzIdentML.