### PR TITLE
Remove wrong synonym for MS1 median cycle time

### DIFF
--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -26782,7 +26782,6 @@ relationship: has_value_type xsd:float
 id: MS:4000192
 name: MS1 median cycle time
 def: "The median time between consecutive MS1 scans across the full run." [PSI:MS]
-synonym: "sampling frequency" RELATED [MS:1000029]
 synonym: "fastest frequency for MS level 1 collection" RELATED [MS:4000065]
 is_a: MS:4000003 ! single value
 relationship: has_metric_category MS:4000009 ! ID free metric


### PR DESCRIPTION
Removed synonym 'sampling frequency' which is wrong.  
Wout agrees and I forgot to create the PR earlier today. Closes #446