### PR TITLE
Add "is_a: MS:1003207 ! library creation software" to DIA-NN

### DIFF
--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -21479,6 +21479,7 @@ name: DIA-NN
 def: "A universal software for data-independent acquisition (DIA) proteomics data processing" [PMID:31768060, https://github.com/vdemichev/DiaNN]
 is_a: MS:1001139 ! quantitation software name
 is_a: MS:1001456 ! analysis software
+is_a: MS:1003207 ! library creation software
 
 [Term]
 id: MS:1003254

--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -1,7 +1,7 @@
 format-version: 1.2
-data-version: 4.1.172
-date: 15:08:2024 07:15
-saved-by: Eric Deutsch
+data-version: 4.1.173
+date: 25:08:2024 07:15
+saved-by: Joshua Klein
 auto-generated-by: OBO-Edit 2.3.1
 default-namespace: MS
 namespace-id-rule: * MS:$sequence(7,0,9999999)$


### PR DESCRIPTION
This is required for a DIA-NN converted spectral library to be valid.