### PR TITLE
Accession order fixes

### DIFF
--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -1,6 +1,6 @@
 format-version: 1.2
-data-version: 4.1.176
-date: 17:09:2024 07:15
+data-version: 4.1.177
+date: 27:09:2024 07:15
 saved-by: Chris Bielow
 auto-generated-by: OBO-Edit 2.3.1
 default-namespace: MS

--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -22523,6 +22523,20 @@ def: "Software designed to group multiple mass spectra by high similarity, gener
 is_a: MS:1000531 ! software
 
 [Term]
+id: MS:1003407
+name: Scout
+def: "Identifying crosslinked peptides in complex protein mixtures" [PSI:MS]
+is_a: MS:1001456 ! analysis software
+
+[Term]
+id: MS:1003408
+name: Scout score
+def: "Scout identification search engine score" [PSI:MS]
+is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_order MS:1003407 ! higher score better
+relationship: has_value_type xsd:double ! The allowed value-type for this CV term
+
+[Term]
 id: MS:1003409
 name: Stellar
 def: "Thermo Scientific Stellar mass spectrometer contains a quadrupole mass filter, a collision cell, and a quadrupole linear ion trap mass analyzer." [PSI:MS]
@@ -24226,20 +24240,6 @@ synonym: "RT-MSMS-Q1" RELATED [PMID:24494671]
 synonym: "RT-MSMS-Q2" RELATED [PMID:24494671]
 synonym: "RT-MSMS-Q3" RELATED [PMID:24494671]
 synonym: "RT-MSMS-Q4" RELATED [PMID:24494671]
-
-[Term]
-id: MS:1003407
-name: Scout
-def: "Identifying crosslinked peptides in complex protein mixtures" [PSI:MS]
-is_a: MS:1001456 ! analysis software
-
-[Term]
-id: MS:1003408
-name: Scout score
-def: "Scout identification search engine score" [PSI:MS]
-is_a: MS:1001143 ! PSM-level search engine specific statistic
-relationship: has_order MS:1003407 ! higher score better
-relationship: has_value_type xsd:double ! The allowed value-type for this CV term
 
 [Term]
 id: PEFF:0000001

--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -1,7 +1,7 @@
 format-version: 1.2
-data-version: 4.1.175
-date: 25:08:2024 07:15
-saved-by: Joshua Klein
+data-version: 4.1.176
+date: 17:09:2024 07:15
+saved-by: Chris Bielow
 auto-generated-by: OBO-Edit 2.3.1
 default-namespace: MS
 namespace-id-rule: * MS:$sequence(7,0,9999999)$

--- a/scripts/find_next_available_number.py
+++ b/scripts/find_next_available_number.py
@@ -22,10 +22,12 @@ def collect_gaps(stream, min_value=1000300):
                     last_seen[cv] = acc
                     continue
                 diff = acc - last_in_cv
+                if diff < 1:
+                    sys.stderr.write(f"CV is not sorted! {cv}:{acc} found after {cv}:{last_in_cv}\n")
                 if diff > 1 and acc > min_value:
                     for i in range(1, diff):
                         gaps.append((cv, last_in_cv + i))
-                    sys.stderr.write(f"Found gap {gaps[-diff + 1]} to {gaps[-1]}\n")
+                    sys.stderr.write(f"Found gap of size {diff-1}: {gaps[-diff + 1]} to {gaps[-1]}\n")
                 last_seen[cv] = acc
         return gaps, last_seen
     except UnicodeDecodeError:


### PR DESCRIPTION
Enhances `scripts/find_next_available_number.py` to report the gap size and also now detects an unsorted CV (which would cause reporting of false positive gaps).

e.g.
```
Found gap of size 62: ('MS', 1000938) to ('MS', 1000999)
...
Found gap of size 1: ('MS', 1003236) to ('MS', 1003236)
Found gap of size 2: ('MS', 1003407) to ('MS', 1003408)               <-- false positive...
Found gap of size 2996587: ('MS', 1003413) to ('MS', 3999999)
Found gap of size 1: ('MS', 4000011) to ('MS', 4000011)
Found gap of size 25: ('MS', 4000025) to ('MS', 4000049)
CV is not sorted! MS:1003407 found after MS:4000181
Found gap of size 1000965: ('PEFF', 1036) to ('PEFF', 1002000)
```


Ordering of accessions is restored as well in this PR (eliminating `CV is not sorted! MS:1003407 found after MS:4000181`).

This might be worth adding to GH actions? i.e. fail if not sorted?