### PR TITLE
Addition of "AlphaLP" as a new term - refinements and suggestions welcome

### DIFF
--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -8502,7 +8502,7 @@ def: "A serine protease that hydrolyzes peptide bonds at the C-terminus of threo
 is_a: MS:1001045 ! cleavage agent name
 synonym: "alpha-lytic endopeptidase" EXACT []
 synonym: "alpha-lytic protease" EXACT []
-relationship: has_regexp MS:1003435 ! /(?<=[TASV])/
+relationship: has_regexp MS:1003435 ! (?<=[TASV])
 
 [Term]
 id: MS:1001314

--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -8502,6 +8502,7 @@ def: "A serine protease that hydrolyzes peptide bonds at the C-terminus of threo
 is_a: MS:1001045 ! cleavage agent name
 synonym: "alpha-lytic endopeptidase" EXACT []
 synonym: "alpha-lytic protease" EXACT []
+relationship: has_regexp MS:1003435 ! /(?<=[TASV])/
 
 [Term]
 id: MS:1001314
@@ -12871,6 +12872,12 @@ is_a: MS:1001180 ! Cleavage agent regular expression
 id: MS:1001960
 name: (?<=W)
 def: "Regular expression for 2-iodobenzoate." [PSI:PI]
+is_a: MS:1001180 ! Cleavage agent regular expression
+
+[Term]
+id: MS:1003435
+name: /(?<=[TSAV])/
+def: "Regular expression for alphaLP."
 is_a: MS:1001180 ! Cleavage agent regular expression
 
 [Term]

--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -8498,7 +8498,7 @@ relationship: has_regexp MS:1001339 ! (?<=[KR])
 [Term]
 id: MS:1003434
 name: AlphaLP
-def: "A serine protease that hydrolyzes peptide bonds at the C-terminus of threonine, alanine, serine, and valine."
+def: "A serine protease that hydrolyzes peptide bonds at the C-terminus of threonine, alanine, serine, and valine. (EC:3.4.21.12)" [DOI:10.1038/228438a0, DOI:10.1021/bi00445a015]
 is_a: MS:1001045 ! cleavage agent name
 synonym: "alpha-lytic endopeptidase" EXACT []
 synonym: "alpha-lytic protease" EXACT []

--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -12877,7 +12877,7 @@ is_a: MS:1001180 ! Cleavage agent regular expression
 [Term]
 id: MS:1003435
 name: (?<=[TSAV])
-def: "Regular expression for alphaLP."
+def: "Regular expression for alphaLP." [PSI:PI]
 is_a: MS:1001180 ! Cleavage agent regular expression
 
 [Term]

--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -1,5 +1,5 @@
 format-version: 1.2
-data-version: 4.1.188
+data-version: 4.1.189
 date: 13:01:2025 17:58
 saved-by: Joshua Klein
 default-namespace: MS

--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -8496,6 +8496,14 @@ is_a: MS:1001045 ! cleavage agent name
 relationship: has_regexp MS:1001339 ! (?<=[KR])
 
 [Term]
+id: MS:1003434
+name: AlphaLP
+def: "A serine protease that hydrolyzes peptide bonds at the C-terminus of threonine, alanine, serine, and valine."
+is_a: MS:1001045 ! cleavage agent name
+synonym: "alpha-lytic endopeptidase" EXACT []
+synonym: "alpha-lytic protease" EXACT []
+
+[Term]
 id: MS:1001314
 name: V8-DE
 def: "Cleavage agent V8-DE." [PSI:PI]

--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -12876,7 +12876,7 @@ is_a: MS:1001180 ! Cleavage agent regular expression
 
 [Term]
 id: MS:1003435
-name: /(?<=[TSAV])/
+name: (?<=[TSAV])
 def: "Regular expression for alphaLP."
 is_a: MS:1001180 ! Cleavage agent regular expression
 

--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -8501,7 +8501,6 @@ name: AlphaLP
 def: "A serine protease that hydrolyzes peptide bonds at the C-terminus of threonine, alanine, serine, and valine."
 is_a: MS:1001045 ! cleavage agent name
 synonym: "alpha-lytic endopeptidase" EXACT []
-synonym: "alpha-lytic protease" EXACT []
 
 [Term]
 id: MS:1001314

--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -8501,6 +8501,7 @@ name: AlphaLP
 def: "A serine protease that hydrolyzes peptide bonds at the C-terminus of threonine, alanine, serine, and valine."
 is_a: MS:1001045 ! cleavage agent name
 synonym: "alpha-lytic endopeptidase" EXACT []
+synonym: "alpha-lytic protease" EXACT []
 
 [Term]
 id: MS:1001314


### PR DESCRIPTION
Please see: https://github.com/HUPO-PSI/psi-ms-CV/issues/366 for more details.

I used the script in this repository, `find_next_available_number.py` to find the biggest gap in the identifier space, and picked the next from that gap:

```
Found gap of size 2996566: ('MS', 1003434) to ('MS', 3999999)
```