### PR TITLE
do we want to add "neutral"?

### DIFF
--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -1,6 +1,6 @@
 format-version: 1.2
-data-version: 4.1.175
-date: 25:08:2024 07:15
+data-version: 4.1.180
+date: 04:10:2024 07:15
 saved-by: Joshua Klein
 auto-generated-by: OBO-Edit 2.3.1
 default-namespace: MS

--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -7312,11 +7312,12 @@ is_a: MS:1001085 ! protein-level identification attribute
 
 [Term]
 id: MS:1001117
-name: theoretical mass
+name: theoretical neutral mass
 def: "The theoretical neutral mass of the molecule (e.g. the peptide sequence and its modifications) not including its charge carrier." [PSI:PI]
 is_a: MS:1001105 ! peptide sequence-level identification attribute
 relationship: has_units UO:0000221 ! dalton
 relationship: has_value_type xsd:double ! The allowed value-type for this CV term
+synonym: "theoretical mass" EXACT []
 
 [Term]
 id: MS:1001118


### PR DESCRIPTION
This has been proposed by the reviewer of the mzSpecLib manuscript. Do we want to make this change? What implications are there for downstream tools and files?