### PR TITLE
add hierarchy for GC systems and method types

### DIFF
--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -1,6 +1,6 @@
 format-version: 1.2
 data-version: 4.1.216
-date: 11:11:2025 12:00
+date: 19:11:2025 11:00
 saved-by: Jonathan Hunter
 default-namespace: MS
 namespace-id-rule: * MS:$sequence(7,0,9999999)$


### PR DESCRIPTION
Dear all,

As in #408, please consider this proposed hierarchy to capture GC systems and GC methodologies. The PR is structured to be in-keeping with the implementation for the LC systems, as illustrated in this example:

```markdown
PSI-MS-CV
├── 'hyphenated separation'
│    ├── 'gas chromatography'
│    │    ├── 'gas-liquid chromatography'
│    │    │    └── 'mid-polar stationary phase gas-liquid chromatography'
│    │    └── 'gas-solid chromatography'
│    │ 
│    └── 'liquid chromatography'
│ 
└── 'hyphenated separation system'
     ├── 'gas chromatography system'
     │    └── 'gas chromatography system model'
     │         └── 'Agilent gas chromatography system model''
     │              └── '6890N'
     ├── 'gas chromatography mass spectrometry system'
     │    └── 'gas chromatography mass spectrometry system model'
     │         └── 'Shimadzu gas chromatography mass spectrometry system model'
     │              └── 'GCMS-TQ8050NX'
     │
     └── 'liquid chromatography system'
```

Notes:
- For definitions, I've used "Agilent 6890N gas **chromatograph**." in line with the way GC[-MS] systems are defined in the pre-existing instrument models section. For term names I have used chromatography system as prev. discussed in #408.
- Vendors use both GC-MS integrated system names (eg. Shimadzu) and separate names for GC and MS components (eg. Agilent) - so we probably need the correct 'system model' hierarchies to capture both of these (we see both reported in study metadata). For integrated GC-MS systems these will exist also under the mass spec hierarchy (eg. IS_A Shimadzu Scientific instrument model). Similarly, separate mass spec detector model names will also exist under the existing mass spec hierarchy (many GC-MS instruments are already represented in the mass spec hierarchy).

Best wishes,

Jon
EMBL-EBI