### PR TITLE
add MsQuality Term

### DIFF
--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -23595,7 +23595,7 @@ synonym: "MsQuality" EXACT []
 
 [Term]
 id: MS:4000152
-name: Precursor median m/z for IDs
+name: precursor median m/z for IDs
 def: "Median m/z value for all identified peptides (unique ions) after FDR." [PSI:MS]
 is_a: MS:4000003 ! single value
 is_a: MS:4000008 ! ID based
@@ -23604,7 +23604,7 @@ is_a: QC:4000025 ! ion source metric
 
 [Term]
 id: MS:4000153
-name: Interquartile RT period for peptide identifications
+name: interquartile RT period for peptide identifications
 def: "The interquartile retention time period, in seconds, for all peptide identifications over the complete run. Longer times indicate better chromatographic separation." [PSI:QC]
 is_a: MS:4000003 ! single value
 is_a: MS:4000008 ! ID based
@@ -23612,7 +23612,7 @@ is_a: QC:4000017 ! chromatogram metric
 
 [Term]
 id: MS:4000154
-name: Peptide identification rate of the interquartile RT period
+name: peptide identification rate of the interquartile RT period
 def: "The identification rate of peptides for the interquartile retention time period, in peptides per second. Higher rates indicate efficient sampling and identification." [PSI:MS]
 is_a: MS:4000003 ! single value
 is_a: MS:4000008 ! ID based
@@ -23620,7 +23620,7 @@ is_a: MS:4000017 ! chromatogram metric
 
 [Term]
 id: MS:4000155
-name: Area under TIC
+name: area under TIC
 def: "The area under the total ion chromatogram." [PSI:MS]
 is_a: MS:4000003 ! single value
 is_a: MS:40000MS ! ID free
@@ -23628,7 +23628,7 @@ is_a: MS:4000017 ! chromatogram metric
 
 [Term]
 id: MS:4000156
-name: Area under TIC RT quantiles
+name: area under TIC RT quantiles
 def: "The area under the total ion chromatogram of the retention time quantiles. Number of quantiles are given by the n-tuple." [PSI:MS]
 is_a: QC:4000004 ! n-tuple
 is_a: MS:4000009 ! ID free
@@ -23636,7 +23636,7 @@ is_a: MS:4000017 ! chromatogram metric
 
 [Term]
 id: MS:4000157
-name: Extent of identified precursor intensity
+name: extent of identified precursor intensity
 def: "Ratio of 95th over 5th percentile of precursor intensity for identified peptides. Can be used to approximate the dynamic range of signal." [PSI:MS]
 is_a: MS:4000003 ! single value
 is_a: MS:4000008 ! ID based
@@ -23644,7 +23644,7 @@ is_a: QC:4000001 ! QC metric
 
 [Term]
 id: MS:4000158
-name: Median of TIC values in the RT range in which the middle half of peptides are identified
+name: median of TIC values in the RT range in which the middle half of peptides are identified
 def: "Median of TIC values in the RT range in which half of peptides are identified (RT values of Q1 to Q3 of identifications)" [PSI:MS]
 is_a: MS:4000003 ! single value
 is_a: MS:4000008 ! ID based
@@ -23653,7 +23653,7 @@ is_a: QC:4000001 ! QC metric
 
 [Term]
 id: MS:4000159
-name: Median of TIC values in the shortest RT range in which half of the peptides are identified
+name: median of TIC values in the shortest RT range in which half of the peptides are identified
 def: "Median of TIC values in the shortest RT range in which half of the peptides are identified"  [PSI:MS] 
 is_a: MS:4000003 ! single value
 is_a: MS:4000008 ! ID based
@@ -23661,7 +23661,7 @@ is_a: QC:4000001 ! QC metric
 
 [Term]
 id: MS:4000160
-name: Precursor intensity range
+name: precursor intensity range
 def: "Minimum and maximum precursor intensity recorded." [PSI:MS]
 is_a: MS:4000009 ! ID free
 is_a: QC:4000001 ! QC metric
@@ -23669,7 +23669,7 @@ is_a: QC:4000004 ! n-tuple
 
 [Term]
 id: MS:4000161
-name: Identified precursor intensity distribution Q1, Q2, Q3
+name: identified precursor intensity distribution Q1, Q2, Q3
 def: "From the distribution of identified precursor intensities, the quartiles Q1, Q2, Q3" [PSI:MS]
 is_a: MS:4000004 ! n-tuple
 relationship: has_metric_category MS:4000009 ! ID free metric
@@ -23680,7 +23680,7 @@ relationship: has_units MS:1000043 ! intensity unit
 
 [Term]
 id: MS:4000162
-name: Unidentified precursor intensity distribution Q1, Q2, Q3
+name: unidentified precursor intensity distribution Q1, Q2, Q3
 def: "From the distribution of unidentified precursor intensities, the quartiles Q1, Q2, Q3" [PSI:MS]
 relationship: has_metric_category MS:4000009 ! ID free metric
 relationship: has_metric_category MS:4000022 ! MS2 metric
@@ -23690,7 +23690,7 @@ relationship: has_units MS:1000043 ! intensity unit
 
 [Term]
 id: MS:4000163
-name: Identified precursor intensity distribution mean
+name: identified precursor intensity distribution mean
 def: "From the distribution of identified precursor intensities, the mean. The intensity distribution of the identified precursors informs about the dynamic range of the acquisition in relation to identifiability." [PSI:MS]
 is_a: MS:4000003 ! single value
 relationship: has_metric_category MS:4000009 ! ID free metric
@@ -23700,7 +23700,7 @@ relationship: has_units MS:1000043 ! intensity unit
 
 [Term]
 id: MS:4000164
-name: Unidentified precursor intensity distribution mean
+name: unidentified precursor intensity distribution mean
 def: "From the distribution of unidentified precursor intensities, the mean. The intensity distribution of the unidentified precursors informs about the dynamic range of the acquisition in relation to identifiability." [PSI:MS]
 is_a: MS:4000003 ! single value
 relationship: has_metric_category MS:4000009 ! ID free metric
@@ -23710,7 +23710,7 @@ relationship: has_units MS:1000043 ! intensity unit
 
 [Term]
 id: MS:4000165
-name: Charged peptides ratio 1+ over 2+
+name: charged peptides ratio 1+ over 2+
 def: "Ratio of 1+ peptide count over 2+ peptide count in identified spectra" [PSI:MS]
 is_a: MS:4000003 ! single value
 is_a: MS:4000008 ! ID based
@@ -23718,7 +23718,7 @@ is_a: MS:4000001 ! QC metric
 
 [Term]
 id: MS:4000166
-name: Charged spectra ratio 1+ over 2+
+name: charged spectra ratio 1+ over 2+
 def: "Ratio of 1+ spectra count over 2+ spectra count in all MS2" [PSI:MS]
 is_a: MS:4000003 ! single value
 is_a: MS:4000008 ! ID based
@@ -23726,7 +23726,7 @@ is_a: MS:4000001 ! QC metric
 
 [Term]
 id: MS:4000167
-name: Charged peptides ratio 3+ over 2+
+name: charged peptides ratio 3+ over 2+
 def: "Ratio of 3+ peptide count over 2+ peptide count in identified spectra" [PSI:MS]
 is_a: MS:4000003 ! single value
 is_a: MS:4000008 ! ID based
@@ -23734,7 +23734,7 @@ is_a: MS:4000001 ! QC metric
 
 [Term]
 id: MS:4000168
-name: Charged spectra ratio 3+ over 2+ 
+name: charged spectra ratio 3+ over 2+ 
 def: "Ratio of 3+ peptide count over 2+ peptide count in all MS2" [PSI:MS]
 is_a: MS:4000003 ! single value
 is_a: MS:4000008 ! ID based
@@ -23742,7 +23742,7 @@ is_a: MS:4000001 ! QC metric
 
 [Term]
 id: MS:4000169
-name: Charged peptides ratio 4+ over 2+ 
+name: charged peptides ratio 4+ over 2+ 
 def: "Ratio of 4+ peptide count  over 2+ peptide count in identified spectra" [PSI:MS]
 is_a: MS:4000003 ! single value
 is_a: MS:4000008 ! ID based
@@ -23750,7 +23750,7 @@ is_a: MS:4000001 ! QC metric
 
 [Term]
 id: MS:4000170
-name: Charged spectra ratio 4+ over 2+
+name: charged spectra ratio 4+ over 2+
 def: "Ratio of 4+ peptide count over 2+ peptide count in all MS2" [PSI:MS]
 is_a: MS:4000003 ! single value
 is_a: MS:4000008 ! ID based
@@ -23758,7 +23758,7 @@ is_a: MS:4000001 ! QC metric
 
 [Term]
 id: MS:4000171
-name: Mean charge in identified spectra
+name: mean charge in identified spectra
 def: "Mean charge in identified spectra" [PSI:MS]
 is_a: MS:4000003 ! single value
 is_a: MS:4000008 ! ID based
@@ -23774,7 +23774,7 @@ is_a: MS:4000001 ! QC metric
 
 [Term]
 id: MS:4000173
-name: Median charge in identified spectra
+name: median charge in identified spectra
 def: "Median charge in identified spectra" [PSI:MS]
 is_a: MS:4000003 ! single value
 is_a: MS:4000008 ! ID based
@@ -23782,7 +23782,7 @@ is_a: MS:4000001 ! QC metric
 
 [Term]
 id: MS:4000174
-name: Median charge in all MS2
+name: median charge in all MS2
 def: "Median precursor charge in all MS2" [PSI:MS]
 is_a: MS:4000003 ! single value
 is_a: MS:4000008 ! ID based

--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -23587,6 +23587,13 @@ relationship: has_metric_category MS:4000016 ! retention time metric
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
+id: MS:4000151
+name: MsQuality
+def: "MsQuality – an interoperable open-source package for the calculation of standardized quality metrics of mass spectrometry data." [DOI:10.1101/2023.05.12.540477, https://github.com/tnaake/MsQuality/]
+is_a: MS:1001456 ! analysis software
+synonym: "MsQuality" EXACT []
+
+[Term]
 id: PEFF:0000001
 name: PEFF CV term
 def: "PSI Extended FASTA Format controlled vocabulary term." [PSI:PEFF]
@@ -24534,3 +24541,5 @@ synonym: "A^[2]" RELATED []
 is_a: UO:0000047
 created_by: gkoutos
 creation_date: 2013-06-27T05:06:40Z
+
+

--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -23594,6 +23594,201 @@ is_a: MS:1001456 ! analysis software
 synonym: "MsQuality" EXACT []
 
 [Term]
+id: MS:4000152
+name: Precursor median m/z for IDs
+def: "Median m/z value for all identified peptides (unique ions) after FDR." [PSI:MS]
+is_a: MS:4000003 ! single value
+is_a: MS:4000008 ! ID based
+is_a: MS:4000021 ! MS1 metric
+is_a: QC:4000025 ! ion source metric
+
+[Term]
+id: MS:4000153
+name: Interquartile RT period for peptide identifications
+def: "The interquartile retention time period, in seconds, for all peptide identifications over the complete run. Longer times indicate better chromatographic separation." [PSI:QC]
+is_a: MS:4000003 ! single value
+is_a: MS:4000008 ! ID based
+is_a: QC:4000017 ! chromatogram metric
+
+[Term]
+id: MS:4000154
+name: Peptide identification rate of the interquartile RT period
+def: "The identification rate of peptides for the interquartile retention time period, in peptides per second. Higher rates indicate efficient sampling and identification." [PSI:MS]
+is_a: MS:4000003 ! single value
+is_a: MS:4000008 ! ID based
+is_a: MS:4000017 ! chromatogram metric
+
+[Term]
+id: MS:4000155
+name: Area under TIC
+def: "The area under the total ion chromatogram." [PSI:MS]
+is_a: MS:4000003 ! single value
+is_a: MS:40000MS ! ID free
+is_a: MS:4000017 ! chromatogram metric
+
+[Term]
+id: MS:4000156
+name: Area under TIC RT quantiles
+def: "The area under the total ion chromatogram of the retention time quantiles. Number of quantiles are given by the n-tuple." [PSI:MS]
+is_a: QC:4000004 ! n-tuple
+is_a: MS:4000009 ! ID free
+is_a: MS:4000017 ! chromatogram metric
+
+[Term]
+id: MS:4000157
+name: Extent of identified precursor intensity
+def: "Ratio of 95th over 5th percentile of precursor intensity for identified peptides. Can be used to approximate the dynamic range of signal." [PSI:MS]
+is_a: MS:4000003 ! single value
+is_a: MS:4000008 ! ID based
+is_a: QC:4000001 ! QC metric
+
+[Term]
+id: MS:4000158
+name: Median of TIC values in the RT range in which the middle half of peptides are identified
+def: "Median of TIC values in the RT range in which half of peptides are identified (RT values of Q1 to Q3 of identifications)" [PSI:MS]
+is_a: MS:4000003 ! single value
+is_a: MS:4000008 ! ID based
+is_a: QC:4000001 ! QC metric
+
+
+[Term]
+id: MS:4000159
+name: Median of TIC values in the shortest RT range in which half of the peptides are identified
+def: "Median of TIC values in the shortest RT range in which half of the peptides are identified"  [PSI:MS] 
+is_a: MS:4000003 ! single value
+is_a: MS:4000008 ! ID based
+is_a: QC:4000001 ! QC metric
+
+[Term]
+id: MS:4000160
+name: Precursor intensity range
+def: "Minimum and maximum precursor intensity recorded." [PSI:MS]
+is_a: MS:4000009 ! ID free
+is_a: QC:4000001 ! QC metric
+is_a: QC:4000004 ! n-tuple
+
+[Term]
+id: MS:4000161
+name: Identified precursor intensity distribution Q1, Q2, Q3
+def: "From the distribution of identified precursor intensities, the quartiles Q1, Q2, Q3" [PSI:MS]
+is_a: MS:4000004 ! n-tuple
+relationship: has_metric_category MS:4000009 ! ID free metric
+relationship: has_metric_category MS:4000022 ! MS2 metric
+relationship: has_value_concept STATO:0000291 ! quantile
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
+relationship: has_units MS:1000043 ! intensity unit
+
+[Term]
+id: MS:4000162
+name: Unidentified precursor intensity distribution Q1, Q2, Q3
+def: "From the distribution of unidentified precursor intensities, the quartiles Q1, Q2, Q3" [PSI:MS]
+relationship: has_metric_category MS:4000009 ! ID free metric
+relationship: has_metric_category MS:4000022 ! MS2 metric
+relationship: has_value_concept STATO:0000291 ! quantile
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
+relationship: has_units MS:1000043 ! intensity unit
+
+[Term]
+id: MS:4000163
+name: Identified precursor intensity distribution mean
+def: "From the distribution of identified precursor intensities, the mean. The intensity distribution of the identified precursors informs about the dynamic range of the acquisition in relation to identifiability." [PSI:MS]
+is_a: MS:4000003 ! single value
+relationship: has_metric_category MS:4000009 ! ID free metric
+relationship: has_value_concept STATO:0000401 ! sample mean
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
+relationship: has_units MS:1000043 ! intensity unit
+
+[Term]
+id: MS:4000164
+name: Unidentified precursor intensity distribution mean
+def: "From the distribution of unidentified precursor intensities, the mean. The intensity distribution of the unidentified precursors informs about the dynamic range of the acquisition in relation to identifiability." [PSI:MS]
+is_a: MS:4000003 ! single value
+relationship: has_metric_category MS:4000009 ! ID free metric
+relationship: has_value_concept STATO:0000401 ! sample mean
+relationship: has_value_type xsd:float ! The allowed value-type for this CV term
+relationship: has_units MS:1000043 ! intensity unit
+
+[Term]
+id: MS:4000165
+name: Charged peptides ratio 1+ over 2+
+def: "Ratio of 1+ peptide count over 2+ peptide count in identified spectra" [PSI:MS]
+is_a: MS:4000003 ! single value
+is_a: MS:4000008 ! ID based
+is_a: MS:4000001 ! QC metric
+
+[Term]
+id: MS:4000166
+name: Charged spectra ratio 1+ over 2+
+def: "Ratio of 1+ spectra count over 2+ spectra count in all MS2" [PSI:MS]
+is_a: MS:4000003 ! single value
+is_a: MS:4000008 ! ID based
+is_a: MS:4000001 ! QC metric
+
+[Term]
+id: MS:4000167
+name: Charged peptides ratio 3+ over 2+
+def: "Ratio of 3+ peptide count over 2+ peptide count in identified spectra" [PSI:MS]
+is_a: MS:4000003 ! single value
+is_a: MS:4000008 ! ID based
+is_a: MS:4000001 ! QC metric
+
+[Term]
+id: MS:4000168
+name: Charged spectra ratio 3+ over 2+ 
+def: "Ratio of 3+ peptide count over 2+ peptide count in all MS2" [PSI:MS]
+is_a: MS:4000003 ! single value
+is_a: MS:4000008 ! ID based
+is_a: MS:4000001 ! QC metric
+
+[Term]
+id: MS:4000169
+name: Charged peptides ratio 4+ over 2+ 
+def: "Ratio of 4+ peptide count  over 2+ peptide count in identified spectra" [PSI:MS]
+is_a: MS:4000003 ! single value
+is_a: MS:4000008 ! ID based
+is_a: MS:4000001 ! QC metric
+
+[Term]
+id: MS:4000170
+name: Charged spectra ratio 4+ over 2+
+def: "Ratio of 4+ peptide count over 2+ peptide count in all MS2" [PSI:MS]
+is_a: MS:4000003 ! single value
+is_a: MS:4000008 ! ID based
+is_a: MS:4000001 ! QC metric
+
+[Term]
+id: MS:4000171
+name: Mean charge in identified spectra
+def: "Mean charge in identified spectra" [PSI:MS]
+is_a: MS:4000003 ! single value
+is_a: MS:4000008 ! ID based
+is_a: MS:4000001 ! QC metric
+
+[Term]
+id: MS:4000172
+name: mean precursor charge in all MS2
+def: "Mean precursor charge in all MS2" [PSI:MS]
+is_a: MS:4000003 ! single value
+is_a: MS:4000008 ! ID based
+is_a: MS:4000001 ! QC metric
+
+[Term]
+id: MS:4000173
+name: Median charge in identified spectra
+def: "Median charge in identified spectra" [PSI:MS]
+is_a: MS:4000003 ! single value
+is_a: MS:4000008 ! ID based
+is_a: MS:4000001 ! QC metric
+
+[Term]
+id: MS:4000174
+name: Median charge in all MS2
+def: "Median precursor charge in all MS2" [PSI:MS]
+is_a: MS:4000003 ! single value
+is_a: MS:4000008 ! ID based
+is_a: MS:4000001 ! QC metric
+
+[Term]
 id: PEFF:0000001
 name: PEFF CV term
 def: "PSI Extended FASTA Format controlled vocabulary term." [PSI:PEFF]

--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -1,6 +1,6 @@
 format-version: 1.2
-data-version: 4.1.127
-date: 23:06:2023 11:30
+data-version: 4.1.129
+date: 29:06:2023 11:30
 saved-by: Joshua Klein
 auto-generated-by: OBO-Edit 2.3.1
 import: http://purl.obolibrary.org/obo/pato.obo


### PR DESCRIPTION
Hi,

I would like to add a term related to the [`MsQuality`](https://bioconductor.org/packages/release/bioc/html/MsQuality.html) software that uses mzQC terms. In a second step, after adding the term for `MsQuality`, we would like to integrate our tool with the `rmzqc` package. 

Currently, the manuscript is available on BioRXiv (see the DOI). Upon acceptance, we would also like to update the DOI to the new DOI (I think in that case I will create another PR). 

EDIT: in the second commit, I have added several QC metrics that were previously present in [PSI:QC] but I could not find them in the current [PSI:MS]. Could I please ask you to include them or explain why they weren't transfered to [PSI:MS]? The MsQuality package uses these terms and it would be great to still use them in the next versions.


Many thanks and please let me know, if I need to do anything else.

Best,
Thomas