### PR TITLE
Classify Instruments III

### DIFF
--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -1,6 +1,6 @@
 format-version: 1.2
-data-version: 4.1.244
-date: 13:03:2026 12:00
+data-version: 4.1.245
+date: 30:03:2026 12:00
 saved-by: Jonathan Hunter
 default-namespace: MS
 namespace-id-rule: * MS:$sequence(7,0,9999999)$
@@ -1156,6 +1156,7 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 id: MS:1000139
 name: 4000 QTRAP
 def: "Applied Biosystems/MDS SCIEX Q 4000 TRAP MS." [PSI:MS]
+is_a: MS:1003765 ! triple quadrupole linear ion trap instrument
 is_a: MS:1000121 ! SCIEX instrument model
 
 [Term]
@@ -1169,54 +1170,63 @@ is_a: MS:1000495 ! Applied Biosystems instrument model
 id: MS:1000141
 name: apex IV
 def: "Bruker Daltonics' apex IV: ESI, MALDI, Nanospray, APCI, APPI, Qh-FT_ICR." [PSI:MS]
+is_a: MS:1003766 ! quadrupole fourier transform ion cyclotron resonance instrument
 is_a: MS:1001556 ! Bruker Daltonics apex series
 
 [Term]
 id: MS:1000142
 name: apex Q
 def: "Bruker Daltonics' apex Q: ESI, MALDI, Nanospray, APCI, APPI, Qh-FT_ICR." [PSI:MS]
+is_a: MS:1003766 ! quadrupole fourier transform ion cyclotron resonance instrument
 is_a: MS:1001556 ! Bruker Daltonics apex series
 
 [Term]
 id: MS:1000143
 name: API 150EX
 def: "Applied Biosystems/MDS SCIEX API 150EX MS." [PSI:MS]
+is_a: MS:1003950 ! quadrupole instrument
 is_a: MS:1000121 ! SCIEX instrument model
 
 [Term]
 id: MS:1000144
 name: API 150EX Prep
 def: "Applied Biosystems/MDS SCIEX API 150EX Prep MS." [PSI:MS]
+is_a: MS:1003950 ! quadrupole instrument
 is_a: MS:1000121 ! SCIEX instrument model
 
 [Term]
 id: MS:1000145
 name: API 2000
 def: "Applied Biosystems/MDS SCIEX API 2000 MS." [PSI:MS]
+is_a: MS:1003762 ! triple quadrupole instrument
 is_a: MS:1000121 ! SCIEX instrument model
 
 [Term]
 id: MS:1000146
 name: API 3000
 def: "Applied Biosystems/MDS SCIEX API 3000 MS." [PSI:MS]
+is_a: MS:1003762 ! triple quadrupole instrument
 is_a: MS:1000121 ! SCIEX instrument model
 
 [Term]
 id: MS:1000147
 name: API 4000
 def: "Applied Biosystems/MDS SCIEX API 4000 MS." [PSI:MS]
+is_a: MS:1003762 ! triple quadrupole instrument
 is_a: MS:1000121 ! SCIEX instrument model
 
 [Term]
 id: MS:1000148
 name: autoflex II
 def: "Bruker Daltonics' autoflex II: MALDI TOF." [PSI:MS]
+is_a: MS:1003951 ! time-of-flight instrument
 is_a: MS:1001534 ! Bruker Daltonics flex series
 
 [Term]
 id: MS:1000149
 name: autoflex TOF/TOF
 def: "Bruker Daltonics' autoflex TOF/TOF MS: MALDI TOF." [PSI:MS]
+is_a: MS:1003946 ! tandem time-of-flight instrument
 is_a: MS:1001534 ! Bruker Daltonics flex series
 
 [Term]
@@ -1229,12 +1239,14 @@ is_a: MS:1000126 ! Waters instrument model
 id: MS:1000151
 name: BioTOF II
 def: "Bruker Daltonics' BioTOF II: ESI TOF." [PSI:MS]
+is_a: MS:1003951 ! time-of-flight instrument
 is_a: MS:1001535 ! Bruker Daltonics BioTOF series
 
 [Term]
 id: MS:1000152
 name: BioTOF-Q
 def: "Bruker Daltonics' BioTOF-Q: ESI Q-TOF." [PSI:MS]
+is_a: MS:1003763 ! quadrupole time-of-flight instrument
 is_a: MS:1001535 ! Bruker Daltonics BioTOF series
 
 [Term]
@@ -1260,12 +1272,14 @@ is_obsolete: true
 id: MS:1000156
 name: esquire 4000
 def: "Bruker Daltonics' esquire 4000: linear ion trap, ESI, MALDI, Nanospray, APCI, APPI." [PSI:MS]
+is_a: MS:1003952 ! ion trap instrument
 is_a: MS:1001533 ! Bruker Daltonics esquire series
 
 [Term]
 id: MS:1000157
 name: esquire 6000
 def: "Bruker Daltonics' esquire 6000: linear ion trap, ESI, MALDI, Nanospray, APCI, APPI." [PSI:MS]
+is_a: MS:1003952 ! ion trap instrument
 is_a: MS:1001533 ! Bruker Daltonics esquire series
 
 [Term]
@@ -1285,12 +1299,14 @@ is_a: MS:1000126 ! Waters instrument model
 id: MS:1000160
 name: HCT
 def: "Bruker Daltonics' HCT: ESI Q-TOF, Nanospray, APCI, APPI." [PSI:MS]
+is_a: MS:1003952 ! ion trap instrument
 is_a: MS:1000697 ! Bruker Daltonics HCT Series
 
 [Term]
 id: MS:1000161
 name: HCTplus
 def: "Bruker Daltonics' HCTplus: ESI Q-TOF, Nanospray, APCI, APPI." [PSI:MS]
+is_a: MS:1003952 ! ion trap instrument
 is_a: MS:1000697 ! Bruker Daltonics HCT Series
 
 [Term]
@@ -1394,12 +1410,14 @@ is_a: MS:1000493 ! Finnigan MAT instrument model
 id: MS:1000177
 name: microflex
 def: "Bruker Daltonics' microflex: MALDI TOF." [PSI:MS]
+is_a: MS:1003951 ! time-of-flight instrument
 is_a: MS:1001534 ! Bruker Daltonics flex series
 
 [Term]
 id: MS:1000178
 name: microTOF LC
 def: "Bruker Daltonics' microTOF LC: ESI TOF, Nanospray, APCI, APPI." [PSI:MS]
+is_a: MS:1003951 ! time-of-flight instrument
 is_a: MS:1001536 ! Bruker Daltonics micrOTOF series
 
 [Term]
@@ -1432,6 +1450,7 @@ is_a: MS:1000123 ! IonSpec instrument model
 id: MS:1000183
 name: OmniFlex
 def: "Bruker Daltonics' OmniFlex: MALDI TOF." [PSI:MS]
+is_a: MS:1003951 ! time-of-flight instrument
 is_a: MS:1001534 ! Bruker Daltonics flex series
 
 [Term]
@@ -1456,6 +1475,7 @@ is_a: MS:1000121 ! SCIEX instrument model
 id: MS:1000187
 name: Q TRAP
 def: "Applied Biosystems/MDS SCIEX Q TRAP MS." [PSI:MS]
+is_a: MS:1003765 ! triple quadrupole linear ion trap instrument
 is_a: MS:1000121 ! SCIEX instrument model
 
 [Term]
@@ -1474,6 +1494,7 @@ is_a: MS:1000126 ! Waters instrument model
 id: MS:1000190
 name: QSTAR
 def: "Applied Biosystems/MDS SCIEX QSTAR MS." [PSI:MS]
+is_a: MS:1003763 ! quadrupole time-of-flight instrument
 is_a: MS:1000121 ! SCIEX instrument model
 
 [Term]
@@ -1541,12 +1562,14 @@ is_a: MS:1000123 ! IonSpec instrument model
 id: MS:1000201
 name: ultraflex
 def: "Bruker Daltonics' ultraflex: MALDI TOF." [PSI:MS]
+is_a: MS:1003951 ! time-of-flight instrument
 is_a: MS:1001534 ! Bruker Daltonics flex series
 
 [Term]
 id: MS:1000202
 name: ultraflex TOF/TOF
 def: "Bruker Daltonics' ultraflex TOF/TOF: MALDI TOF." [PSI:MS]
+is_a: MS:1003946 ! tandem time-of-flight instrument
 is_a: MS:1001534 ! Bruker Daltonics flex series
 
 [Term]
@@ -4372,54 +4395,63 @@ is_a: MS:1000124 ! Shimadzu instrument model
 id: MS:1000604
 name: LCMS-IT-TOF
 def: "Shimadzu Scientific Instruments LCMS-IT-TOF MS." [PSI:MS]
+is_a: MS:1003764 ! ion trap time-of-flight instrument
 is_a: MS:1000603 ! Shimadzu Scientific Instruments instrument model
 
 [Term]
 id: MS:1000605
 name: LCMS-2010EV
 def: "Shimadzu Scientific Instruments LCMS-2010EV MS." [PSI:MS]
+is_a: MS:1003950 ! quadrupole instrument
 is_a: MS:1000603 ! Shimadzu Scientific Instruments instrument model
 
 [Term]
 id: MS:1000606
 name: LCMS-2010A
 def: "Shimadzu Scientific Instruments LCMS-2010A MS." [PSI:MS]
+is_a: MS:1003950 ! quadrupole instrument
 is_a: MS:1000603 ! Shimadzu Scientific Instruments instrument model
 
 [Term]
 id: MS:1000607
 name: AXIMA CFR MALDI-TOF
 def: "Shimadzu Biotech AXIMA CFR MALDI-TOF MS." [PSI:MS]
+is_a: MS:1003951 ! time-of-flight instrument
 is_a: MS:1000602 ! Shimadzu MALDI-TOF instrument model
 
 [Term]
 id: MS:1000608
 name: AXIMA-QIT
 def: "Shimadzu Biotech AXIMA-QIT MS." [PSI:MS]
+is_a: MS:1003952 ! ion trap instrument
 is_a: MS:1000602 ! Shimadzu MALDI-TOF instrument model
 
 [Term]
 id: MS:1000609
 name: AXIMA-CFR plus
 def: "Shimadzu Biotech AXIMA-CFR plus MS." [PSI:MS]
+is_a: MS:1003951 ! time-of-flight instrument
 is_a: MS:1000602 ! Shimadzu MALDI-TOF instrument model
 
 [Term]
 id: MS:1000610
 name: AXIMA Performance MALDI-TOF/TOF
 def: "Shimadzu Biotech AXIMA Performance MALDI-TOF/TOF MS." [PSI:MS]
+is_a: MS:1003946 ! tandem time-of-flight instrument
 is_a: MS:1000602 ! Shimadzu MALDI-TOF instrument model
 
 [Term]
 id: MS:1000611
 name: AXIMA Confidence MALDI-TOF
 def: "Shimadzu Biotech AXIMA Confidence MALDI-TOF (curved field reflectron) MS." [PSI:MS]
+is_a: MS:1003951 ! time-of-flight instrument
 is_a: MS:1000602 ! Shimadzu MALDI-TOF instrument model
 
 [Term]
 id: MS:1000612
 name: AXIMA Assurance Linear MALDI-TOF
 def: "Shimadzu Biotech AXIMA Assurance Linear MALDI-TOF MS." [PSI:MS]
+is_a: MS:1003951 ! time-of-flight instrument
 is_a: MS:1000602 ! Shimadzu MALDI-TOF instrument model
 
 [Term]
@@ -4688,42 +4720,49 @@ is_a: MS:1001457 ! data processing software
 id: MS:1000651
 name: 3200 QTRAP
 def: "SCIEX or Applied Biosystems|MDS SCIEX QTRAP 3200." [PSI:MS]
+is_a: MS:1003765 ! triple quadrupole linear ion trap instrument
 is_a: MS:1000121 ! SCIEX instrument model
 
 [Term]
 id: MS:1000652
 name: 4800 Plus MALDI TOF/TOF
 def: "SCIEX or Applied Biosystems|MDS SCIEX 4800 Plus MALDI TOF-TOF Analyzer." [PSI:MS]
+is_a: MS:1003946 ! tandem time-of-flight instrument
 is_a: MS:1000121 ! SCIEX instrument model
 
 [Term]
 id: MS:1000653
 name: API 3200
 def: "SCIEX or Applied Biosystems|MDS SCIEX API 3200 MS." [PSI:MS]
+is_a: MS:1003762 ! triple quadrupole instrument
 is_a: MS:1000121 ! SCIEX instrument model
 
 [Term]
 id: MS:1000654
 name: API 5000
 def: "SCIEX or Applied Biosystems|MDS SCIEX API 5000 MS." [PSI:MS]
+is_a: MS:1003762 ! triple quadrupole instrument
 is_a: MS:1000121 ! SCIEX instrument model
 
 [Term]
 id: MS:1000655
 name: QSTAR Elite
 def: "SCIEX or Applied Biosystems|MDS SCIEX QSTAR Elite." [PSI:MS]
+is_a: MS:1003763 ! quadrupole time-of-flight instrument
 is_a: MS:1000121 ! SCIEX instrument model
 
 [Term]
 id: MS:1000656
 name: QSTAR Pulsar
 def: "Applied Biosystems|MDS SCIEX QSTAR Pulsar." [PSI:MS]
+is_a: MS:1003763 ! quadrupole time-of-flight instrument
 is_a: MS:1000121 ! SCIEX instrument model
 
 [Term]
 id: MS:1000657
 name: QSTAR XL
 def: "Applied Biosystems|MDS SCIEX QSTAR XL." [PSI:MS]
+is_a: MS:1003763 ! quadrupole time-of-flight instrument
 is_a: MS:1000121 ! SCIEX instrument model
 
 [Term]
@@ -5006,12 +5045,14 @@ is_a: MS:1000531 ! software
 id: MS:1000695
 name: apex ultra
 def: "Bruker Daltonics' apex ultra: ESI, MALDI, Nanospray, APCI, APPI, Qh-FT_ICR." [PSI:MS]
+is_a: MS:1003766 ! quadrupole fourier transform ion cyclotron resonance instrument
 is_a: MS:1001556 ! Bruker Daltonics apex series
 
 [Term]
 id: MS:1000696
 name: autoflex III smartbeam
 def: "Bruker Daltonics' autoflex III smartbeam: MALDI TOF." [PSI:MS]
+is_a: MS:1003951 ! time-of-flight instrument
 is_a: MS:1001534 ! Bruker Daltonics flex series
 
 [Term]
@@ -5024,48 +5065,56 @@ is_a: MS:1000122 ! Bruker Daltonics instrument model
 id: MS:1000698
 name: HCTultra
 def: "Bruker Daltonics' HCTultra: ESI TOF, Nanospray, APCI, APPI." [PSI:MS]
+is_a: MS:1003952 ! ion trap instrument
 is_a: MS:1000697 ! Bruker Daltonics HCT Series
 
 [Term]
 id: MS:1000699
 name: HCTultra PTM
 def: "Bruker Daltonics' HCTultra PTM: ESI TOF, Nanospray, APCI, APPI, PTR." [PSI:MS]
+is_a: MS:1003952 ! ion trap instrument
 is_a: MS:1000697 ! Bruker Daltonics HCT Series
 
 [Term]
 id: MS:1000700
 name: HCTultra ETD II
 def: "Bruker Daltonics' HCTultra ETD II: ESI Q-TOF, Nanospray, APCI, APPI, ETD." [PSI:MS]
+is_a: MS:1003952 ! ion trap instrument
 is_a: MS:1000697 ! Bruker Daltonics HCT Series
 
 [Term]
 id: MS:1000701
 name: microflex LT
 def: "Bruker Daltonics' microflex LT: MALDI TOF." [PSI:MS]
+is_a: MS:1003951 ! time-of-flight instrument
 is_a: MS:1001534 ! Bruker Daltonics flex series
 
 [Term]
 id: MS:1000702
 name: micrOTOF
 def: "Bruker Daltonics' micrOTOF: ESI TOF, APCI, APPI." [PSI:MS]
+is_a: MS:1003951 ! time-of-flight instrument
 is_a: MS:1001536 ! Bruker Daltonics micrOTOF series
 
 [Term]
 id: MS:1000703
 name: micrOTOF-Q
 def: "Bruker Daltonics' micrOTOF-Q: ESI Q-TOF, Nanospray, APCI, APPI." [PSI:MS]
+is_a: MS:1003763 ! quadrupole time-of-flight instrument
 is_a: MS:1001536 ! Bruker Daltonics micrOTOF series
 
 [Term]
 id: MS:1000704
 name: micrOTOF-Q II
 def: "Bruker Daltonics' micrOTOF-Q II: ESI Q-TOF, Nanospray, APCI, APPI." [PSI:MS]
+is_a: MS:1003763 ! quadrupole time-of-flight instrument
 is_a: MS:1001536 ! Bruker Daltonics micrOTOF series
 
 [Term]
 id: MS:1000705
 name: ultraflex III TOF/TOF
 def: "Bruker Daltonics' ultraflex III TOF/TOF: MALDI TOF." [PSI:MS]
+is_a: MS:1003946 ! tandem time-of-flight instrument
 is_a: MS:1001534 ! Bruker Daltonics flex series
 
 [Term]
@@ -6227,6 +6276,7 @@ id: MS:1000870
 name: 4000 QTRAP
 def: "OBSOLETE SCIEX or Applied Biosystems|MDS SCIEX QTRAP 4000." [PSI:MS]
 comment: This term was obsoleted because was redundant to MS:1000139.
+is_a: MS:1003765 ! triple quadrupole linear ion trap instrument
 is_a: MS:1000121 ! SCIEX instrument model
 is_obsolete: true
 
@@ -6648,12 +6698,14 @@ is_a: MS:1000560 ! mass spectrometer file format
 id: MS:1000931
 name: QTRAP 5500
 def: "Applied Biosystems|MDS SCIEX QTRAP 5500." [PSI:MS]
+is_a: MS:1003765 ! triple quadrupole linear ion trap instrument
 is_a: MS:1000121 ! SCIEX instrument model
 
 [Term]
 id: MS:1000932
 name: TripleTOF 5600
 def: "SCIEX TripleTOF 5600, a quadrupole - quadrupole - time-of-flight mass spectrometer." [PSI:MS]
+is_a: MS:1003763 ! quadrupole time-of-flight instrument
 is_a: MS:1000121 ! SCIEX instrument model
 
 [Term]
@@ -9645,6 +9697,7 @@ is_a: MS:1000560 ! mass spectrometer file format
 id: MS:1001482
 name: 5800 TOF/TOF
 def: "SCIEX 5800 TOF-TOF Analyzer." [PSI:MS]
+is_a: MS:1003946 ! tandem time-of-flight instrument
 is_a: MS:1000121 ! SCIEX instrument model
 
 [Term]
@@ -10010,48 +10063,56 @@ is_a: MS:1000122 ! Bruker Daltonics instrument model
 id: MS:1001537
 name: BioTOF
 def: "Bruker Daltonics' BioTOF: ESI TOF." [PSI:MS]
+is_a: MS:1003951 ! time-of-flight instrument
 is_a: MS:1001535 ! Bruker Daltonics BioTOF series
 
 [Term]
 id: MS:1001538
 name: BioTOF III
 def: "Bruker Daltonics' BioTOF III: ESI TOF." [PSI:MS]
+is_a: MS:1003951 ! time-of-flight instrument
 is_a: MS:1001535 ! Bruker Daltonics BioTOF series
 
 [Term]
 id: MS:1001539
 name: UltroTOF-Q
 def: "Bruker Daltonics' UltroTOF-Q: ESI Q-TOF (MALDI optional)." [PSI:MS]
+is_a: MS:1003763 ! quadrupole time-of-flight instrument
 is_a: MS:1001535 ! Bruker Daltonics BioTOF series
 
 [Term]
 id: MS:1001540
 name: micrOTOF II
 def: "Bruker Daltonics' micrOTOF II: ESI TOF, Nanospray, APCI, APPI." [PSI:MS]
+is_a: MS:1003951 ! time-of-flight instrument
 is_a: MS:1001536 ! Bruker Daltonics micrOTOF series
 
 [Term]
 id: MS:1001541
 name: maXis
 def: "Bruker Daltonics' maXis: ESI Q-TOF, Nanospray, APCI, APPI." [PSI:MS]
+is_a: MS:1003763 ! quadrupole time-of-flight instrument
 is_a: MS:1001547 ! Bruker Daltonics maXis series
 
 [Term]
 id: MS:1001542
 name: amaZon ETD
 def: "Bruker Daltonics' amaZon ETD: ESI quadrupole ion trap, Nanospray, APCI, APPI, ETD, PTR." [PSI:MS]
+is_a: MS:1003952 ! ion trap instrument
 is_a: MS:1001545 ! Bruker Daltonics amaZon series
 
 [Term]
 id: MS:1001543
 name: microflex LRF
 def: "Bruker Daltonics' microflex LRF: MALDI TOF." [PSI:MS]
+is_a: MS:1003951 ! time-of-flight instrument
 is_a: MS:1001534 ! Bruker Daltonics flex series
 
 [Term]
 id: MS:1001544
 name: ultrafleXtreme
 def: "Bruker Daltonics' ultrafleXtreme: MALDI TOF." [PSI:MS]
+is_a: MS:1003946 ! tandem time-of-flight instrument
 is_a: MS:1001534 ! Bruker Daltonics flex series
 
 [Term]
@@ -10064,6 +10125,7 @@ is_a: MS:1000122 ! Bruker Daltonics instrument model
 id: MS:1001546
 name: amaZon X
 def: "Bruker Daltonics' amaZon X: ESI quadrupole ion trap, APCI, APPI, ETD, PTR." [PSI:MS]
+is_a: MS:1003952 ! ion trap instrument
 is_a: MS:1001545 ! Bruker Daltonics amaZon series
 
 [Term]
@@ -10082,30 +10144,35 @@ is_a: MS:1000122 ! Bruker Daltonics instrument model
 id: MS:1001549
 name: solariX
 def: "Bruker Daltonics' solariX: ESI, MALDI, Qh-FT_ICR." [PSI:MS]
+is_a: MS:1003766 ! quadrupole fourier transform ion cyclotron resonance instrument
 is_a: MS:1001548 ! Bruker Daltonics solarix series
 
 [Term]
 id: MS:1001550
 name: microflex II
 def: "Bruker Daltonics' microflex II: MALDI TOF." [PSI:MS]
+is_a: MS:1003951 ! time-of-flight instrument
 is_a: MS:1001534 ! Bruker Daltonics flex series
 
 [Term]
 id: MS:1001553
 name: autoflex II TOF/TOF
 def: "Bruker Daltonics' autoflex II TOF/TOF: MALDI TOF." [PSI:MS]
+is_a: MS:1003946 ! tandem time-of-flight instrument
 is_a: MS:1001534 ! Bruker Daltonics flex series
 
 [Term]
 id: MS:1001554
 name: autoflex III TOF/TOF smartbeam
 def: "Bruker Daltonics' autoflex III TOF/TOF smartbeam: MALDI TOF." [PSI:MS]
+is_a: MS:1003946 ! tandem time-of-flight instrument
 is_a: MS:1001534 ! Bruker Daltonics flex series
 
 [Term]
 id: MS:1001555
 name: autoflex
 def: "Bruker Daltonics' autoflex: MALDI TOF." [PSI:MS]
+is_a: MS:1003951 ! time-of-flight instrument
 is_a: MS:1001534 ! Bruker Daltonics flex series
 
 [Term]
@@ -13753,6 +13820,7 @@ is_a: MS:1001456 ! analysis software
 id: MS:1002077
 name: impact
 def: "Bruker Daltonics' impact: ESI Q-TOF, Nanospray, APCI, APPI, GC-APCI, CaptiveSpray." [PSI:MS]
+is_a: MS:1003763 ! quadrupole time-of-flight instrument
 is_a: MS:1001536 ! Bruker Daltonics micrOTOF series
 
 [Term]
@@ -15054,12 +15122,14 @@ is_a: MS:1001800 ! LECO instrument model
 id: MS:1002279
 name: maXis 4G
 def: "Bruker Daltonics' maXis 4G: ESI Q-TOF, Nanospray, APCI, APPI, GC-APCI, CaptiveSpray." [PSI:MS]
+is_a: MS:1003763 ! quadrupole time-of-flight instrument
 is_a: MS:1001547 ! Bruker Daltonics maXis series
 
 [Term]
 id: MS:1002280
 name: compact
 def: "Bruker Daltonics' compact: ESI Q-TOF, Nanospray, APCI, APPI, GC-APCI, CaptiveSpray." [PSI:MS]
+is_a: MS:1003763 ! quadrupole time-of-flight instrument
 is_a: MS:1001536 ! Bruker Daltonics micrOTOF series
 
 [Term]
@@ -15153,42 +15223,49 @@ is_a: MS:1000122 ! Bruker Daltonics instrument model
 id: MS:1002295
 name: SCION SQ
 def: "Bruker Daltonics' SCION SQ: GC-single quadrupole." [PSI:MS]
+is_a: MS:1003950 ! quadrupole instrument
 is_a: MS:1002293 ! Bruker Daltonics SCION series
 
 [Term]
 id: MS:1002296
 name: SCION TQ
 def: "Bruker Daltonics' SCION TQ: GC-triple quadrupole." [PSI:MS]
+is_a: MS:1003762 ! triple quadrupole instrument
 is_a: MS:1002293 ! Bruker Daltonics SCION series
 
 [Term]
 id: MS:1002297
 name: EVOQ Elite
 def: "Bruker Daltonics' EVOQ Elite: LC-triple quadrupole." [PSI:MS]
+is_a: MS:1003762 ! triple quadrupole instrument
 is_a: MS:1002294 ! Bruker Daltonics EVOQ series
 
 [Term]
 id: MS:1002298
 name: EVOQ Qube
 def: "Bruker Daltonics' EVOQ Qube: LC-triple quadrupole." [PSI:MS]
+is_a: MS:1003762 ! triple quadrupole instrument
 is_a: MS:1002294 ! Bruker Daltonics EVOQ series
 
 [Term]
 id: MS:1002299
 name: micrOTOF-Q III
 def: "Bruker Daltonics' micrOTOF-Q III: ESI Q-TOF, Nanospray, APCI, APPI, GC-APCI, CaptiveSpray." [PSI:MS]
+is_a: MS:1003763 ! quadrupole time-of-flight instrument
 is_a: MS:1001536 ! Bruker Daltonics micrOTOF series
 
 [Term]
 id: MS:1002300
 name: amaZon Speed ETD
 def: "Bruker Daltonics' amaZon Speed ETD: ESI quadrupole ion trap, Nanospray, APCI, APPI, ETD, PTR, GC-APCI, CaptiveSpray." [PSI:MS]
+is_a: MS:1003952 ! ion trap instrument
 is_a: MS:1001545 ! Bruker Daltonics amaZon series
 
 [Term]
 id: MS:1002301
 name: amaZon Speed
 def: "Bruker Daltonics' amaZon ETD: ESI quadrupole ion trap, Nanospray, APCI, APPI, GC-APCI, CaptiveSpray." [PSI:MS]
+is_a: MS:1003952 ! ion trap instrument
 is_a: MS:1001545 ! Bruker Daltonics amaZon series
 
 [Term]
@@ -15768,6 +15845,7 @@ is_a: MS:1001557 ! Shimadzu Corporation software
 id: MS:1002382
 name: Shimadzu MALDI-7090
 def: "Shimadzu MALDI-7090: MALDI-TOF-TOF." [PSI:PI]
+is_a: MS:1003946 ! tandem time-of-flight instrument
 is_a: MS:1000602 ! Shimadzu MALDI-TOF instrument model
 
 [Term]
@@ -16794,6 +16872,7 @@ is_a: MS:1000767 ! native spectrum identifier format
 id: MS:1002533
 name: TripleTOF 6600
 def: "SCIEX TripleTOF 6600, a quadrupole - quadrupole - time-of-flight mass spectrometer." [PSI:MS]
+is_a: MS:1003763 ! quadrupole time-of-flight instrument
 is_a: MS:1000121 ! SCIEX instrument model
 
 [Term]
@@ -17099,114 +17178,133 @@ is_a: MS:1001040 ! intermediate analysis format
 id: MS:1002577
 name: 2000 QTRAP
 def: "SCIEX 2000 QTRAP." [PSI:MS]
+is_a: MS:1003765 ! triple quadrupole linear ion trap instrument
 is_a: MS:1000121 ! SCIEX instrument model
 
 [Term]
 id: MS:1002578
 name: 2500 QTRAP
 def: "SCIEX 2500 QTRAP." [PSI:MS]
+is_a: MS:1003765 ! triple quadrupole linear ion trap instrument
 is_a: MS:1000121 ! SCIEX instrument model
 
 [Term]
 id: MS:1002579
 name: 3500 QTRAP
 def: "SCIEX 3500 QTRAP." [PSI:MS]
+is_a: MS:1003765 ! triple quadrupole linear ion trap instrument
 is_a: MS:1000121 ! SCIEX instrument model
 
 [Term]
 id: MS:1002580
 name: QTRAP 4500
 def: "SCIEX QTRAP 4500." [PSI:MS]
+is_a: MS:1003765 ! triple quadrupole linear ion trap instrument
 is_a: MS:1000121 ! SCIEX instrument model
 
 [Term]
 id: MS:1002581
 name: QTRAP 6500
 def: "SCIEX QTRAP 6500." [PSI:MS]
+is_a: MS:1003765 ! triple quadrupole linear ion trap instrument
 is_a: MS:1000121 ! SCIEX instrument model
 
 [Term]
 id: MS:1002582
 name: QTRAP 6500+
 def: "SCIEX QTRAP 6500+." [PSI:MS]
+is_a: MS:1003765 ! triple quadrupole linear ion trap instrument
 is_a: MS:1000121 ! SCIEX instrument model
 
 [Term]
 id: MS:1002583
 name: TripleTOF 4600
 def: "SCIEX TripleTOF 4600 time-of-flight mass spectrometer." [PSI:MS]
+is_a: MS:1003763 ! quadrupole time-of-flight instrument
 is_a: MS:1000121 ! SCIEX instrument model
 
 [Term]
 id: MS:1002584
 name: TripleTOF 5600+
 def: "SCIEX TripleTOF 5600+ time-of-flight mass spectrometer." [PSI:MS]
+is_a: MS:1003763 ! quadrupole time-of-flight instrument
 is_a: MS:1000121 ! SCIEX instrument model
 
 [Term]
 id: MS:1002585
 name: API 100
 def: "Applied Biosystems/MDS SCIEX API 100 MS." [PSI:MS]
+is_a: MS:1003950 ! quadrupole instrument
 is_a: MS:1000121 ! SCIEX instrument model
 
 [Term]
 id: MS:1002586
 name: API 100LC
 def: "Applied Biosystems/MDS SCIEX API 100LC MS." [PSI:MS]
+is_a: MS:1003950 ! quadrupole instrument
 is_a: MS:1000121 ! SCIEX instrument model
 
 [Term]
 id: MS:1002587
 name: API 165
 def: "Applied Biosystems/MDS SCIEX API 165 MS." [PSI:MS]
+is_a: MS:1003950 ! quadrupole instrument
 is_a: MS:1000121 ! SCIEX instrument model
 
 [Term]
 id: MS:1002588
 name: API 300
 def: "Applied Biosystems/MDS SCIEX API 300 MS." [PSI:MS]
+is_a: MS:1003762 ! triple quadrupole instrument
 is_a: MS:1000121 ! SCIEX instrument model
 
 [Term]
 id: MS:1002589
 name: API 350
 def: "Applied Biosystems/MDS SCIEX API 350 MS." [PSI:MS]
+is_a: MS:1003762 ! triple quadrupole instrument
 is_a: MS:1000121 ! SCIEX instrument model
 
 [Term]
 id: MS:1002590
 name: API 365
 def: "Applied Biosystems/MDS SCIEX API 365 MS." [PSI:MS]
+is_a: MS:1003762 ! triple quadrupole instrument
 is_a: MS:1000121 ! SCIEX instrument model
 
 [Term]
 id: MS:1002591
 name: Triple Quad 3500
 def: "SCIEX Triple Quad 3500." [PSI:MS]
+is_a: MS:1003762 ! triple quadrupole instrument
 is_a: MS:1000121 ! SCIEX instrument model
 
 [Term]
 id: MS:1002592
 name: Triple Quad 4500
 def: "SCIEX Triple Quad 4500." [PSI:MS]
+is_a: MS:1003762 ! triple quadrupole instrument
 is_a: MS:1000121 ! SCIEX instrument model
 
 [Term]
 id: MS:1002593
 name: Triple Quad 5500
 def: "SCIEX Triple Quad 5500." [PSI:MS]
+is_a: MS:1003762 ! triple quadrupole instrument
 is_a: MS:1000121 ! SCIEX instrument model
 
 [Term]
 id: MS:1002594
 name: Triple Quad 6500
 def: "SCIEX Triple Quad 6500." [PSI:MS]
+is_a: MS:1003762 ! triple quadrupole instrument
 is_a: MS:1000121 ! SCIEX instrument model
 
 [Term]
 id: MS:1002595
 name: Triple Quad 6500+
 def: "SCIEX Triple Quad 6500+." [PSI:MS]
+is_a: MS:1003762 ! triple quadrupole instrument
 is_a: MS:1000121 ! SCIEX instrument model
 
 [Term]
@@ -17676,12 +17774,14 @@ is_a: MS:1002479 ! regular expression
 id: MS:1002666
 name: impact II
 def: "Bruker Daltonics' impact II." [PSI:MS]
+is_a: MS:1003763 ! quadrupole time-of-flight instrument
 is_a: MS:1001536 ! Bruker Daltonics micrOTOF series
 
 [Term]
 id: MS:1002667
 name: impact HD
 def: "Bruker Daltonics' impact HD." [PSI:MS]
+is_a: MS:1003763 ! quadrupole time-of-flight instrument
 is_a: MS:1001536 ! Bruker Daltonics micrOTOF series
 
 [Term]
@@ -17728,6 +17828,7 @@ is_a: MS:1000752 ! TOPP software
 id: MS:1002674
 name: X500R QTOF
 def: "SCIEX X500R QTOF, a quadrupole - quadrupole - time-of-flight mass spectrometer." [PSI:MS]
+is_a: MS:1003763 ! quadrupole time-of-flight instrument
 is_a: MS:1000121 ! SCIEX instrument model
 
 [Term]
@@ -18586,12 +18687,14 @@ is_a: MS:1000490 ! Agilent instrument model
 id: MS:1002804
 name: 7800 Quadrupole ICP-MS
 def: "The 7800 Quadrupole ICP-MS system is a Agilent inductively couple plasma instrument combined with a Agilent quadrupole mass spectrometer." [PSI:MS]
+is_a: MS:1003950 ! quadrupole instrument
 is_a: MS:1000490 ! Agilent instrument model
 
 [Term]
 id: MS:1002805
 name: 8800 Triple Quadrupole ICP-MS
 def: "The 8800 Quadrupole ICP-MS system is a Agilent inductively couple plasma instrument combined with a Agilent quadrupole mass spectrometer." [PSI:MS]
+is_a: MS:1003762 ! triple quadrupole instrument
 is_a: MS:1000490 ! Agilent instrument model
 
 [Term]
@@ -19894,48 +19997,56 @@ relationship: has_value_type xsd:nonNegativeInteger ! The allowed value-type for
 id: MS:1002998
 name: LCMS-9030
 def: "Shimadzu Scientific Instruments LCMS-9030 Q-TOF MS." [PSI:MS]
+is_a: MS:1003763 ! quadrupole time-of-flight instrument
 is_a: MS:1000603 ! Shimadzu Scientific Instruments instrument model
 
 [Term]
 id: MS:1002999
 name: LCMS-8060
 def: "Shimadzu Scientific Instruments LCMS-8060 MS." [PSI:MS]
+is_a: MS:1003762 ! triple quadrupole instrument
 is_a: MS:1000603 ! Shimadzu Scientific Instruments instrument model
 
 [Term]
 id: MS:1003000
 name: LCMS-8050
 def: "Shimadzu Scientific Instruments LCMS-8050 MS." [PSI:MS]
+is_a: MS:1003762 ! triple quadrupole instrument
 is_a: MS:1000603 ! Shimadzu Scientific Instruments instrument model
 
 [Term]
 id: MS:1003001
 name: LCMS-8045
 def: "Shimadzu Scientific Instruments LCMS-8045 MS." [PSI:MS]
+is_a: MS:1003762 ! triple quadrupole instrument
 is_a: MS:1000603 ! Shimadzu Scientific Instruments instrument model
 
 [Term]
 id: MS:1003002
 name: LCMS-8040
 def: "Shimadzu Scientific Instruments LCMS-8040 MS." [PSI:MS]
+is_a: MS:1003762 ! triple quadrupole instrument
 is_a: MS:1000603 ! Shimadzu Scientific Instruments instrument model
 
 [Term]
 id: MS:1003003
 name: LCMS-2020
 def: "Shimadzu Scientific Instruments LCMS-2020." [PSI:MS]
+is_a: MS:1003950 ! quadrupole instrument
 is_a: MS:1000603 ! Shimadzu Scientific Instruments instrument model
 
 [Term]
 id: MS:1003004
 name: maXis II
 def: "Bruker Daltonics' maXis II." [PSI:MS]
+is_a: MS:1003763 ! quadrupole time-of-flight instrument
 is_a: MS:1001547 ! Bruker Daltonics maXis series
 
 [Term]
 id: MS:1003005
 name: timsTOF Pro
 def: "Bruker Daltonics' timsTOF Pro." [PSI:MS]
+is_a: MS:1003767 ! quadrupole ion mobility time-of-flight instrument
 is_a: MS:1003123 ! Bruker Daltonics timsTOF series
 
 [Term]
@@ -20717,6 +20828,7 @@ relationship: has_value_type xsd:double ! The allowed value-type for this CV ter
 id: MS:1003122
 name: rapifleX
 def: "Bruker Daltonics' rapiflex: MALDI TOF/TOF." [PSI:MS]
+is_a: MS:1003946 ! tandem time-of-flight instrument
 is_a: MS:1001534 ! Bruker Daltonics flex series
 
 [Term]
@@ -20729,6 +20841,7 @@ is_a: MS:1000122 ! Bruker Daltonics instrument model
 id: MS:1003124
 name: timsTOF fleX
 def: "Bruker Daltonics' timsTOF fleX" [PSI:MS]
+is_a: MS:1003767 ! quadrupole ion mobility time-of-flight instrument
 is_a: MS:1003123 ! Bruker Daltonics timsTOF series
 
 [Term]
@@ -20881,6 +20994,7 @@ relationship: has_units UO:0000221 ! dalton
 id: MS:1003144
 name: Triple Quad 7500
 def: "SCIEX Triple Quad 7500." [PSI:MS]
+is_a: MS:1003762 ! triple quadrupole instrument
 is_a: MS:1000121 ! SCIEX instrument model
 
 [Term]
@@ -20934,6 +21048,7 @@ relationship: has_value_type xsd:string ! The allowed value-type for this CV ter
 id: MS:1003152
 name: GCMS-QP2010SE
 def: "Shimadzu Scientific Instruments GCMS-QP2010SE." [PSI:MS]
+is_a: MS:1003950 ! quadrupole instrument
 is_a: MS:1000603 ! Shimadzu Scientific Instruments instrument model
 
 [Term]
@@ -21481,18 +21596,21 @@ is_a: MS:1003213 ! mass spectrometry acquisition method
 id: MS:1003229
 name: timsTOF
 def: "Bruker Daltonics' timsTOF." [PSI:MS]
+is_a: MS:1003767 ! quadrupole ion mobility time-of-flight instrument
 is_a: MS:1003123 ! Bruker Daltonics timsTOF series
 
 [Term]
 id: MS:1003230
 name: timsTOF Pro 2
 def: "Bruker Daltonics' timsTOF Pro 2." [PSI:MS]
+is_a: MS:1003767 ! quadrupole ion mobility time-of-flight instrument
 is_a: MS:1003123 ! Bruker Daltonics timsTOF series
 
 [Term]
 id: MS:1003231
 name: timsTOF SCP
 def: "Bruker Daltonics' timsTOF SCP." [PSI:MS]
+is_a: MS:1003767 ! quadrupole ion mobility time-of-flight instrument
 is_a: MS:1003123 ! Bruker Daltonics timsTOF series
 
 [Term]
@@ -21902,6 +22020,7 @@ is_a: MS:1000494 ! Thermo Scientific instrument model
 id: MS:1003293
 name: ZenoTOF 7600
 def: "SCIEX ZenoTOF 7600." [PSI:MS]
+is_a: MS:1003763 ! quadrupole time-of-flight instrument
 is_a: MS:1000121 ! SCIEX instrument model
 
 [Term]
@@ -22519,6 +22638,7 @@ is_a: MS:1001457 ! data processing software
 id: MS:1003383
 name: timsTOF Ultra
 def: "Bruker Daltonics' timsTOF Ultra." [PSI:MS]
+is_a: MS:1003767 ! quadrupole ion mobility time-of-flight instrument
 is_a: MS:1003123 ! Bruker Daltonics timsTOF series
 
 [Term]
@@ -22616,6 +22736,7 @@ is_a: MS:1003731 ! Agilent gas chromatography system model
 id: MS:1003397
 name: timsTOF fleX MALDI-2
 def: "Bruker Daltonics' timsTOF fleX MALDI-2." [PSI:MS]
+is_a: MS:1003767 ! quadrupole ion mobility time-of-flight instrument
 is_a: MS:1003123 ! Bruker Daltonics timsTOF series
 
 [Term]
@@ -22660,6 +22781,7 @@ relationship: has_value_type xsd:string ! The allowed value-type for this CV ter
 id: MS:1003404
 name: timsTOF HT
 def: "Bruker Daltonics' timsTOF HT." [PSI:MS]
+is_a: MS:1003767 ! quadrupole ion mobility time-of-flight instrument
 is_a: MS:1003123 ! Bruker Daltonics timsTOF series
 
 [Term]
@@ -22712,6 +22834,7 @@ is_a: MS:1000494 ! Thermo Scientific instrument model
 id: MS:1003412
 name: timsTOF Ultra 2
 def: "Bruker Daltonics timsTOF Ultra 2." [PSI:MS]
+is_a: MS:1003767 ! quadrupole ion mobility time-of-flight instrument
 is_a: MS:1003123 ! Bruker Daltonics timsTOF series
 
 [Term]
@@ -22936,18 +23059,21 @@ is_a: MS:1000494 ! Thermo Scientific instrument model
 id: MS:1003443
 name: ZenoTOF 8600
 def: "SCIEX ZenoTOF 8600 system." [PSI:MS]
+is_a: MS:1003763 ! quadrupole time-of-flight instrument
 is_a: MS:1000121 ! SCIEX instrument model
 
 [Term]
 id: MS:1003444
 name: ZenoTOF 7600+
 def: "SCIEX ZenoTOF 7600+ system." [PSI:MS]
+is_a: MS:1003763 ! quadrupole time-of-flight instrument
 is_a: MS:1000121 ! SCIEX instrument model
 
 [Term]
 id: MS:1003445
 name: SCIEX 7500+
 def: "SCIEX 7500+ system." [PSI:MS]
+is_a: MS:1003762 ! triple quadrupole instrument
 is_a: MS:1000121 ! SCIEX instrument model
 
 [Term]
@@ -23026,162 +23152,189 @@ is_a: MS:1000031 ! instrument model
 id: MS:1003456
 name: TripleTOF 6600+
 def: "SCIEX TripleTOF 6600+ triple quadrupole - time-of-flight mass spectrometer." [PSI:MS]
+is_a: MS:1003763 ! quadrupole time-of-flight instrument
 is_a: MS:1000121 ! SCIEX instrument model
 
 [Term]
 id: MS:1003457
 name: Triple Quad 5500+
 def: "SCIEX Triple Quad 5500+ triple quadrupole mass spectrometer." [PSI:MS]
+is_a: MS:1003762 ! triple quadrupole instrument
 is_a: MS:1000121 ! SCIEX instrument model
 
 [Term]
 id: MS:1003458
 name: Triple Quad 5500+ QTRAP Ready
 def: "SCIEX Triple Quad 5500+ QTRAP Ready quadrupole - linear ion trap mass spectrometer." [PSI:MS]
+is_a: MS:1003765 ! triple quadrupole linear ion trap instrument
 is_a: MS:1000121 ! SCIEX instrument model
 
 [Term]
 id: MS:1003459
 name: APEX-Qe
 def: "Bruker APEX-Qe FT-ICR-MS mass spectrometer." [PSI:MS]
+is_a: MS:1003766 ! quadrupole fourier transform ion cyclotron resonance instrument
 is_a: MS:1001556 ! Bruker Daltonics apex series
 
 [Term]
 id: MS:1003460
 name: autoflex speed TOF/TOF
 def: "Bruker autoflex speed TOF/TOF MALDI TOF/TOF mass spectrometer." [PSI:MS]
+is_a: MS:1003946 ! tandem time-of-flight instrument
 is_a: MS:1001534 ! Bruker Daltonics flex series
 
 [Term]
 id: MS:1003461
 name: esquire 3000
 def: "Bruker esquire 3000 ion trap mass spectrometer." [PSI:MS]
+is_a: MS:1003952 ! ion trap instrument
 is_a: MS:1001533 ! Bruker Daltonics esquire series
 
 [Term]
 id: MS:1003462
 name: maXis impact
 def: "Bruker maXis impact quadrupole time-of-flight mass spectrometer." [PSI:MS]
+is_a: MS:1003763 ! quadrupole time-of-flight instrument
 is_a: MS:1001547 ! Bruker Daltonics maXis series
 
 [Term]
 id: MS:1003463
 name: maXis impact HD
 def: "Bruker maXis impact HD quadrupole time-of-flight mass spectrometer." [PSI:MS]
+is_a: MS:1003763 ! quadrupole time-of-flight instrument
 is_a: MS:1001547 ! Bruker Daltonics maXis series
 
 [Term]
 id: MS:1003464
 name: maXis 3G
 def: "Bruker maXis 3G quadrupole time-of-flight mass spectrometer." [PSI:MS]
+is_a: MS:1003763 ! quadrupole time-of-flight instrument
 is_a: MS:1001547 ! Bruker Daltonics maXis series
 
 [Term]
 id: MS:1003465
 name: solariX XR
 def: "Bruker solariX XR FT-ICR-MS mass spectrometer." [PSI:MS]
+is_a: MS:1003766 ! quadrupole fourier transform ion cyclotron resonance instrument
 is_a: MS:1001548 ! Bruker Daltonics solarix series
 
 [Term]
 id: MS:1003466
 name: amaZon SL
 def: "Bruker amaZon SL ion trap mass spectrometer." [PSI:MS]
+is_a: MS:1003952 ! ion trap instrument
 is_a: MS:1001545 ! Bruker Daltonics amaZon series
 
 [Term]
 id: MS:1003467
 name: EVOQ DART-TQ+
 def: "Bruker EVOQ DART-TQ+ triple quadrupole mass spectrometer with Direct Analysis in Real Time (DART) ion source." [PSI:MS]
+is_a: MS:1003762 ! triple quadrupole instrument
 is_a: MS:1002294 ! Bruker Daltonics EVOQ series
 
 [Term]
 id: MS:1003468
 name: EVOQ LC-TQ
 def: "Bruker EVOQ LC-TQ triple quadrupole mass spectrometer." [PSI:MS]
+is_a: MS:1003762 ! triple quadrupole instrument
 is_a: MS:1002294 ! Bruker Daltonics EVOQ series
 
 [Term]
 id: MS:1003469
 name: EVOQ GC-TQ
 def: "Bruker EVOQ GC-TQ gas chromatograph - triple quadrupole mass spectrometer." [PSI:MS]
+is_a: MS:1003762 ! triple quadrupole instrument
 is_a: MS:1002294 ! Bruker Daltonics EVOQ series
 
 [Term]
 id: MS:1003470
 name: Toxtyper
 def: "Bruker Toxtyper ion trap mass spectrometer." [PSI:MS]
+is_a: MS:1003952 ! ion trap instrument
 is_a: MS:1000122 ! Bruker Daltonics instrument model
 
 [Term]
 id: MS:1003471
 name: impact II VIP
 def: "Bruker impact II VIP quadrupole time-of-flight mass spectrometer." [PSI:MS]
+is_a: MS:1003763 ! quadrupole time-of-flight instrument
 is_a: MS:1001536 ! Bruker Daltonics micrOTOF series
 
 [Term]
 id: MS:1003472
 name: ecTOF
 def: "Bruker ecTOF gas chromatograph - time-of-flight mass spectrometer." [PSI:MS]
+is_a: MS:1003951 ! time-of-flight instrument
 is_a: MS:1000122 ! Bruker Daltonics instrument model
 
 [Term]
 id: MS:1003473
 name: autoflex maX
 def: "Bruker autoflex maX MALDI TOF mass spectrometer." [PSI:MS]
+is_a: MS:1003951 ! time-of-flight instrument
 is_a: MS:1001534 ! Bruker Daltonics flex series
 
 [Term]
 id: MS:1003474
 name: rapifleX MALDI PharmaPulse
 def: "Bruker rapifleX MALDI PharmaPulse MALDI TOF mass spectrometer with ultra-high-throughput screening (uHTS) capability." [PSI:MS]
+is_a: MS:1003951 ! time-of-flight instrument
 is_a: MS:1001534 ! Bruker Daltonics flex series
 
 [Term]
 id: MS:1003475
 name: smartfleX
 def: "Bruker smartfleX MALDI TOF mass spectrometer." [PSI:MS]
+is_a: MS:1003951 ! time-of-flight instrument
 is_a: MS:1001534 ! Bruker Daltonics flex series
 
 [Term]
 id: MS:1003476
 name: neofleX
 def: "Bruker neofleX MALDI TOF/TOF mass spectrometer." [PSI:MS]
+is_a: MS:1003946 ! tandem time-of-flight instrument
 is_a: MS:1001534 ! Bruker Daltonics flex series
 
 [Term]
 id: MS:1003477
 name: MALDI Biotyper
 def: "Bruker MALDI Biotyper MALDI TOF mass spectrometer." [PSI:MS]
+is_a: MS:1003951 ! time-of-flight instrument
 is_a: MS:1000122 ! Bruker Daltonics instrument model
 
 [Term]
 id: MS:1003478
 name: scimaX
 def: "Bruker scimaX FT-ICR-MS mass spectrometer." [PSI:MS]
+is_a: MS:1003766 ! quadrupole fourier transform ion cyclotron resonance instrument
 is_a: MS:1000122 ! Bruker Daltonics instrument model
 
 [Term]
 id: MS:1003479
 name: timsMetabo
 def: "Bruker timsMetabo TIMS-Q-TOF mass spectrometer." [PSI:MS]
+is_a: MS:1003767 ! quadrupole ion mobility time-of-flight instrument
 is_a: MS:1003123 ! Bruker Daltonics timsTOF series
 
 [Term]
 id: MS:1003480
 name: timsUltra AIP
 def: "Bruker timsUltra AIP TIMS-Q-TOF mass spectrometer." [PSI:MS]
+is_a: MS:1003767 ! quadrupole ion mobility time-of-flight instrument
 is_a: MS:1003123 ! Bruker Daltonics timsTOF series
 
 [Term]
 id: MS:1003481
 name: timsOmni
 def: "Bruker timsOmni TIMS-Q-TOF mass spectrometer." [PSI:MS]
+is_a: MS:1003767 ! quadrupole ion mobility time-of-flight instrument
 is_a: MS:1003123 ! Bruker Daltonics timsTOF series
 
 [Term]
 id: MS:1003482
 name: timsTOF MALDI PharmaPulse
 def: "Bruker timsTOF MALDI PharmaPulse MALDI TIMS-Q-TOF mass spectrometer with ultra-high-throughput screening (uHTS) capability." [PSI:MS]
+is_a: MS:1003767 ! quadrupole ion mobility time-of-flight instrument
 is_a: MS:1003123 ! Bruker Daltonics timsTOF series
 
 [Term]
@@ -23204,30 +23357,35 @@ is_a: MS:1000489 ! Varian instrument model
 id: MS:1003485
 name: LCMS-8030
 def: "Shimadzu LCMS-8030 triple quadrupole mass spectrometer." [PSI:MS]
+is_a: MS:1003762 ! triple quadrupole instrument
 is_a: MS:1000603 ! Shimadzu Scientific Instruments instrument model
 
 [Term]
 id: MS:1003486
 name: LCMS-8030 Plus
 def: "Shimadzu LCMS-8030 Plus triple quadrupole mass spectrometer." [PSI:MS]
+is_a: MS:1003762 ! triple quadrupole instrument
 is_a: MS:1000603 ! Shimadzu Scientific Instruments instrument model
 
 [Term]
 id: MS:1003487
 name: GCMS-QP2010 Plus
 def: "Shimadzu GCMS-QP2010 Plus gas chromatograph - quadrupole mass spectrometer." [PSI:MS]
+is_a: MS:1003950 ! quadrupole instrument
 is_a: MS:1000603 ! Shimadzu Scientific Instruments instrument model
 
 [Term]
 id: MS:1003488
 name: LCMS-8060NX
 def: "Shimadzu LCMS-8060NX triple quadrupole mass spectrometer." [PSI:MS]
+is_a: MS:1003762 ! triple quadrupole instrument
 is_a: MS:1000603 ! Shimadzu Scientific Instruments instrument model
 
 [Term]
 id: MS:1003489
 name: GCMS-TQ8050NX
 def: "Shimadzu GCMS-TQ8050NX gas chromatograph - triple quadrupole mass spectrometer." [PSI:MS]
+is_a: MS:1003762 ! triple quadrupole instrument
 is_a: MS:1000603 ! Shimadzu Scientific Instruments instrument model
 is_a: MS:1003733 ! gas chromatography mass spectrometry system
 
@@ -23235,30 +23393,35 @@ is_a: MS:1003733 ! gas chromatography mass spectrometry system
 id: MS:1003490
 name: GCMS-TQ8040NX
 def: "Shimadzu GCMS-TQ8040NX gas chromatograph - triple quadrupole mass spectrometer." [PSI:MS]
+is_a: MS:1003762 ! triple quadrupole instrument
 is_a: MS:1000603 ! Shimadzu Scientific Instruments instrument model
 
 [Term]
 id: MS:1003491
 name: GCMS-TQ8040
 def: "Shimadzu GCMS-TQ8040 gas chromatograph - triple quadrupole mass spectrometer." [PSI:MS]
+is_a: MS:1003762 ! triple quadrupole instrument
 is_a: MS:1000603 ! Shimadzu Scientific Instruments instrument model
 
 [Term]
 id: MS:1003492
 name: GCMS-QP5000
 def: "Shimadzu GCMS-QP5000 gas chromatograph - quadrupole mass spectrometer." [PSI:MS]
+is_a: MS:1003950 ! quadrupole instrument
 is_a: MS:1000603 ! Shimadzu Scientific Instruments instrument model
 
 [Term]
 id: MS:1003493
 name: GCMS-QP2020
 def: "Shimadzu GCMS-QP2020 gas chromatograph - quadrupole mass spectrometer." [PSI:MS]
+is_a: MS:1003950 ! quadrupole instrument
 is_a: MS:1000603 ! Shimadzu Scientific Instruments instrument model
 
 [Term]
 id: MS:1003494
 name: GCMS-QP2010 Ultra
 def: "Shimadzu GCMS-QP2010 Ultra gas chromatograph - quadrupole mass spectrometer." [PSI:MS]
+is_a: MS:1003950 ! quadrupole instrument
 is_a: MS:1000603 ! Shimadzu Scientific Instruments instrument model
 
 [Term]
@@ -23691,126 +23854,147 @@ is_a: MS:1000125 ! Thermo Finnigan instrument model
 id: MS:1003555
 name: AXIMA-LNR
 def: "Shimadzu AXIMA-LNR MALDI TOF mass spectrometer." [PSI:MS]
+is_a: MS:1003951 ! time-of-flight instrument
 is_a: MS:1000602 ! Shimadzu MALDI-TOF instrument model
 
 [Term]
 id: MS:1003556
 name: AXIMA-TOF²
 def: "Shimadzu AXIMA-TOF² MALDI TOF/TOF mass spectrometer." [PSI:MS]
+is_a: MS:1003946 ! tandem time-of-flight instrument
 is_a: MS:1000602 ! Shimadzu MALDI-TOF instrument model
 
 [Term]
 id: MS:1003557
 name: AXIMA Resonance
 def: "Shimadzu AXIMA Resonance MALDI TOF mass spectrometerwith Ion Trap for MSn." [PSI:MS]
+is_a: MS:1003952 ! ion trap instrument
 is_a: MS:1000602 ! Shimadzu MALDI-TOF instrument model
 
 [Term]
 id: MS:1003558
 name: MALDI-8020
 def: "Shimadzu MALDI-8020 benchtop MALDI TOF mass spectrometer." [PSI:MS]
+is_a: MS:1003951 ! time-of-flight instrument
 is_a: MS:1000602 ! Shimadzu MALDI-TOF instrument model
 
 [Term]
 id: MS:1003559
 name: MALDI-8030
 def: "Shimadzu MALDI-8030 benchtop MALDI TOF mass spectrometer." [PSI:MS]
+is_a: MS:1003951 ! time-of-flight instrument
 is_a: MS:1000602 ! Shimadzu MALDI-TOF instrument model
 
 [Term]
 id: MS:1003560
 name: MALDI-8020 EasyCare
 def: "Shimadzu MALDI-8020 EasyCare benchtop MALDI TOF mass spectrometer." [PSI:MS]
+is_a: MS:1003951 ! time-of-flight instrument
 is_a: MS:1000602 ! Shimadzu MALDI-TOF instrument model
 
 [Term]
 id: MS:1003561
 name: MALDI-8030 EasyCare
 def: "Shimadzu MALDI-8030 EasyCare benchtop MALDI TOF mass spectrometer." [PSI:MS]
+is_a: MS:1003951 ! time-of-flight instrument
 is_a: MS:1000602 ! Shimadzu MALDI-TOF instrument model
 
 [Term]
 id: MS:1003562
 name: LCMS-2010
 def: "Shimadzu LCMS-2010 quadrupole mass spectrometer." [PSI:MS]
+is_a: MS:1003950 ! quadrupole instrument
 is_a: MS:1000603 ! Shimadzu Scientific Instruments instrument model
 
 [Term]
 id: MS:1003563
 name: LCMS-2050
 def: "Shimadzu LCMS-2050 quadrupole mass spectrometer." [PSI:MS]
+is_a: MS:1003950 ! quadrupole instrument
 is_a: MS:1000603 ! Shimadzu Scientific Instruments instrument model
 
 [Term]
 id: MS:1003564
 name: LCMS-8045RX
 def: "Shimadzu LCMS-8045RX triple quadrupole mass spectrometer." [PSI:MS]
+is_a: MS:1003762 ! triple quadrupole instrument
 is_a: MS:1000603 ! Shimadzu Scientific Instruments instrument model
 
 [Term]
 id: MS:1003565
 name: LCMS-8050RX
 def: "Shimadzu LCMS-8050RX triple quadrupole mass spectrometer." [PSI:MS]
+is_a: MS:1003762 ! triple quadrupole instrument
 is_a: MS:1000603 ! Shimadzu Scientific Instruments instrument model
 
 [Term]
 id: MS:1003566
 name: LCMS-8060RX
 def: "Shimadzu LCMS-8060RX triple quadrupole mass spectrometer." [PSI:MS]
+is_a: MS:1003762 ! triple quadrupole instrument
 is_a: MS:1000603 ! Shimadzu Scientific Instruments instrument model
 
 [Term]
 id: MS:1003567
 name: LCMS-8065XE
 def: "Shimadzu LCMS-8065XE triple quadrupole mass spectrometer." [PSI:MS]
+is_a: MS:1003762 ! triple quadrupole instrument
 is_a: MS:1000603 ! Shimadzu Scientific Instruments instrument model
 
 [Term]
 id: MS:1003568
 name: LCMS-9050
 def: "Shimadzu LCMS-9050 quadrupole time-of-flight mass spectrometer." [PSI:MS]
+is_a: MS:1003763 ! quadrupole time-of-flight instrument
 is_a: MS:1000603 ! Shimadzu Scientific Instruments instrument model
 
 [Term]
 id: MS:1003569
 name: GCMS-QP5050A
 def: "Shimadzu GCMS-QP5050A gas chromatograph - quadrupole mass spectrometer." [PSI:MS]
+is_a: MS:1003950 ! quadrupole instrument
 is_a: MS:1000603 ! Shimadzu Scientific Instruments instrument model
 
 [Term]
 id: MS:1003570
 name: GCMS-QP2010S
 def: "Shimadzu GCMS-QP2010S gas chromatograph - quadrupole mass spectrometer." [PSI:MS]
+is_a: MS:1003950 ! quadrupole instrument
 is_a: MS:1000603 ! Shimadzu Scientific Instruments instrument model
 
 [Term]
 id: MS:1003571
 name: GCMS-QP2010
 def: "Shimadzu GCMS-QP2010 gas chromatograph - quadrupole mass spectrometer." [PSI:MS]
+is_a: MS:1003950 ! quadrupole instrument
 is_a: MS:1000603 ! Shimadzu Scientific Instruments instrument model
 
 [Term]
 id: MS:1003572
 name: GCMS-QP2020NX
 def: "Shimadzu GCMS-QP2020NX gas chromatograph - quadrupole mass spectrometer." [PSI:MS]
+is_a: MS:1003950 ! quadrupole instrument
 is_a: MS:1000603 ! Shimadzu Scientific Instruments instrument model
 
 [Term]
 id: MS:1003573
 name: GCMS-QP2050
 def: "Shimadzu GCMS-QP2050 gas chromatograph - quadrupole mass spectrometer." [PSI:MS]
+is_a: MS:1003950 ! quadrupole instrument
 is_a: MS:1000603 ! Shimadzu Scientific Instruments instrument model
 
 [Term]
 id: MS:1003574
 name: GCMS-TQ 8030
 def: "Shimadzu GCMS-TQ 8030 gas chromatograph - triple quadrupole mass spectrometer." [PSI:MS]
+is_a: MS:1003762 ! triple quadrupole instrument
 is_a: MS:1000603 ! Shimadzu Scientific Instruments instrument model
 
 [Term]
 id: MS:1003575
 name: GCMS-TQ 8050
 def: "Shimadzu GCMS-TQ 8050 gas chromatograph - triple quadrupole mass spectrometer." [PSI:MS]
+is_a: MS:1003762 ! triple quadrupole instrument
 is_a: MS:1000603 ! Shimadzu Scientific Instruments instrument model
 
 [Term]
@@ -25180,12 +25364,14 @@ is_a: MS:1000531 ! software
 id: MS:1003804
 name: Ionoptika J105
 def: "Ionoptika J105 time-of-flight secondary ion mass spectrometer." [PSI:MS]
+is_a: MS:1003951 ! time-of-flight instrument
 is_a: MS:1003802 ! Ionoptika instrument model
 
 [Term]
 id: MS:1003805
 name: J Series III
 def: "Ionoptika J Series III time-of-flight secondary ion mass spectrometer." [PSI:MS]
+is_a: MS:1003951 ! time-of-flight instrument
 is_a: MS:1003802 ! Ionoptika instrument model
 
 [Term]

--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -1170,7 +1170,7 @@ is_a: MS:1000495 ! Applied Biosystems instrument model
 id: MS:1000141
 name: apex IV
 def: "Bruker Daltonics' apex IV: ESI, MALDI, Nanospray, APCI, APPI, Qh-FT_ICR." [PSI:MS]
-is_a: MS:1003766 ! quadrupole fourier transform ion cyclotron resonance instrument
+is_a: MS:1003948 ! fourier transform ion cyclotron resonance instrument
 is_a: MS:1001556 ! Bruker Daltonics apex series
 
 [Term]
@@ -4423,7 +4423,7 @@ is_a: MS:1000602 ! Shimadzu MALDI-TOF instrument model
 id: MS:1000608
 name: AXIMA-QIT
 def: "Shimadzu Biotech AXIMA-QIT MS." [PSI:MS]
-is_a: MS:1003952 ! ion trap instrument
+is_a: MS:1003764 ! ion trap time-of-flight instrument
 is_a: MS:1000602 ! Shimadzu MALDI-TOF instrument model
 
 [Term]
@@ -6276,7 +6276,6 @@ id: MS:1000870
 name: 4000 QTRAP
 def: "OBSOLETE SCIEX or Applied Biosystems|MDS SCIEX QTRAP 4000." [PSI:MS]
 comment: This term was obsoleted because was redundant to MS:1000139.
-is_a: MS:1003765 ! triple quadrupole linear ion trap instrument
 is_a: MS:1000121 ! SCIEX instrument model
 is_obsolete: true
 
@@ -20046,7 +20045,7 @@ is_a: MS:1001547 ! Bruker Daltonics maXis series
 id: MS:1003005
 name: timsTOF Pro
 def: "Bruker Daltonics' timsTOF Pro." [PSI:MS]
-is_a: MS:1003767 ! quadrupole ion mobility time-of-flight instrument
+is_a: MS:1003970 ! ion mobility quadrupole time-of-flight instrument
 is_a: MS:1003123 ! Bruker Daltonics timsTOF series
 
 [Term]
@@ -20841,7 +20840,7 @@ is_a: MS:1000122 ! Bruker Daltonics instrument model
 id: MS:1003124
 name: timsTOF fleX
 def: "Bruker Daltonics' timsTOF fleX" [PSI:MS]
-is_a: MS:1003767 ! quadrupole ion mobility time-of-flight instrument
+is_a: MS:1003970 ! ion mobility quadrupole time-of-flight instrument
 is_a: MS:1003123 ! Bruker Daltonics timsTOF series
 
 [Term]
@@ -21596,21 +21595,21 @@ is_a: MS:1003213 ! mass spectrometry acquisition method
 id: MS:1003229
 name: timsTOF
 def: "Bruker Daltonics' timsTOF." [PSI:MS]
-is_a: MS:1003767 ! quadrupole ion mobility time-of-flight instrument
+is_a: MS:1003970 ! ion mobility quadrupole time-of-flight instrument
 is_a: MS:1003123 ! Bruker Daltonics timsTOF series
 
 [Term]
 id: MS:1003230
 name: timsTOF Pro 2
 def: "Bruker Daltonics' timsTOF Pro 2." [PSI:MS]
-is_a: MS:1003767 ! quadrupole ion mobility time-of-flight instrument
+is_a: MS:1003970 ! ion mobility quadrupole time-of-flight instrument
 is_a: MS:1003123 ! Bruker Daltonics timsTOF series
 
 [Term]
 id: MS:1003231
 name: timsTOF SCP
 def: "Bruker Daltonics' timsTOF SCP." [PSI:MS]
-is_a: MS:1003767 ! quadrupole ion mobility time-of-flight instrument
+is_a: MS:1003970 ! ion mobility quadrupole time-of-flight instrument
 is_a: MS:1003123 ! Bruker Daltonics timsTOF series
 
 [Term]
@@ -22638,7 +22637,7 @@ is_a: MS:1001457 ! data processing software
 id: MS:1003383
 name: timsTOF Ultra
 def: "Bruker Daltonics' timsTOF Ultra." [PSI:MS]
-is_a: MS:1003767 ! quadrupole ion mobility time-of-flight instrument
+is_a: MS:1003970 ! ion mobility quadrupole time-of-flight instrument
 is_a: MS:1003123 ! Bruker Daltonics timsTOF series
 
 [Term]
@@ -22736,7 +22735,7 @@ is_a: MS:1003731 ! Agilent gas chromatography system model
 id: MS:1003397
 name: timsTOF fleX MALDI-2
 def: "Bruker Daltonics' timsTOF fleX MALDI-2." [PSI:MS]
-is_a: MS:1003767 ! quadrupole ion mobility time-of-flight instrument
+is_a: MS:1003970 ! ion mobility quadrupole time-of-flight instrument
 is_a: MS:1003123 ! Bruker Daltonics timsTOF series
 
 [Term]
@@ -22781,7 +22780,7 @@ relationship: has_value_type xsd:string ! The allowed value-type for this CV ter
 id: MS:1003404
 name: timsTOF HT
 def: "Bruker Daltonics' timsTOF HT." [PSI:MS]
-is_a: MS:1003767 ! quadrupole ion mobility time-of-flight instrument
+is_a: MS:1003970 ! ion mobility quadrupole time-of-flight instrument
 is_a: MS:1003123 ! Bruker Daltonics timsTOF series
 
 [Term]
@@ -22834,7 +22833,7 @@ is_a: MS:1000494 ! Thermo Scientific instrument model
 id: MS:1003412
 name: timsTOF Ultra 2
 def: "Bruker Daltonics timsTOF Ultra 2." [PSI:MS]
-is_a: MS:1003767 ! quadrupole ion mobility time-of-flight instrument
+is_a: MS:1003970 ! ion mobility quadrupole time-of-flight instrument
 is_a: MS:1003123 ! Bruker Daltonics timsTOF series
 
 [Term]
@@ -23278,7 +23277,7 @@ is_a: MS:1001534 ! Bruker Daltonics flex series
 id: MS:1003474
 name: rapifleX MALDI PharmaPulse
 def: "Bruker rapifleX MALDI PharmaPulse MALDI TOF mass spectrometer with ultra-high-throughput screening (uHTS) capability." [PSI:MS]
-is_a: MS:1003951 ! time-of-flight instrument
+is_a: MS:1003946 ! tandem time-of-flight instrument
 is_a: MS:1001534 ! Bruker Daltonics flex series
 
 [Term]
@@ -23313,28 +23312,28 @@ is_a: MS:1000122 ! Bruker Daltonics instrument model
 id: MS:1003479
 name: timsMetabo
 def: "Bruker timsMetabo TIMS-Q-TOF mass spectrometer." [PSI:MS]
-is_a: MS:1003767 ! quadrupole ion mobility time-of-flight instrument
+is_a: MS:1003970 ! ion mobility quadrupole time-of-flight instrument
 is_a: MS:1003123 ! Bruker Daltonics timsTOF series
 
 [Term]
 id: MS:1003480
 name: timsUltra AIP
 def: "Bruker timsUltra AIP TIMS-Q-TOF mass spectrometer." [PSI:MS]
-is_a: MS:1003767 ! quadrupole ion mobility time-of-flight instrument
+is_a: MS:1003970 ! ion mobility quadrupole time-of-flight instrument
 is_a: MS:1003123 ! Bruker Daltonics timsTOF series
 
 [Term]
 id: MS:1003481
 name: timsOmni
 def: "Bruker timsOmni TIMS-Q-TOF mass spectrometer." [PSI:MS]
-is_a: MS:1003767 ! quadrupole ion mobility time-of-flight instrument
+is_a: MS:1003970 ! ion mobility quadrupole time-of-flight instrument
 is_a: MS:1003123 ! Bruker Daltonics timsTOF series
 
 [Term]
 id: MS:1003482
 name: timsTOF MALDI PharmaPulse
 def: "Bruker timsTOF MALDI PharmaPulse MALDI TIMS-Q-TOF mass spectrometer with ultra-high-throughput screening (uHTS) capability." [PSI:MS]
-is_a: MS:1003767 ! quadrupole ion mobility time-of-flight instrument
+is_a: MS:1003970 ! ion mobility quadrupole time-of-flight instrument
 is_a: MS:1003123 ! Bruker Daltonics timsTOF series
 
 [Term]
@@ -23868,7 +23867,7 @@ is_a: MS:1000602 ! Shimadzu MALDI-TOF instrument model
 id: MS:1003557
 name: AXIMA Resonance
 def: "Shimadzu AXIMA Resonance MALDI TOF mass spectrometerwith Ion Trap for MSn." [PSI:MS]
-is_a: MS:1003952 ! ion trap instrument
+is_a: MS:1003764 ! ion trap time-of-flight instrument
 is_a: MS:1000602 ! Shimadzu MALDI-TOF instrument model
 
 [Term]
@@ -25880,6 +25879,13 @@ def: "Thermo Scientific software for complex biotherapeutic characterization by 
 is_a: MS:1003961 ! Thermo Scientific software
 is_a: MS:1001456 ! analysis software
 is_a: MS:1001457 ! data processing software
+
+[Term]
+id: MS:1003970
+name: ion mobility quadrupole time-of-flight instrument
+def: "An instrument that uses an ion mobility analyzer followed by a quadrupole mass filter and a time-of-flight mass analyzer as its primary means of mass analysis." [PSI:MS]
+synonym: "IMS-Q-TOF" EXACT []
+is_a: MS:1003761 ! instrument class
 
 [Term]
 id: MS:4000000


### PR DESCRIPTION
## Summary

Assigns instrument classification (`is_a` MS:1003761 children) to 186 instrument models across Agilent (2), Bruker Daltonics (82), Ionoptika (2), SCIEX (62), and Shimadzu (38). Continues the work from #476.

### New term

- **MS:1003970 ion mobility quadrupole time-of-flight instrument** — for instruments where ion mobility separation precedes the quadrupole (Bruker timsTOF/tims series). Distinct from MS:1003767 (quadrupole ion mobility time-of-flight instrument) where the quadrupole precedes IMS (Waters Synapt, Agilent 6560).

### Classifications by type

| Instrument class | Count |
|---|---:|
| triple quadrupole | 39 |
| quadrupole time-of-flight | 31 |
| time-of-flight | 30 |
| quadrupole | 22 |
| tandem time-of-flight | 15 |
| ion trap | 14 |
| ion mobility quadrupole time-of-flight (new) | 13 |
| triple quadrupole linear ion trap | 11 |
| quadrupole FTICR | 6 |
| ion trap time-of-flight | 3 |
| FTICR | 1 |

### Not classified

Three SCIEX instruments were skipped as their instrument types could not be determined:
- MS:1000186 proteomics solution 1
- MS:1000194 SymBiot I
- MS:1000195 SymBiot XVI