### PR TITLE
Add ion mobility attribute as parent for CCS

### DIFF
--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -1,5 +1,5 @@
 format-version: 1.2
-data-version: 4.1.137
+data-version: 4.1.138
 date: 07:12:2023 16:37
 saved-by: Matt Chambers
 auto-generated-by: OBO-Edit 2.3.1

--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -19419,7 +19419,6 @@ id: MS:1002954
 name: collisional cross sectional area
 def: "Structural molecular descriptor for the effective interaction area between the ion and neutral gas measured in ion mobility mass spectrometry." [PSI:PI]
 is_a: MS:1000861 ! molecular entity property
-is_a: MS:1002892 ! ion mobility attribute
 is_a: MS:1000455 ! ion selection attribute
 relationship: has_units UO:0000324 ! square angstrom
 relationship: has_value_type xsd:double ! The allowed value-type for this CV term

--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -19420,6 +19420,7 @@ name: collisional cross sectional area
 def: "Structural molecular descriptor for the effective interaction area between the ion and neutral gas measured in ion mobility mass spectrometry." [PSI:PI]
 is_a: MS:1000861 ! molecular entity property
 is_a: MS:1002892 ! ion mobility attribute
+is_a: MS:1000455 ! ion selection attribute
 relationship: has_units UO:0000324 ! square angstrom
 relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 

--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -19419,6 +19419,7 @@ id: MS:1002954
 name: collisional cross sectional area
 def: "Structural molecular descriptor for the effective interaction area between the ion and neutral gas measured in ion mobility mass spectrometry." [PSI:PI]
 is_a: MS:1000861 ! molecular entity property
+is_a: MS:1002892 ! ion mobility attribute
 relationship: has_units UO:0000324 ! square angstrom
 relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 


### PR DESCRIPTION
As discussed on PSI call, we want to allow CCS to be encoded in mzML wherever individual ion mobility values are currently allowed. 