### PR TITLE
Add new spectrum origin type

### DIFF
--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -22548,6 +22548,12 @@ name: timsTOF Ultra 2
 def: "Bruker Daltonics timsTOF Ultra 2." [PSI:MS]
 is_a: MS:1003123 ! Bruker Daltonics timsTOF series
 
+[Term]
+id: MS:1003424
+name: theoretical m/z observed intensity limited peak spectrum
+def: "Spectrum for which the peaks are limited to a subset of known product ions that are important for subsequent identification, the m/z values are corrected to theoretical values, and the intensity values are experimentally derived." [PSI:PI]
+is_a: MS:1003072 ! spectrum origin type
+
 
 [Term]
 id: MS:4000000


### PR DESCRIPTION
As pointed out by reviewer of mzSpecLib, existing spectrum origin types are not adequate to classify this type of spectrum, commonly used for DIA analysis.