### PR TITLE
Debug/ols validation

### DIFF
--- a/.github/workflows/validate-owl.yaml
+++ b/.github/workflows/validate-owl.yaml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: 'temurin' # Install JDK from Eclipse Adoptium
-          java-version: '21'
+          java-version: '24'
 
       - name: Cache Maven packages
         uses: actions/cache@v3

--- a/.github/workflows/validate-owl.yaml
+++ b/.github/workflows/validate-owl.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Set up JDK 11
+      - name: Set up JDK 24
         uses: actions/setup-java@v5
         with:
           distribution: 'temurin' # Install JDK from Eclipse Adoptium
@@ -36,9 +36,9 @@ jobs:
         run: |
            git clone https://github.com/EBISPOT/ols4
            cd ols4/ols-shared/
-           mvn -e clean install
+           mvn clean install
            cd ../../ols4/dataload/rdf2json
-           mvn -e clean install
+           mvn clean install
 
       - name: Validate OWL File for OLS
         run: |

--- a/.github/workflows/validate-owl.yaml
+++ b/.github/workflows/validate-owl.yaml
@@ -16,10 +16,10 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up JDK 11
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin' # Install JDK from Eclipse Adoptium
-          java-version: '17'
+          java-version: '21'
 
       - name: Cache Maven packages
         uses: actions/cache@v3
@@ -36,9 +36,9 @@ jobs:
         run: |
            git clone https://github.com/EBISPOT/ols4
            cd ols4/ols-shared/
-           mvn clean install
+           mvn -e clean install
            cd ../../ols4/dataload/rdf2json
-           mvn clean install
+           mvn -e clean install
 
       - name: Validate OWL File for OLS
         run: |

--- a/.github/workflows/validate-owl.yaml
+++ b/.github/workflows/validate-owl.yaml
@@ -2,7 +2,7 @@ name: OWL file validation
 
 on:
   push:
-    branches: [master, dev]
+    branches: [master, dev, "debug/ols-validation"]
 
   pull_request:
     branches: [master, dev]
@@ -19,7 +19,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin' # Install JDK from Eclipse Adoptium
-          java-version: '11'
+          java-version: '17'
 
       - name: Cache Maven packages
         uses: actions/cache@v3
@@ -41,7 +41,7 @@ jobs:
            mvn clean install
 
       - name: Validate OWL File for OLS
-        run: |   
+        run: |
            cd ols4/dataload/rdf2json/target
            wget https://raw.githubusercontent.com/HUPO-PSI/psi-ms-CV/master/owl-config-ols/foundry.json
            wget https://raw.githubusercontent.com/HUPO-PSI/psi-ms-CV/master/owl-config-ols/fail_owl.json


### PR DESCRIPTION
Fixes #503 

From reading the logs, it looked like the Java version being used to build OLS4 wasn't compatible with the latest version of the web service or its backend ingestion process (`rdf2json`). Upgrading the version of Java seems to have fixed the issue. This was inevitable because we must live on the edge (release) of OLS to ensure we're compatible with whatever their current state is.

I upgraded from Java 11 to Java 24. Java 21 alone would have been sufficient but reading https://github.com/EBISPOT/ols4/blob/dev/backend/Dockerfile I gather they are already using Java 24.

@ypriverol, I think you wrote this originally. Was there any other validation that needed to be done that this was working beyond "everything runs to completion"?