### PR TITLE
Reparent `combined dissociation method` to `precursor activation attribute`

### DIFF
--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -20994,7 +20994,7 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 id: MS:1003181
 name: combined dissociation method
 def: "Combination of two or more dissociation methods that are known by a special term." [PSI:PI]
-is_a: MS:1000044 ! dissociation method
+is_a: MS:1000510 ! precursor activation attribute
 
 [Term]
 id: MS:1003182


### PR DESCRIPTION
Closes #285 

@caetera This PR will make using the combined dissociation method terms illegal in mzML. Validators will still need to update their CV versions, however.