### PR TITLE
Revert owl

### DIFF
--- a/.github/workflows/trigger-deploy.yml
+++ b/.github/workflows/trigger-deploy.yml
@@ -22,6 +22,7 @@ jobs:
           echo "CV_VERSION=${CV_VERSION}" >> $GITHUB_ENV
       - name: Generate OWL and Commit
         run: |
+          docker pull obolibrary/robot:v1.8.1
           # Replace the imports of the UO and PATO ontology .obo files with the equivalent .owl files
           cp psi-ms.obo tmp.obo
           sed -e "s/pato.obo/pato.owl/g" -e "s/uo.obo/uo.owl/g" -i tmp.obo
@@ -30,12 +31,10 @@ jobs:
           python -m pip install fastobo
           python scripts/prepare_template.py tmp.obo cv_template.tsv
 
-          wget --no-check-certificate https://github.com/ontodev/robot/releases/download/v1.9.5/robot.jar
-
           export JAVA_TOOL_OPTIONS=-Xmx6G
-          java -jar robot.jar -vvv template -p "PEFF: http://purl.obolibrary.org/obo/PEFF_" --input psi-ms.obo -t cv_template.tsv convert -f ofn -o psi-ms.owl
+          docker run --rm -v ${{ github.workspace }}:/work obolibrary/robot:v1.8.1 cd /work && robot convert -vvv template -p "PEFF: http://purl.obolibrary.org/obo/PEFF_" -i /work/tmp.obo -t /work/cv_template.tsv convert -f ofn -o /work/psi-ms.owl
           rm tmp.obo cv_template.tsv
-          rm *robot.jar*
+
           git config --global user.name 'PSI-MS CV Bot'
           git config --global user.email 'mobiusklein@users.noreply.github.com'
           OWL_CHANGE=`git diff psi-ms.owl`

--- a/.github/workflows/trigger-deploy.yml
+++ b/.github/workflows/trigger-deploy.yml
@@ -22,17 +22,20 @@ jobs:
           echo "CV_VERSION=${CV_VERSION}" >> $GITHUB_ENV
       - name: Generate OWL and Commit
         run: |
-          docker pull obolibrary/robot:v1.8.1
           # Replace the imports of the UO and PATO ontology .obo files with the equivalent .owl files
           cp psi-ms.obo tmp.obo
           sed -e "s/pato.obo/pato.owl/g" -e "s/uo.obo/uo.owl/g" -i tmp.obo
           head -n 50 tmp.obo
 
-          python -m pip install fastobo
-          python scripts/prepare_template.py tmp.obo cv_template.tsv
+          # python -m pip install fastobo
+          # python scripts/prepare_template.py tmp.obo cv_template.tsv
+          # echo Generated template with `wc -l cv_template.tsv`
 
+          wget -nv --no-check-certificate https://github.com/ontodev/robot/releases/download/v1.9.5/robot.jar
           export JAVA_TOOL_OPTIONS=-Xmx6G
-          docker run --rm -v ${{ github.workspace }}:/work obolibrary/robot:v1.8.1 cd /work && robot convert -vvv template -p "PEFF: http://purl.obolibrary.org/obo/PEFF_" -i /work/tmp.obo -t /work/cv_template.tsv convert -f ofn -o /work/psi-ms.owl
+          # java -jar robot.jar -vvv template -p "PEFF: http://purl.obolibrary.org/obo/PEFF_" -i psi-ms.obo -t cv_template.tsv convert -f ofn -o psi-ms.owl
+          java -jar robot.jar convert -v -i tmp.obo -o psi-ms.owl --format owl
+          rm *robot.jar*
           rm tmp.obo cv_template.tsv
 
           git config --global user.name 'PSI-MS CV Bot'

--- a/.github/workflows/update-owl.yaml
+++ b/.github/workflows/update-owl.yaml
@@ -21,6 +21,7 @@ jobs:
           echo "CV_VERSION=${CV_VERSION}" >> $GITHUB_ENV
       - name: Generate OWL
         run: |
+          docker pull obolibrary/robot:v1.8.1
           # Replace the imports of the UO and PATO ontology .obo files with the equivalent .owl files
           cp psi-ms.obo tmp.obo
           sed -e "s/pato.obo/pato.owl/g" -e "s/uo.obo/uo.owl/g" -i tmp.obo
@@ -30,12 +31,9 @@ jobs:
           python scripts/prepare_template.py tmp.obo cv_template.tsv
           echo Generated template with `wc -l cv_template.tsv`
 
-          wget -nv --no-check-certificate https://github.com/ontodev/robot/releases/download/v1.9.5/robot.jar
-
           export JAVA_TOOL_OPTIONS=-Xmx6G
-          java -jar robot.jar -vvv template -p "PEFF: http://purl.obolibrary.org/obo/PEFF_" -i psi-ms.obo -t cv_template.tsv convert -f ofn -o psi-ms.owl
+          docker run --rm -v ${{ github.workspace }}:/work obolibrary/robot:v1.8.1 sh -c "cd /work && robot convert -vvv template -p "PEFF: http://purl.obolibrary.org/obo/PEFF_" --input /work/psi-ms.obo -t /work/cv_template.tsv convert -f ofn -o /work/psi-ms.owl"
 
-          rm *robot.jar*
           rm tmp.obo cv_template.tsv
       - name: Create pull request
         id: cpr
@@ -57,7 +55,7 @@ jobs:
           number: ${{ steps.cpr.outputs.pull-request-number }}
       - name: Merge pull request
         if: (steps.cpr.outputs.pull-request-operation == 'created' ||	steps.cpr.outputs.pull-request-operation == 'updated')
-        uses: peter-evans/enable-pull-request-automerge@v3
+        uses: peter-evans/enable-pull-request-automerge@v2
         with:
           token: ${{ secrets.PSI_MS_CV_GITHUB_TOKEN }}
           pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}

--- a/.github/workflows/update-owl.yaml
+++ b/.github/workflows/update-owl.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   generate-owl:
-    if: "! contains(github.event.head_commit.message, 'Update OWL file')"
+    if: ${{ ! contains(github.event.head_commit.message, 'Update OWL file') }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -21,19 +21,20 @@ jobs:
           echo "CV_VERSION=${CV_VERSION}" >> $GITHUB_ENV
       - name: Generate OWL
         run: |
-          docker pull obolibrary/robot:v1.8.1
           # Replace the imports of the UO and PATO ontology .obo files with the equivalent .owl files
           cp psi-ms.obo tmp.obo
           sed -e "s/pato.obo/pato.owl/g" -e "s/uo.obo/uo.owl/g" -i tmp.obo
           head -n 50 tmp.obo
 
-          python -m pip install fastobo
-          python scripts/prepare_template.py tmp.obo cv_template.tsv
-          echo Generated template with `wc -l cv_template.tsv`
+          # python -m pip install fastobo
+          # python scripts/prepare_template.py tmp.obo cv_template.tsv
+          # echo Generated template with `wc -l cv_template.tsv`
 
+          wget -nv --no-check-certificate https://github.com/ontodev/robot/releases/download/v1.9.5/robot.jar
           export JAVA_TOOL_OPTIONS=-Xmx6G
-          docker run --rm -v ${{ github.workspace }}:/work obolibrary/robot:v1.8.1 sh -c "cd /work && robot convert -vvv template -p "PEFF: http://purl.obolibrary.org/obo/PEFF_" --input /work/psi-ms.obo -t /work/cv_template.tsv convert -f ofn -o /work/psi-ms.owl"
-
+          # java -jar robot.jar -vvv template -p "PEFF: http://purl.obolibrary.org/obo/PEFF_" -i psi-ms.obo -t cv_template.tsv convert -f ofn -o psi-ms.owl
+          java -jar robot.jar convert -v -i tmp.obo -o psi-ms.owl --format owl
+          rm *robot.jar*
           rm tmp.obo cv_template.tsv
       - name: Create pull request
         id: cpr
@@ -55,7 +56,7 @@ jobs:
           number: ${{ steps.cpr.outputs.pull-request-number }}
       - name: Merge pull request
         if: (steps.cpr.outputs.pull-request-operation == 'created' ||	steps.cpr.outputs.pull-request-operation == 'updated')
-        uses: peter-evans/enable-pull-request-automerge@v2
+        uses: peter-evans/enable-pull-request-automerge@v3
         with:
           token: ${{ secrets.PSI_MS_CV_GITHUB_TOKEN }}
           pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}

--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -1,7 +1,7 @@
 format-version: 1.2
-data-version: 4.1.134
-date: 06:10:2023 11:30
-saved-by: Eric Deutsch
+data-version: 4.1.135
+date: 11:10:2023 11:08
+saved-by: Yasset Perez-Riverol
 auto-generated-by: OBO-Edit 2.3.1
 import: http://purl.obolibrary.org/obo/pato.obo
 import: http://purl.obolibrary.org/obo/stato.owl

--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -24017,6 +24017,34 @@ synonym: "MS2-PrecZ-5" RELATED [PMID:24494671]
 synonym: "MS2-PrecZ-more" RELATED [PMID:24494671]
 
 [Term]
+id: MS:4000177
+name: ms2 mass analyzer
+def: "Terms used to describe the MS2 Analyzer." [PSI:MS]
+synonym: "ms2 analyzer" EXACT []
+is_a: MS:1000451 ! mass analyzer
+
+[Term]
+id: MS:4000178
+name: ms3 mass analyzer
+def: "Terms used to describe the MS3 Analyzer." [PSI:MS]
+synonym: "ms3 analyzer" EXACT []
+is_a: MS:1000451 ! mass analyzer
+
+[Term]
+id: MS:4000179
+name: ms2 dissociation method
+def: "MS2 Fragmentation method used for dissociation or fragmentation." [PSI:MS]
+synonym: "Activation Method" RELATED []
+is_a: MS:1000044 ! dissociation method
+
+[Term]
+id: MS:4000180
+name: ms3 dissociation method
+def: "MS3 Fragmentation method used for dissociation or fragmentation." [PSI:MS]
+synonym: "Activation Method" RELATED []
+is_a: MS:1000044 ! dissociation method
+
+[Term]
 id: PEFF:0000001
 name: PEFF CV term
 def: "PSI Extended FASTA Format controlled vocabulary term." [PSI:PEFF]


### PR DESCRIPTION
OLS has removed the PSI-MS because the owl file is incompatible with OLS4. Until the file is well generated and tested with the OLS4 team please keep the previous version even if it has errors rendering. 