### PR TITLE
Add first batch of mzqc readers/writers

### DIFF
--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -24041,6 +24041,24 @@ synonym: "MS2-PrecZ-5" RELATED [PMID:24494671]
 synonym: "MS2-PrecZ-more" RELATED [PMID:24494671]
 
 [Term]
+id: MS:4000177
+name: rmzqc
+def: "An R package for reading, validating, and writing mzQC files." [https://github.com/MS-Quality-hub/rmzqc]
+is_a: MS:1001457 ! data processing software
+
+[Term]
+id: MS:4000178
+name: jmzqc
+def: "A Java package for reading, validating, and writing mzQC files." [https://github.com/MS-Quality-hub/jmzqc]
+is_a: MS:1001457 ! data processing software
+
+[Term]
+id: MS:4000179
+name: pymzqc
+def: "A Python package for reading, validating, and writing mzQC files." [https://github.com/MS-Quality-hub/pymzqc]
+is_a: MS:1001457 ! data processing software
+
+[Term]
 id: PEFF:0000001
 name: PEFF CV term
 def: "PSI Extended FASTA Format controlled vocabulary term." [PSI:PEFF]

--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -1,7 +1,7 @@
 format-version: 1.2
-data-version: 4.1.135
-date: 02:11:2023 11:30
-saved-by: Eric Deutsch
+data-version: 4.1.136
+date: 10:11:2023 11:30
+saved-by: Chris Bielow
 auto-generated-by: OBO-Edit 2.3.1
 import: http://purl.obolibrary.org/obo/pato.obo
 import: http://purl.obolibrary.org/obo/stato.owl
@@ -22414,6 +22414,30 @@ def: "The data contained in this file have been processed to remove, collapse, o
 is_a: MS:1000524 ! data file content
 
 [Term]
+id: MS:1003399
+name: quality control software
+def: "Software that creates or manipulates QC-related data." [PSI:MS]
+is_a: MS:1001457 ! data processing software
+
+[Term]
+id: MS:1003400
+name: rmzqc
+def: "An R package for reading, validating, and writing mzQC files." [https://github.com/MS-Quality-hub/rmzqc]
+is_a: MS:1003399 ! quality control software
+
+[Term]
+id: MS:1003401
+name: jmzqc
+def: "A Java package for reading, validating, and writing mzQC files." [https://github.com/MS-Quality-hub/jmzqc]
+is_a: MS:1003399 ! quality control software
+
+[Term]
+id: MS:1003402
+name: pymzqc
+def: "A Python package for reading, validating, and writing mzQC files." [https://github.com/MS-Quality-hub/pymzqc]
+is_a: MS:1003399 ! quality control software
+
+[Term]
 id: MS:4000000
 name: PSI-MS CV Quality Control Vocabulary
 def: "PSI Quality Control controlled vocabulary term." [PSI:MS]
@@ -24039,24 +24063,6 @@ synonym: "MS2-PrecZ-3" RELATED [PMID:24494671]
 synonym: "MS2-PrecZ-4" RELATED [PMID:24494671]
 synonym: "MS2-PrecZ-5" RELATED [PMID:24494671]
 synonym: "MS2-PrecZ-more" RELATED [PMID:24494671]
-
-[Term]
-id: MS:4000177
-name: rmzqc
-def: "An R package for reading, validating, and writing mzQC files." [https://github.com/MS-Quality-hub/rmzqc]
-is_a: MS:1001457 ! data processing software
-
-[Term]
-id: MS:4000178
-name: jmzqc
-def: "A Java package for reading, validating, and writing mzQC files." [https://github.com/MS-Quality-hub/jmzqc]
-is_a: MS:1001457 ! data processing software
-
-[Term]
-id: MS:4000179
-name: pymzqc
-def: "A Python package for reading, validating, and writing mzQC files." [https://github.com/MS-Quality-hub/pymzqc]
-is_a: MS:1001457 ! data processing software
 
 [Term]
 id: PEFF:0000001


### PR DESCRIPTION
@mwalzer 
@nilshoffmann
@bittremieux 
please have a look. Thanks! :)

I used the MS:4....... space, since its QC software.

Was also wondering if we should have a new term like
```
[Term]
id: MS:?????
name: quality control software
def: "Quality Control software." [PSI:MS]
is_a: MS:1000531 ! software
```
which we can derive from.