### PR TITLE
Classify Instruments IV

### DIFF
--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -1,6 +1,6 @@
 format-version: 1.2
-data-version: 4.1.244
-date: 13:03:2026 12:00
+data-version: 4.1.246
+date: 31:03:2026 12:00
 saved-by: Jonathan Hunter
 default-namespace: MS
 namespace-id-rule: * MS:$sequence(7,0,9999999)$
@@ -1223,6 +1223,7 @@ is_a: MS:1001534 ! Bruker Daltonics flex series
 id: MS:1000150
 name: Auto Spec Ultima NT
 def: "Waters magnetic sector based AutoSpec Ultima NT MS." [PSI:MS]
+is_a: MS:1003949 ! magnetic sector instrument
 is_a: MS:1000126 ! Waters instrument model
 
 [Term]
@@ -1241,12 +1242,14 @@ is_a: MS:1001535 ! Bruker Daltonics BioTOF series
 id: MS:1000153
 name: DELTA plusAdvantage
 def: "ThermoFinnigan DELTA plusAdvantage MS." [PSI:MS]
+is_a: MS:1003949 ! magnetic sector instrument
 is_a: MS:1000125 ! Thermo Finnigan instrument model
 
 [Term]
 id: MS:1000154
 name: DELTAplusXP
 def: "ThermoFinnigan DELTAplusXP MS." [PSI:MS]
+is_a: MS:1003949 ! magnetic sector instrument
 is_a: MS:1000125 ! Thermo Finnigan instrument model
 
 [Term]
@@ -1279,6 +1282,7 @@ is_a: MS:1000123 ! IonSpec instrument model
 id: MS:1000159
 name: GCT
 def: "Waters oa-ToF based GCT." [PSI:MS]
+is_a: MS:1003951 ! time-of-flight instrument
 is_a: MS:1000126 ! Waters instrument model
 
 [Term]
@@ -1311,48 +1315,56 @@ is_a: MS:1000123 ! IonSpec instrument model
 id: MS:1000164
 name: IsoPrime
 def: "Waters IsoPrime MS." [PSI:MS]
+is_a: MS:1003949 ! magnetic sector instrument
 is_a: MS:1000126 ! Waters instrument model
 
 [Term]
 id: MS:1000165
 name: IsoProbe
 def: "Waters IsoProbe MS." [PSI:MS]
+is_a: MS:1003949 ! magnetic sector instrument
 is_a: MS:1000126 ! Waters instrument model
 
 [Term]
 id: MS:1000166
 name: IsoProbe T
 def: "Waters IsoProbe T MS." [PSI:MS]
+is_a: MS:1003949 ! magnetic sector instrument
 is_a: MS:1000126 ! Waters instrument model
 
 [Term]
 id: MS:1000167
 name: LCQ Advantage
 def: "ThermoFinnigan LCQ Advantage MS." [PSI:MS]
+is_a: MS:1003952 ! ion trap instrument
 is_a: MS:1000125 ! Thermo Finnigan instrument model
 
 [Term]
 id: MS:1000168
 name: LCQ Classic
 def: "ThermoFinnigan LCQ Classic MS." [PSI:MS]
+is_a: MS:1003952 ! ion trap instrument
 is_a: MS:1000125 ! Thermo Finnigan instrument model
 
 [Term]
 id: MS:1000169
 name: LCQ Deca XP Plus
 def: "ThermoFinnigan LCQ Deca XP Plus MS." [PSI:MS]
+is_a: MS:1003952 ! ion trap instrument
 is_a: MS:1000125 ! Thermo Finnigan instrument model
 
 [Term]
 id: MS:1000170
 name: M@LDI L
 def: "Waters oa-ToF based MALDI L." [PSI:MS]
+is_a: MS:1003951 ! time-of-flight instrument
 is_a: MS:1000126 ! Waters instrument model
 
 [Term]
 id: MS:1000171
 name: M@LDI LR
 def: "Waters oa-ToF based MALDI LR." [PSI:MS]
+is_a: MS:1003951 ! time-of-flight instrument
 is_a: MS:1000126 ! Waters instrument model
 
 [Term]
@@ -1406,6 +1418,7 @@ is_a: MS:1001536 ! Bruker Daltonics micrOTOF series
 id: MS:1000179
 name: neptune
 def: "ThermoFinnigan NEPTUNE MS." [PSI:MS]
+is_a: MS:1003949 ! magnetic sector instrument
 is_a: MS:1000125 ! Thermo Finnigan instrument model
 
 [Term]
@@ -1444,6 +1457,7 @@ is_a: MS:1000126 ! Waters instrument model
 id: MS:1000185
 name: PolarisQ
 def: "ThermoFinnigan PolarisQ MS." [PSI:MS]
+is_a: MS:1003952 ! ion trap instrument
 is_a: MS:1000125 ! Thermo Finnigan instrument model
 
 [Term]
@@ -1462,12 +1476,14 @@ is_a: MS:1000121 ! SCIEX instrument model
 id: MS:1000188
 name: Q-Tof micro
 def: "Waters oa-ToF based Q-Tof micro." [PSI:MS]
+is_a: MS:1003763 ! quadrupole time-of-flight instrument
 is_a: MS:1000126 ! Waters instrument model
 
 [Term]
 id: MS:1000189
 name: Q-Tof Ultima
 def: "Waters oa-ToF based Q-Tof Ultima." [PSI:MS]
+is_a: MS:1003763 ! quadrupole time-of-flight instrument
 is_a: MS:1000126 ! Waters instrument model
 
 [Term]
@@ -1480,18 +1496,21 @@ is_a: MS:1000121 ! SCIEX instrument model
 id: MS:1000191
 name: quattro micro
 def: "Waters (triple) quadrupole based micro." [PSI:MS]
+is_a: MS:1003762 ! triple quadrupole instrument
 is_a: MS:1000126 ! Waters instrument model
 
 [Term]
 id: MS:1000192
 name: Quattro Ultima
 def: "Waters (triple) quadrupole based Ultima." [PSI:MS]
+is_a: MS:1003762 ! triple quadrupole instrument
 is_a: MS:1000126 ! Waters instrument model
 
 [Term]
 id: MS:1000193
 name: Surveyor MSQ
 def: "ThermoFinnigan Surveyor MSQ MS." [PSI:MS]
+is_a: MS:1003950 ! quadrupole instrument
 is_a: MS:1000125 ! Thermo Finnigan instrument model
 
 [Term]
@@ -1510,24 +1529,28 @@ is_a: MS:1000121 ! SCIEX instrument model
 id: MS:1000196
 name: TEMPUS TOF
 def: "ThermoFinnigan TEMPUS TOF MS." [PSI:MS]
+is_a: MS:1003951 ! time-of-flight instrument
 is_a: MS:1000125 ! Thermo Finnigan instrument model
 
 [Term]
 id: MS:1000197
 name: TRACE DSQ
 def: "ThermoFinnigan TRACE DSQ MS." [PSI:MS]
+is_a: MS:1003950 ! quadrupole instrument
 is_a: MS:1000125 ! Thermo Finnigan instrument model
 
 [Term]
 id: MS:1000198
 name: TRITON
 def: "ThermoFinnigan TRITON MS." [PSI:MS]
+is_a: MS:1003949 ! magnetic sector instrument
 is_a: MS:1000125 ! Thermo Finnigan instrument model
 
 [Term]
 id: MS:1000199
 name: TSQ Quantum
 def: "ThermoFinnigan TSQ Quantum MS." [PSI:MS]
+is_a: MS:1003762 ! triple quadrupole instrument
 is_a: MS:1000125 ! Thermo Finnigan instrument model
 
 [Term]
@@ -3285,24 +3308,28 @@ is_a: MS:1000008 ! ionization type
 id: MS:1000447
 name: LTQ
 def: "Finnigan LTQ MS." [PSI:MS]
+is_a: MS:1003952 ! ion trap instrument
 is_a: MS:1000494 ! Thermo Scientific instrument model
 
 [Term]
 id: MS:1000448
 name: LTQ FT
 def: "Finnigan LTQ FT MS." [PSI:MS]
+is_a: MS:1003971 ! ion trap fourier transform ion cyclotron resonance instrument
 is_a: MS:1000494 ! Thermo Scientific instrument model
 
 [Term]
 id: MS:1000449
 name: LTQ Orbitrap
 def: "Finnigan LTQ Orbitrap MS." [PSI:MS]
+is_a: MS:1003768 ! ion trap orbitrap instrument
 is_a: MS:1000494 ! Thermo Scientific instrument model
 
 [Term]
 id: MS:1000450
 name: LXQ
 def: "Finnigan LXQ MS." [PSI:MS]
+is_a: MS:1003952 ! ion trap instrument
 is_a: MS:1000494 ! Thermo Scientific instrument model
 
 [Term]
@@ -4038,30 +4065,35 @@ is_a: MS:1001457 ! data processing software
 id: MS:1000554
 name: LCQ Deca
 def: "ThermoFinnigan LCQ Deca." [PSI:MS]
+is_a: MS:1003952 ! ion trap instrument
 is_a: MS:1000125 ! Thermo Finnigan instrument model
 
 [Term]
 id: MS:1000555
 name: LTQ Orbitrap Discovery
 def: "LTQ Orbitrap Discovery." [PSI:MS]
+is_a: MS:1003768 ! ion trap orbitrap instrument
 is_a: MS:1000494 ! Thermo Scientific instrument model
 
 [Term]
 id: MS:1000556
 name: LTQ Orbitrap XL
 def: "LTQ Orbitrap XL." [PSI:MS]
+is_a: MS:1003768 ! ion trap orbitrap instrument
 is_a: MS:1000494 ! Thermo Scientific instrument model
 
 [Term]
 id: MS:1000557
 name: LTQ FT Ultra
 def: "LTQ FT Ultra." [PSI:MS]
+is_a: MS:1003971 ! ion trap fourier transform ion cyclotron resonance instrument
 is_a: MS:1000494 ! Thermo Scientific instrument model
 
 [Term]
 id: MS:1000558
 name: GC Quantum
 def: "GC Quantum." [PSI:MS]
+is_a: MS:1003762 ! triple quadrupole instrument
 is_a: MS:1000125 ! Thermo Finnigan instrument model
 
 [Term]
@@ -4187,6 +4219,7 @@ is_a: MS:1000499 ! spectrum attribute
 id: MS:1000578
 name: LCQ Fleet
 def: "LCQ Fleet." [PSI:MS]
+is_a: MS:1003952 ! ion trap instrument
 is_a: MS:1000125 ! Thermo Finnigan instrument model
 
 [Term]
@@ -4570,6 +4603,7 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 id: MS:1000632
 name: Q-Tof Premier
 def: "Waters oa-ToF based Q-Tof Premier." [PSI:MS]
+is_a: MS:1003763 ! quadrupole time-of-flight instrument
 is_a: MS:1000126 ! Waters instrument model
 
 [Term]
@@ -4583,84 +4617,98 @@ relationship: has_value_type xsd:int ! The allowed value-type for this CV term
 id: MS:1000634
 name: DSQ
 def: "ThermoFinnigan DSQ GC-MS." [PSI:MS]
+is_a: MS:1003950 ! quadrupole instrument
 is_a: MS:1000125 ! Thermo Finnigan instrument model
 
 [Term]
 id: MS:1000635
 name: ITQ 700
 def: "Thermo Scientific ITQ 700 GC-MS." [PSI:MS]
+is_a: MS:1003952 ! ion trap instrument
 is_a: MS:1000494 ! Thermo Scientific instrument model
 
 [Term]
 id: MS:1000636
 name: ITQ 900
 def: "Thermo Scientific ITQ 900 GC-MS." [PSI:MS]
+is_a: MS:1003952 ! ion trap instrument
 is_a: MS:1000494 ! Thermo Scientific instrument model
 
 [Term]
 id: MS:1000637
 name: ITQ 1100
 def: "Thermo Scientific ITQ 1100 GC-MS." [PSI:MS]
+is_a: MS:1003952 ! ion trap instrument
 is_a: MS:1000494 ! Thermo Scientific instrument model
 
 [Term]
 id: MS:1000638
 name: LTQ XL ETD
 def: "Thermo Scientific LTQ XL MS with ETD." [PSI:MS]
+is_a: MS:1003952 ! ion trap instrument
 is_a: MS:1000494 ! Thermo Scientific instrument model
 
 [Term]
 id: MS:1000639
 name: LTQ Orbitrap XL ETD
 def: "Thermo Scientific LTQ Orbitrap XL MS with ETD." [PSI:MS]
+is_a: MS:1003768 ! ion trap orbitrap instrument
 is_a: MS:1000494 ! Thermo Scientific instrument model
 
 [Term]
 id: MS:1000640
 name: DFS
 def: "Thermo Scientific DFS HR GC-MS." [PSI:MS]
+is_a: MS:1003949 ! magnetic sector instrument
 is_a: MS:1000494 ! Thermo Scientific instrument model
 
 [Term]
 id: MS:1000641
 name: DSQ II
 def: "Thermo Scientific DSQ II GC-MS." [PSI:MS]
+is_a: MS:1003950 ! quadrupole instrument
 is_a: MS:1000494 ! Thermo Scientific instrument model
 
 [Term]
 id: MS:1000642
 name: MALDI LTQ XL
 def: "Thermo Scientific MALDI LTQ XL MS." [PSI:MS]
+is_a: MS:1003952 ! ion trap instrument
 is_a: MS:1000494 ! Thermo Scientific instrument model
 
 [Term]
 id: MS:1000643
 name: MALDI LTQ Orbitrap
 def: "Thermo Scientific MALDI LTQ Orbitrap MS." [PSI:MS]
+is_a: MS:1003768 ! ion trap orbitrap instrument
 is_a: MS:1000494 ! Thermo Scientific instrument model
 
 [Term]
 id: MS:1000644
 name: TSQ Quantum Access
 def: "Thermo Scientific TSQ Quantum Access MS." [PSI:MS]
+is_a: MS:1003762 ! triple quadrupole instrument
 is_a: MS:1000494 ! Thermo Scientific instrument model
 
 [Term]
 id: MS:1000645
 name: Element XR
 def: "Thermo Scientific Element XR HR-ICP-MS." [PSI:MS]
+is_a: MS:1003949 ! magnetic sector instrument
 is_a: MS:1000494 ! Thermo Scientific instrument model
 
 [Term]
 id: MS:1000646
 name: Element 2
 def: "Thermo Scientific Element 2 HR-ICP-MS." [PSI:MS]
+is_a: MS:1003949 ! magnetic sector instrument
 is_a: MS:1000494 ! Thermo Scientific instrument model
 
 [Term]
 id: MS:1000647
 name: Element GD
 def: "Thermo Scientific Element GD Glow Discharge MS." [PSI:MS]
+is_a: MS:1003949 ! magnetic sector instrument
 is_a: MS:1000494 ! Thermo Scientific instrument model
 
 [Term]
@@ -4673,6 +4721,7 @@ is_a: MS:1000494 ! Thermo Scientific instrument model
 id: MS:1000649
 name: Exactive
 def: "Thermo Scientific Exactive MS." [PSI:MS]
+is_a: MS:1003953 ! orbitrap instrument
 is_a: MS:1000494 ! Thermo Scientific instrument model
 
 [Term]
@@ -4746,6 +4795,7 @@ is_a: MS:1001457 ! data processing software
 id: MS:1000660
 name: Xevo MRT MS
 def: "Waters Corporation Xevo MRT Mass Spectrometer." [PSI:MS]
+is_a: MS:1003763 ! quadrupole time-of-flight instrument
 is_a: MS:1000126 ! Waters instrument model
 
 [Term]
@@ -5327,6 +5377,7 @@ is_a: MS:1001040 ! intermediate analysis format
 id: MS:1000743
 name: TSQ Quantum Ultra AM
 def: "Thermo Scientific TSQ Quantum Ultra AM." [PSI:MS]
+is_a: MS:1003762 ! triple quadrupole instrument
 is_a: MS:1000494 ! Thermo Scientific instrument model
 
 [Term]
@@ -5381,6 +5432,7 @@ is_a: MS:1000493 ! Finnigan MAT instrument model
 id: MS:1000751
 name: TSQ Quantum Ultra
 def: "Thermo Scientific TSQ Quantum Ultra." [PSI:MS]
+is_a: MS:1003762 ! triple quadrupole instrument
 is_a: MS:1000494 ! Thermo Scientific instrument model
 
 [Term]
@@ -6118,18 +6170,21 @@ is_a: MS:1000842 ! laser type
 id: MS:1000854
 name: LTQ XL
 def: "Thermo Scientific LTQ XL MS." [PSI:MS]
+is_a: MS:1003952 ! ion trap instrument
 is_a: MS:1000494 ! Thermo Scientific instrument model
 
 [Term]
 id: MS:1000855
 name: LTQ Velos
 def: "Thermo Scientific LTQ Velos MS." [PSI:MS]
+is_a: MS:1003952 ! ion trap instrument
 is_a: MS:1000494 ! Thermo Scientific instrument model
 
 [Term]
 id: MS:1000856
 name: LTQ Velos/ETD
 def: "Thermo Scientific LTQ Velos MS with ETD." [PSI:MS]
+is_a: MS:1003952 ! ion trap instrument
 is_a: MS:1000494 ! Thermo Scientific instrument model
 synonym: "LTQ Velos ETD" EXACT []
 
@@ -9834,6 +9889,7 @@ is_a: MS:1000560 ! mass spectrometer file format
 id: MS:1001510
 name: TSQ Vantage
 def: "TSQ Vantage." [PSI:MS]
+is_a: MS:1003762 ! triple quadrupole instrument
 is_a: MS:1000494 ! Thermo Scientific instrument model
 
 [Term]
@@ -11466,6 +11522,7 @@ relationship: has_value_type xsd:string ! The allowed value-type for this CV ter
 id: MS:1001742
 name: LTQ Orbitrap Velos
 def: "Finnigan LTQ Orbitrap Velos MS." [PSI:MS]
+is_a: MS:1003768 ! ion trap orbitrap instrument
 is_a: MS:1000494 ! Thermo Scientific instrument model
 
 [Term]
@@ -11664,120 +11721,140 @@ is_a: MS:1003591 ! ultra-performance liquid chromatography system
 id: MS:1001770
 name: GCT Premier
 def: "Waters oa-ToF based GCT Premier." [PSI:MS]
+is_a: MS:1003951 ! time-of-flight instrument
 is_a: MS:1000126 ! Waters instrument model
 
 [Term]
 id: MS:1001771
 name: MALDI Synapt G2 HDMS
 def: "Waters oa-ToF based MALDI Synapt G2 HDMS." [PSI:MS]
+is_a: MS:1003767 ! quadrupole ion mobility time-of-flight instrument
 is_a: MS:1000126 ! Waters instrument model
 
 [Term]
 id: MS:1001772
 name: MALDI Synapt G2 MS
 def: "Waters oa-ToF based MALDI Synapt G2 MS." [PSI:MS]
+is_a: MS:1003763 ! quadrupole time-of-flight instrument
 is_a: MS:1000126 ! Waters instrument model
 
 [Term]
 id: MS:1001773
 name: MALDI Synapt G2-S HDMS
 def: "Waters oa-ToF based MALDI Synapt G2 MS." [PSI:MS]
+is_a: MS:1003767 ! quadrupole ion mobility time-of-flight instrument
 is_a: MS:1000126 ! Waters instrument model
 
 [Term]
 id: MS:1001774
 name: MALDI Synapt G2-S MS
 def: "Waters oa-ToF based MALDI Synapt G2-S MS." [PSI:MS]
+is_a: MS:1003763 ! quadrupole time-of-flight instrument
 is_a: MS:1000126 ! Waters instrument model
 
 [Term]
 id: MS:1001775
 name: MALDI Synapt HDMS
 def: "Waters oa-ToF based MALDI Synapt HDMS." [PSI:MS]
+is_a: MS:1003767 ! quadrupole ion mobility time-of-flight instrument
 is_a: MS:1000126 ! Waters instrument model
 
 [Term]
 id: MS:1001776
 name: MALDI Synapt MS
 def: "Waters oa-ToF based MALDI Synapt MS." [PSI:MS]
+is_a: MS:1003763 ! quadrupole time-of-flight instrument
 is_a: MS:1000126 ! Waters instrument model
 
 [Term]
 id: MS:1001777
 name: Synapt G2 HDMS
 def: "Waters oa-ToF based Synapt G2 HDMS." [PSI:MS]
+is_a: MS:1003767 ! quadrupole ion mobility time-of-flight instrument
 is_a: MS:1000126 ! Waters instrument model
 
 [Term]
 id: MS:1001778
 name: Synapt G2 MS
 def: "Waters oa-ToF based Synapt G2 MS." [PSI:MS]
+is_a: MS:1003763 ! quadrupole time-of-flight instrument
 is_a: MS:1000126 ! Waters instrument model
 
 [Term]
 id: MS:1001779
 name: Synapt G2-S HDMS
 def: "Waters oa-ToF based Synapt G2-S HDMS." [PSI:MS]
+is_a: MS:1003767 ! quadrupole ion mobility time-of-flight instrument
 is_a: MS:1000126 ! Waters instrument model
 
 [Term]
 id: MS:1001780
 name: Synapt G2-S MS
 def: "Waters oa-ToF based Synapt G2-S MS." [PSI:MS]
+is_a: MS:1003763 ! quadrupole time-of-flight instrument
 is_a: MS:1000126 ! Waters instrument model
 
 [Term]
 id: MS:1001781
 name: Synapt HDMS
 def: "Waters oa-ToF based Synapt HDMS." [PSI:MS]
+is_a: MS:1003767 ! quadrupole ion mobility time-of-flight instrument
 is_a: MS:1000126 ! Waters instrument model
 
 [Term]
 id: MS:1001782
 name: Synapt MS
 def: "Waters oa-ToF based Synapt MS." [PSI:MS]
+is_a: MS:1003763 ! quadrupole time-of-flight instrument
 is_a: MS:1000126 ! Waters instrument model
 
 [Term]
 id: MS:1001783
 name: Xevo G2 Q-Tof
 def: "Waters oa-ToF based Xevo G2 Q-Tof." [PSI:MS]
+is_a: MS:1003763 ! quadrupole time-of-flight instrument
 is_a: MS:1000126 ! Waters instrument model
 
 [Term]
 id: MS:1001784
 name: Xevo G2 Tof
 def: "Waters oa-ToF based Xevo G2 Tof." [PSI:MS]
+is_a: MS:1003951 ! time-of-flight instrument
 is_a: MS:1000126 ! Waters instrument model
 
 [Term]
 id: MS:1001785
 name: Xevo Q-Tof
 def: "Waters oa-ToF based Xevo Q-Tof." [PSI:MS]
+is_a: MS:1003763 ! quadrupole time-of-flight instrument
 is_a: MS:1000126 ! Waters instrument model
 
 [Term]
 id: MS:1001786
 name: 3100
 def: "Waters quadrupole based 3100." [PSI:MS]
+is_a: MS:1003950 ! quadrupole instrument
 is_a: MS:1000126 ! Waters instrument model
 
 [Term]
 id: MS:1001787
 name: Acquity SQD
 def: "Waters quadrupole based Acquity SQD." [PSI:MS]
+is_a: MS:1003950 ! quadrupole instrument
 is_a: MS:1000126 ! Waters instrument model
 
 [Term]
 id: MS:1001788
 name: Acquity TQD
 def: "Waters quadrupole based Acquity TQD." [PSI:MS]
+is_a: MS:1003762 ! triple quadrupole instrument
 is_a: MS:1000126 ! Waters instrument model
 
 [Term]
 id: MS:1001789
 name: Quattro micro GC
 def: "Waters (triple) quadrupole based Quattro micro GC." [PSI:MS]
+is_a: MS:1003762 ! triple quadrupole instrument
 is_a: MS:1000126 ! Waters instrument model
 
 [Term]
@@ -11791,12 +11868,14 @@ is_a: MS:1003762 ! triple quadrupole instrument
 id: MS:1001791
 name: Xevo TQD
 def: "Waters quadrupole based Xevo TQD." [PSI:MS]
+is_a: MS:1003762 ! triple quadrupole instrument
 is_a: MS:1000126 ! Waters instrument model
 
 [Term]
 id: MS:1001792
 name: Xevo TQ-S
 def: "Waters quadrupole based Xevo TQ-S." [PSI:MS]
+is_a: MS:1003762 ! triple quadrupole instrument
 is_a: MS:1000126 ! Waters instrument model
 
 [Term]
@@ -12584,18 +12663,21 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 id: MS:1001908
 name: ISQ
 def: "Thermo Scientific ISQ single quadrupole MS with the ExtractraBrite source." [PSI:MS]
+is_a: MS:1003950 ! quadrupole instrument
 is_a: MS:1000494 ! Thermo Scientific instrument model
 
 [Term]
 id: MS:1001909
 name: Velos Plus
 def: "Thermo Scientific second generation Velos." [PSI:MS]
+is_a: MS:1003952 ! ion trap instrument
 is_a: MS:1000494 ! Thermo Scientific instrument model
 
 [Term]
 id: MS:1001910
 name: Orbitrap Elite
 def: "Thermo Scientific Orbitrap Elite, sometimes referred to as the LTQ Orbitrap Elite." [PSI:MS]
+is_a: MS:1003768 ! ion trap orbitrap instrument
 is_a: MS:1000494 ! Thermo Scientific instrument model
 synonym: "LTQ Orbitrap Elite" EXACT []
 
@@ -12603,6 +12685,7 @@ synonym: "LTQ Orbitrap Elite" EXACT []
 id: MS:1001911
 name: Q Exactive
 def: "Thermo Scientific Q Exactive." [PSI:MS]
+is_a: MS:1003769 ! quadrupole orbitrap instrument
 is_a: MS:1000494 ! Thermo Scientific instrument model
 
 [Term]
@@ -15022,24 +15105,28 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 id: MS:1002274
 name: SQ Detector 2
 def: "Waters quadrupole based SQ Detector 2." [PSI:MS]
+is_a: MS:1003950 ! quadrupole instrument
 is_a: MS:1000126 ! Waters instrument model
 
 [Term]
 id: MS:1002275
 name: Xevo G2-S Tof
 def: "Waters oa-ToF based Xevo G2-S Tof." [PSI:MS]
+is_a: MS:1003951 ! time-of-flight instrument
 is_a: MS:1000126 ! Waters instrument model
 
 [Term]
 id: MS:1002276
 name: Xevo G2-S QTof
 def: "Waters oa-ToF based Xevo G2-S QTof." [PSI:MS]
+is_a: MS:1003763 ! quadrupole time-of-flight instrument
 is_a: MS:1000126 ! Waters instrument model
 
 [Term]
 id: MS:1002277
 name: AutoSpec Premier
 def: "Waters AutoSpec Premier magnetic sector instrument." [PSI:MS]
+is_a: MS:1003949 ! magnetic sector instrument
 is_a: MS:1000126 ! Waters instrument model
 
 [Term]
@@ -15999,24 +16086,28 @@ relationship: has_value_type xsd:boolean ! The allowed value-type for this CV te
 id: MS:1002416
 name: Orbitrap Fusion
 def: "Thermo Scientific Orbitrap Fusion." [PSI:PI]
+is_a: MS:1003770 ! quadrupole ion trap orbitrap instrument
 is_a: MS:1000494 ! Thermo Scientific instrument model
 
 [Term]
 id: MS:1002417
 name: Orbitrap Fusion ETD
 def: "Thermo Scientific Orbitrap Fusion with ETD." [PSI:PI]
+is_a: MS:1003770 ! quadrupole ion trap orbitrap instrument
 is_a: MS:1000494 ! Thermo Scientific instrument model
 
 [Term]
 id: MS:1002418
 name: TSQ Quantiva
 def: "Thermo Scientific TSQ Quantiva MS." [PSI:PI]
+is_a: MS:1003762 ! triple quadrupole instrument
 is_a: MS:1000494 ! Thermo Scientific instrument model
 
 [Term]
 id: MS:1002419
 name: TSQ Endura
 def: "Thermo Scientific TSQ Endura MS." [PSI:PI]
+is_a: MS:1003762 ! triple quadrupole instrument
 is_a: MS:1000494 ! Thermo Scientific instrument model
 
 [Term]
@@ -16728,6 +16819,7 @@ relationship: has_value_type xsd:string ! The allowed value-type for this CV ter
 id: MS:1002523
 name: Q Exactive HF
 def: "Thermo Scientific Q Exactive." [PSI:PI]
+is_a: MS:1003769 ! quadrupole orbitrap instrument
 is_a: MS:1000494 ! Thermo Scientific instrument model
 
 [Term]
@@ -16741,12 +16833,14 @@ is_a: MS:1001457 ! data processing software
 id: MS:1002525
 name: TSQ 8000 Evo
 def: "Thermo Scientific TSQ 8000 Evo MS." [PSI:PI]
+is_a: MS:1003762 ! triple quadrupole instrument
 is_a: MS:1000494 ! Thermo Scientific instrument model
 
 [Term]
 id: MS:1002526
 name: Exactive Plus
 def: "Thermo Scientific Exactive Plus MS." [PSI:PI]
+is_a: MS:1003953 ! orbitrap instrument
 is_a: MS:1000494 ! Thermo Scientific instrument model
 
 [Term]
@@ -17447,6 +17541,7 @@ relationship: has_value_type xsd:anyURI ! The allowed value-type for this CV ter
 id: MS:1002634
 name: Q Exactive Plus
 def: "Thermo Scientific Q Exactive Plus." [PSI:PI]
+is_a: MS:1003769 ! quadrupole orbitrap instrument
 is_a: MS:1000494 ! Thermo Scientific instrument model
 
 [Term]
@@ -18085,36 +18180,42 @@ is_a: MS:1003767 ! quadrupole ion mobility time-of-flight instrument
 id: MS:1002727
 name: MALDI SYNAPT G2-Si
 def: "Waters Corporation MALDI SYNAPT G2-Si orthogonal acceleration time-of-flight mass spectrometer." [PSI:PI]
+is_a: MS:1003767 ! quadrupole ion mobility time-of-flight instrument
 is_a: MS:1000126 ! Waters instrument model
 
 [Term]
 id: MS:1002728
 name: Vion IMS QTof
 def: "Waters Corporation Vion IMS QTof orthogonal acceleration time-of-flight mass spectrometer." [PSI:PI]
+is_a: MS:1003767 ! quadrupole ion mobility time-of-flight instrument
 is_a: MS:1000126 ! Waters instrument model
 
 [Term]
 id: MS:1002729
 name: Xevo G2-XS Tof
 def: "Waters Corporation Xevo G2 XS Tof orthogonal acceleration time-of-flight mass spectrometer." [PSI:PI]
+is_a: MS:1003951 ! time-of-flight instrument
 is_a: MS:1000126 ! Waters instrument model
 
 [Term]
 id: MS:1002730
 name: Xevo TQ-XS
 def: "Waters Corporation Xevo TQ-XS triple quadrupole mass spectrometer." [PSI:PI]
+is_a: MS:1003762 ! triple quadrupole instrument
 is_a: MS:1000126 ! Waters instrument model
 
 [Term]
 id: MS:1002731
 name: Xevo TQ-S micro
 def: "Waters Corporation Xevo TQ-S micro triple quadrupole mass spectrometer." [PSI:PI]
+is_a: MS:1003762 ! triple quadrupole instrument
 is_a: MS:1000126 ! Waters instrument model
 
 [Term]
 id: MS:1002732
 name: Orbitrap Fusion Lumos
 def: "Thermo Scientific Orbitrap Fusion Lumos mass spectrometer with Tribrid architecture consisting of quadrupole mass filter, linear ion trap and Orbitrap mass analyzers." [PSI:PI]
+is_a: MS:1003770 ! quadrupole ion trap orbitrap instrument
 is_a: MS:1000494 ! Thermo Scientific instrument model
 
 [Term]
@@ -18797,6 +18898,7 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 id: MS:1002835
 name: LTQ Orbitrap Classic
 def: "Thermo Fisher Scientific LTQ Orbitrap Classic." [PSI:MS]
+is_a: MS:1003768 ! ion trap orbitrap instrument
 is_a: MS:1000494 ! Thermo Scientific instrument model
 
 [Term]
@@ -19056,24 +19158,28 @@ relationship: has_value_type xsd:anyURI ! The allowed value-type for this CV ter
 id: MS:1002874
 name: TSQ Altis
 def: "Thermo Scientific TSQ Altis Triple Quadrupole MS." [PSI:PI]
+is_a: MS:1003762 ! triple quadrupole instrument
 is_a: MS:1000494 ! Thermo Scientific instrument model
 
 [Term]
 id: MS:1002875
 name: TSQ Quantis
 def: "Thermo Scientific TSQ Quantis Triple Quadrupole MS." [PSI:PI]
+is_a: MS:1003762 ! triple quadrupole instrument
 is_a: MS:1000494 ! Thermo Scientific instrument model
 
 [Term]
 id: MS:1002876
 name: TSQ 9000
 def: "Thermo Scientific TSQ 9000 Triple Quadrupole MS." [PSI:PI]
+is_a: MS:1003762 ! triple quadrupole instrument
 is_a: MS:1000494 ! Thermo Scientific instrument model
 
 [Term]
 id: MS:1002877
 name: Q Exactive HF-X
 def: "Thermo Scientific Q Exactive HF-X Hybrid Quadrupole Orbitrap MS." [PSI:PI]
+is_a: MS:1003769 ! quadrupole orbitrap instrument
 is_a: MS:1000494 ! Thermo Scientific instrument model
 
 [Term]
@@ -19854,18 +19960,21 @@ is_a: MS:1002333 ! conversion software
 id: MS:1002992
 name: Orbitrap Exploris GC-MS
 def: "Thermo Scientific Orbitrap Exploris GC-MS." [PSI:PI]
+is_a: MS:1003769 ! quadrupole orbitrap instrument
 is_a: MS:1000494 ! Thermo Scientific instrument model
 
 [Term]
 id: MS:1002993
 name: Q Exactive Focus
 def: "Q Exactive Focus Hybrid Quadrupole-Orbitrap Mass Spectrometer." [PSI:PI]
+is_a: MS:1003769 ! quadrupole orbitrap instrument
 is_a: MS:1000494 ! Thermo Scientific instrument model
 
 [Term]
 id: MS:1002994
 name: Orbitrap Excedion Pro
 def: "Thermo Scientific Orbitrap Excedion Pro." [PSI:MS]
+is_a: MS:1003769 ! quadrupole orbitrap instrument
 is_a: MS:1000494 ! Thermo Scientific instrument model
 
 [Term]
@@ -20096,12 +20205,14 @@ is_a: MS:1003025 ! named element
 id: MS:1003028
 name: Orbitrap Exploris 480
 def: "Thermo Scientific Orbitrap Exploris 480 Quadrupole Orbitrap MS." [PSI:PI]
+is_a: MS:1003769 ! quadrupole orbitrap instrument
 is_a: MS:1000494 ! Thermo Scientific instrument model
 
 [Term]
 id: MS:1003029
 name: Orbitrap Eclipse
 def: "Thermo Scientific Orbitrap Eclipse mass spectrometer with Tribrid architecture consisting of quadrupole mass filter, linear ion trap and Orbitrap mass analyzers." [PSI:PI]
+is_a: MS:1003770 ! quadrupole ion trap orbitrap instrument
 is_a: MS:1000494 ! Thermo Scientific instrument model
 
 [Term]
@@ -20528,18 +20639,21 @@ relationship: has_regexp MS:1001335 ! (?=K)
 id: MS:1003094
 name: Orbitrap Exploris 240
 def: "Thermo Scientific Orbitrap Exploris 240 Quadrupole Orbitrap MS." [PSI:PI]
+is_a: MS:1003769 ! quadrupole orbitrap instrument
 is_a: MS:1000494 ! Thermo Scientific instrument model
 
 [Term]
 id: MS:1003095
 name: Orbitrap Exploris 120
 def: "Thermo Scientific Orbitrap Exploris 120 Quadrupole Orbitrap MS." [PSI:PI]
+is_a: MS:1003769 ! quadrupole orbitrap instrument
 is_a: MS:1000494 ! Thermo Scientific instrument model
 
 [Term]
 id: MS:1003096
 name: Orbitrap Velos Pro
 def: "Thermo Scientific LTQ Orbitrap Velos Pro, often just referred to as the Orbitrap Velos Pro." [PSI:MS]
+is_a: MS:1003768 ! ion trap orbitrap instrument
 is_a: MS:1000494 ! Thermo Scientific instrument model
 synonym: "LTQ Orbitrap Velos Pro" EXACT []
 
@@ -20648,6 +20762,7 @@ is_a: MS:1001139 ! quantitation software name
 id: MS:1003112
 name: Orbitrap ID-X
 def: "Thermo Scientific Orbitrap ID-X mass spectrometer with Tribrid architecture consisting of quadrupole mass filter, linear ion trap and Orbitrap mass analyzers." [PSI:MS]
+is_a: MS:1003770 ! quadrupole ion trap orbitrap instrument
 is_a: MS:1000494 ! Thermo Scientific instrument model
 
 [Term]
@@ -21160,18 +21275,21 @@ is_a: MS:1003181 ! combined dissociation method
 id: MS:1003183
 name: Synapt XS
 def: "Waters oa-ToF based Synapt XS." [PSI:PI]
+is_a: MS:1003767 ! quadrupole ion mobility time-of-flight instrument
 is_a: MS:1000126 ! Waters instrument model
 
 [Term]
 id: MS:1003184
 name: SELECT SERIES Cyclic IMS
 def: "Waters oa-ToF based SELECT SERIES Cyclic IMS." [PSI:PI]
+is_a: MS:1003767 ! quadrupole ion mobility time-of-flight instrument
 is_a: MS:1000126 ! Waters instrument model
 
 [Term]
 id: MS:1003185
 name: SELECT SERIES MRT
 def: "Waters oa-ToF based SELECT SERIES MRT." [PSI:PI]
+is_a: MS:1003763 ! quadrupole time-of-flight instrument
 is_a: MS:1000126 ! Waters instrument model
 
 [Term]
@@ -21571,6 +21689,7 @@ relationship: has_value_type xsd:string ! The allowed value-type for this CV ter
 id: MS:1003245
 name: Q Exactive UHMR
 def: "Thermo Scientific Q Exactive UHMR (Ultra High Mass Range) Hybrid Quadrupole Orbitrap MS." [PSI:PI]
+is_a: MS:1003769 ! quadrupole orbitrap instrument
 is_a: MS:1000494 ! Thermo Scientific instrument model
 
 [Term]
@@ -21625,6 +21744,7 @@ relationship: has_units UO:0000189 ! count unit
 id: MS:1003252
 name: Xevo G2-XS QTof
 def: "Waters Corporation Xevo G2-XS QTof quadrupole time-of-flight mass spectrometer." [PSI:PI]
+is_a: MS:1003763 ! quadrupole time-of-flight instrument
 is_a: MS:1000126 ! Waters instrument model
 
 [Term]
@@ -21896,6 +22016,7 @@ relationship: has_regexp MS:1002505 ! regular expression for modification locali
 id: MS:1003292
 name: TSQ Altis Plus
 def: "Thermo Scientific TSQ Altis Plus Triple Quadrupole MS." [PSI:PI]
+is_a: MS:1003762 ! triple quadrupole instrument
 is_a: MS:1000494 ! Thermo Scientific instrument model
 
 [Term]
@@ -22334,6 +22455,7 @@ is_a: MS:1003350 ! mass spectrometry proteomics
 id: MS:1003356
 name: Orbitrap Ascend
 def: "Thermo Scientific Orbitrap Ascend mass spectrometer with Tribrid architecture consisting of quadrupole mass filter, linear ion trap and Orbitrap mass analyzers." [PSI:PI]
+is_a: MS:1003770 ! quadrupole ion trap orbitrap instrument
 is_a: MS:1000494 ! Thermo Scientific instrument model
 
 [Term]
@@ -22485,6 +22607,7 @@ is_a: MS:1001457 ! data processing software
 id: MS:1003378
 name: Orbitrap Astral
 def: "Thermo Scientific Orbitrap Astral mass spectrometer contains three mass analyzers: a quadrupole analyzer, an Orbitrap analyzer, and the Astral analyzer." [PSI:MS]
+is_a: MS:1003771 ! quadrupole orbitrap astral instrument
 is_a: MS:1000494 ! Thermo Scientific instrument model
 
 [Term]
@@ -22498,12 +22621,14 @@ is_a: MS:1000084 ! time-of-flight
 id: MS:1003380
 name: Xevo G3 QTof
 def: "Waters Corporation Xevo G3 QTof quadrupole time-of-flight mass spectrometer." [PSI:MS]
+is_a: MS:1003763 ! quadrupole time-of-flight instrument
 is_a: MS:1000126 ! Waters instrument model
 
 [Term]
 id: MS:1003381
 name: ACQUITY RDa Detector
 def: "Waters Corporation RDa time-of-flight mass detector." [PSI:MS]
+is_a: MS:1003951 ! time-of-flight instrument
 is_a: MS:1000126 ! Waters instrument model
 
 [Term]
@@ -22604,6 +22729,7 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 id: MS:1003395
 name: Q Exactive GC Orbitrap
 def: "Q Exactive GC Orbitrap GC-MS/MS hybrid quadrupole Orbitrap mass spectrometer." [PSI:MS]
+is_a: MS:1003769 ! quadrupole orbitrap instrument
 is_a: MS:1000494 ! Thermo Scientific instrument model
 
 [Term]
@@ -22692,6 +22818,7 @@ relationship: has_value_type xsd:double ! The allowed value-type for this CV ter
 id: MS:1003409
 name: Stellar
 def: "Thermo Scientific Stellar mass spectrometer contains a quadrupole mass filter, a collision cell, and a quadrupole linear ion trap mass analyzer." [PSI:MS]
+is_a: MS:1003972 ! quadrupole ion trap instrument
 is_a: MS:1000494 ! Thermo Scientific instrument model
 
 [Term]
@@ -22706,6 +22833,7 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 id: MS:1003411
 name: Orbitrap IQ-X
 def: "Thermo Scientific Orbitrap IQ-X mass spectrometer with Tribrid architecture consisting of quadrupole mass filter, linear ion trap and Orbitrap mass analyzers." [PSI:MS]
+is_a: MS:1003770 ! quadrupole ion trap orbitrap instrument
 is_a: MS:1000494 ! Thermo Scientific instrument model
 
 [Term]
@@ -22798,6 +22926,7 @@ relationship: has_value_type xsd:int ! The allowed value-type for this CV term
 id: MS:1003423
 name: Orbitrap Exploris GC 240
 def: "Orbitrap Exploris GC 240 Mass Spectrometer." [PSI:MS]
+is_a: MS:1003769 ! quadrupole orbitrap instrument
 is_a: MS:1000494 ! Thermo Scientific instrument model
 
 [Term]
@@ -22930,6 +23059,7 @@ is_a: MS:1003439 ! ion mobility frame representation
 id: MS:1003442
 name: Orbitrap Astral Zoom
 def: "Thermo Scientific Orbitrap Astral Zoom mass spectrometer contains three mass analyzers: a quadrupole analyzer, an Orbitrap analyzer, and an Astral analyzer." [PSI:PI]
+is_a: MS:1003771 ! quadrupole orbitrap astral instrument
 is_a: MS:1000494 ! Thermo Scientific instrument model
 
 [Term]
@@ -22976,6 +23106,7 @@ is_a: MS:1000560 ! mass spectrometer file format
 id: MS:1003449
 name: ISQ 7000
 def: "Thermo Scientific ISQ 7000 Single Quadrupole GC-MS System." [PSI:MS]
+is_a: MS:1003950 ! quadrupole instrument
 is_a: MS:1000494 ! Thermo Scientific instrument model
 
 [Term]
@@ -23265,114 +23396,133 @@ is_a: MS:1000603 ! Shimadzu Scientific Instruments instrument model
 id: MS:1003495
 name: Velos Pro
 def: "Thermo Fisher Scientific Velos Pro ion trap - mass spectrometer." [PSI:MS]
+is_a: MS:1003952 ! ion trap instrument
 is_a: MS:1000494 ! Thermo Scientific instrument model
 
 [Term]
 id: MS:1003496
 name: MALDI LTQ Orbitrap XL
 def: "Thermo Fisher Scientific MALDI LTQ Orbitrap XL linear ion trap - orbitrap mass spectrometer." [PSI:MS]
+is_a: MS:1003768 ! ion trap orbitrap instrument
 is_a: MS:1000494 ! Thermo Scientific instrument model
 
 [Term]
 id: MS:1003497
 name: MALDI LTQ Orbitrap Discovery
 def: "Thermo Fisher Scientific MALDI LTQ Orbitrap Discovery linear ion trap - orbitrap mass spectrometer." [PSI:MS]
+is_a: MS:1003768 ! ion trap orbitrap instrument
 is_a: MS:1000494 ! Thermo Scientific instrument model
 
 [Term]
 id: MS:1003498
 name: TSQ Quantum Access MAX
 def: "Thermo Fisher Scientific TSQ Quantum Access MAX triple quadrupole mass spectrometer." [PSI:MS]
+is_a: MS:1003762 ! triple quadrupole instrument
 is_a: MS:1000494 ! Thermo Scientific instrument model
 
 [Term]
 id: MS:1003499
 name: LTQ Orbitrap Velos/ETD
 def: "Thermo Fisher Scientific LTQ Orbitrap Velos/ETD linear ion trap - orbitrap mass spectrometer." [PSI:MS]
+is_a: MS:1003768 ! ion trap orbitrap instrument
 is_a: MS:1000494 ! Thermo Scientific instrument model
 
 [Term]
 id: MS:1003500
 name: ISQ LT
 def: "Thermo Fisher Scientific ISQ LT gas chromatograph - quadrupole mass spectrometer." [PSI:MS]
+is_a: MS:1003950 ! quadrupole instrument
 is_a: MS:1000494 ! Thermo Scientific instrument model
 
 [Term]
 id: MS:1003501
 name: ITQ
 def: "Thermo Fisher Scientific ITQ ion trap mass spectrometer." [PSI:MS]
+is_a: MS:1003952 ! ion trap instrument
 is_a: MS:1000494 ! Thermo Scientific instrument model
 
 [Term]
 id: MS:1003502
 name: TSQ Quantum XLS
 def: "Thermo Fisher Scientific TSQ Quantum XLS gas chromatograph - triple quadrupole mass spectrometer." [PSI:MS]
+is_a: MS:1003762 ! triple quadrupole instrument
 is_a: MS:1000494 ! Thermo Scientific instrument model
 
 [Term]
 id: MS:1003503
 name: TSQ 8000
 def: "Thermo Fisher Scientific TSQ 8000 gas chromatograph - triple quadrupole mass spectrometer." [PSI:MS]
+is_a: MS:1003762 ! triple quadrupole instrument
 is_a: MS:1000494 ! Thermo Scientific instrument model
 
 [Term]
 id: MS:1003504
 name: DeltaPlus IRMS
 def: "Thermo Fisher Scientific DeltaPlus IRMS isotope ratio mass spectrometer." [PSI:MS]
+is_a: MS:1003949 ! magnetic sector instrument
 is_a: MS:1000494 ! Thermo Scientific instrument model
 
 [Term]
 id: MS:1003505
 name: ACQUITY QDa
 def: "Waters ACQUITY QDa quadrupole mass spectrometer." [PSI:MS]
+is_a: MS:1003950 ! quadrupole instrument
 is_a: MS:1000126 ! Waters instrument model
 
 [Term]
 id: MS:1003506
 name: LCT Premier
 def: "Waters LCT Premier time-of-flight mass spectrometer." [PSI:MS]
+is_a: MS:1003951 ! time-of-flight instrument
 is_a: MS:1000126 ! Waters instrument model
 
 [Term]
 id: MS:1003507
 name: Quattro Premier XE
 def: "Waters Quattro Premier XE triple quadrupole mass spectrometer." [PSI:MS]
+is_a: MS:1003762 ! triple quadrupole instrument
 is_a: MS:1000126 ! Waters instrument model
 
 [Term]
 id: MS:1003508
 name: Synapt G1 HDMS
 def: "Waters Synapt G1 HDMS quadrupole - ion mobility - time-of-flight mass spectrometer." [PSI:MS]
+is_a: MS:1003767 ! quadrupole ion mobility time-of-flight instrument
 is_a: MS:1000126 ! Waters instrument model
 
 [Term]
 id: MS:1003509
 name: Synapt G2-Si HDMS
 def: "Waters Synapt G2-Si HDMS quadrupole - ion mobility - time-of-flight mass spectrometer." [PSI:MS]
+is_a: MS:1003767 ! quadrupole ion mobility time-of-flight instrument
 is_a: MS:1000126 ! Waters instrument model
 
 [Term]
 id: MS:1003510
 name: Synapt G1
 def: "Waters Synapt G1 quadrupole - ion mobility - time-of-flight mass spectrometer." [PSI:MS]
+is_a: MS:1003763 ! quadrupole time-of-flight instrument
 is_a: MS:1000126 ! Waters instrument model
 
 [Term]
 id: MS:1003511
 name: Synapt G2 XS QTOF
 def: "Waters Synapt G2 XS QTOF quadrupole - ion mobility - time-of-flight mass spectrometer." [PSI:MS]
+is_a: MS:1003767 ! quadrupole ion mobility time-of-flight instrument
 is_a: MS:1000126 ! Waters instrument model
 
 [Term]
 id: MS:1003512
 name: Xevo TQ Absolute
 def: "Waters Xevo TQ Absolute triple quadrupole mass spectrometer." [PSI:MS]
+is_a: MS:1003762 ! triple quadrupole instrument
 is_a: MS:1000126 ! Waters instrument model
 
 [Term]
 id: MS:1003513
 name: Xevo TQ Absolute XR
 def: "Waters Xevo TQ Absolute XR triple quadrupole mass spectrometer." [PSI:MS]
+is_a: MS:1003762 ! triple quadrupole instrument
 is_a: MS:1000126 ! Waters instrument model
 
 [Term]
@@ -23685,6 +23835,7 @@ is_a: MS:1003455 ! PerkinElmer instrument model
 id: MS:1003554
 name: ThermoQuest Voyager
 def: "Thermo Finnigan ThermoQuest Voyager gas chromatograph - quadrupole mass spectrometer." [PSI:MS]
+is_a: MS:1003950 ! quadrupole instrument
 is_a: MS:1000125 ! Thermo Finnigan instrument model
 
 [Term]
@@ -25156,6 +25307,7 @@ synonym: "UPC2" RELATED []
 id: MS:1003800
 name: TSQ Certis
 def: "Thermo Scientific TSQ Certis Triple Quadrupole MS." [PSI:PI]
+is_a: MS:1003762 ! triple quadrupole instrument
 is_a: MS:1000494 ! Thermo Scientific instrument model
 
 [Term]
@@ -25694,6 +25846,18 @@ def: "Thermo Scientific software for complex biotherapeutic characterization by 
 is_a: MS:1003961 ! Thermo Scientific software
 is_a: MS:1001456 ! analysis software
 is_a: MS:1001457 ! data processing software
+
+[Term]
+id: MS:1003971
+name: ion trap fourier transform ion cyclotron resonance instrument
+def: "An instrument that uses a linear ion trap coupled to a fourier transform ion cyclotron resonance mass analyzer as its primary means of mass analysis." [PSI:MS]
+is_a: MS:1003761 ! instrument class
+
+[Term]
+id: MS:1003972
+name: quadrupole ion trap instrument
+def: "An instrument that uses a quadrupole mass filter followed by an ion trap mass analyzer as its primary means of mass analysis." [PSI:MS]
+is_a: MS:1003761 ! instrument class
 
 [Term]
 id: MS:4000000


### PR DESCRIPTION
Assigns instrument classification (`is_a` MS:1003761 children) to 152 instrument models across Thermo
  Fisher Scientific (93) and Waters (59).

  ### New terms

  - **MS:1003971 ion trap fourier transform ion cyclotron resonance instrument** — for instruments using a
  linear ion trap coupled to an FTICR analyzer (Thermo LTQ FT, LTQ FT Ultra). Distinct from MS:1003766
  (quadrupole FTICR) which uses a quadrupole mass filter front-end.
  - **MS:1003972 quadrupole ion trap instrument** — for instruments using a quadrupole mass filter followed
  by an ion trap mass analyzer (Thermo Stellar). Distinct from MS:1003770 (tribrid) which adds an Orbitrap.

  ### Classifications by type

  | Instrument class | Thermo | Waters | Total |
  |---|---:|---:|---:|
  | triple quadrupole | 17 | 11 | 28 |
  | ion trap | 19 | — | 19 |
  | quadrupole time-of-flight | — | 17 | 17 |
  | magnetic sector | 9 | 5 | 14 |
  | quadrupole orbitrap | 13 | — | 13 |
  | quadrupole ion mobility time-of-flight | — | 13 | 13 |
  | quadrupole | 8 | 4 | 12 |
  | ion trap orbitrap | 12 | — | 12 |
  | time-of-flight | 1 | 9 | 10 |
  | quadrupole ion trap orbitrap (tribrid) | 7 | — | 7 |
  | ion trap FTICR (new) | 2 | — | 2 |
  | orbitrap (standalone) | 2 | — | 2 |
  | quadrupole orbitrap astral | 2 | — | 2 |
  | quadrupole ion trap (new) | 1 | — | 1 |

  ### Not classified

  Eight instruments were skipped as they are not mass spectrometers or their type could not be determined:
  - Thermo: Surveyor PDA, Accela PDA, GC IsoLink, Thermo Electron instrument model (MS:1000492)
  - Waters: Acquity UPLC PDA, Acquity UPLC FLR, NG-5400, Platform ICP