### PR TITLE
[WIP] Propose PEFF CV term for the actual sequence

### DIFF
--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -1,5 +1,5 @@
 format-version: 1.2
-data-version: 4.1.213
+data-version: 4.1.214
 date: 03:11:2025 12:00
 saved-by: Joshua Klein
 default-namespace: MS


### PR DESCRIPTION
We are looking at a JSON serialization of the information in PEFF 1.0 files, part of this is adding a CV term for the actual sequence, rather than treating it differently from the other data values. 