### PR TITLE
Add cleavage agents Thermolysin, peptidase K and hydroxylamine

### DIFF
--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -1,6 +1,6 @@
 format-version: 1.2
 data-version: 4.1.250
-date: 03:06:2026 17:45
+date: 04:06:2026 12:46
 saved-by: Bruno Maestri Abrianos Becker
 default-namespace: MS
 namespace-id-rule: * MS:$sequence(7,0,9999999)$
@@ -29266,27 +29266,27 @@ created_by: gkoutos
 creation_date: 2013-06-27T05:06:40Z
 
 [Term]
-id: MS:4000216
+id: MS:100398
 name: (?<=[^DE])(?=[AFILMV][^P])
 def: "Regular expression for Thermolysin." [https://enzyme.expasy.org/EC/3.4.24.27, DOI:10.1007/978-3-642-48380-6]
 is_a: MS:1001180 ! Cleavage agent regular expression
 
 [Term]
-id: MS:4000217
+id: MS:100399
 name: Thermolysin
 def: "Thermostable extracellular metalloendopeptidase containing four calcium ions" [https://enzyme.expasy.org/EC/3.4.24.27, DOI:10.1007/978-3-642-48380-6]
 synonym: "Bacillus thermoproteolyticus neutral proteinase" EXACT []
 is_a: MS:1001045 ! cleavage agent name
-relationship: has_regexp MS:4000216 ! (?<=[^DE])(?=[AFILMV][^P])
+relationship: has_regexp MS:100398 ! (?<=[^DE])(?=[AFILMV][^P])
 
 [Term]
-id: MS:4000218
+id: MS:100400
 name: (?=[AEFILTVWY])
 def: "Regular expression for peptidase K." [https://enzyme.expasy.org/EC/3.4.21.64, DOI:10.1007/978-3-642-48380-6]
 is_a: MS:1001180 ! Cleavage agent regular expression
 
 [Term]
-id: MS:4000219
+id: MS:100401
 name: peptidase K
 def: "Peptidase from the mold Tritirachium album Limber" [https://enzyme.expasy.org/EC/3.4.21.64, DOI:10.1007/978-3-642-48380-6]
 synonym: "endopeptidase K" EXACT []
@@ -29294,17 +29294,17 @@ synomym: "proteinase K" EXACT []
 synonym: "Tritirachium album proteinase K" EXACT []
 synonym: "Tritirachium alkaline proteinase" EXACT []
 is_a: MS:1001045 ! cleavage agent name
-relationship: has_regexp MS:4000218 ! (?=[AEFILTVWY])
+relationship: has_regexp MS:100400 ! (?=[AEFILTVWY])
 
 [Term]
-id: MS:4000220
+id: MS:100402
 name: (?<=N)(?=G)
 def: "Regular expression for hydroxylamine." [https://web.expasy.org/peptide_cutter/, DOI:10.1016/0076-6879(77)47016-2]
 is_a: MS:1001180 ! Cleavage agent regular expression
 
 [Term]
-id: MS:4000221
+id: MS:100403
 name: hydroxylamine
 def: "NH2OH" [https://web.expasy.org/peptide_cutter/, DOI:10.1016/0076-6879(77)47016-2]
 is_a: MS:1001045 ! cleavage agent name
-relationship: has_regexp MS:4000220 ! (?<=N)(?=G)
+relationship: has_regexp MS:100402 ! (?<=N)(?=G)

--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -1,6 +1,6 @@
 format-version: 1.2
 data-version: 4.1.250
-date: 04:06:2026 17:12
+date: 05:06:2026 10:00
 saved-by: Bruno Maestri Abrianos Becker
 default-namespace: MS
 namespace-id-rule: * MS:$sequence(7,0,9999999)$
@@ -26082,46 +26082,46 @@ relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 [Term]
 id: MS:1003978
 name: (?<=[^DE])(?=[AFILMV][^P])
-def: "Regular expression for Thermolysin." [https://enzyme.expasy.org/EC/3.4.24.27, DOI:10.1007/978-3-642-48380-6]
+def: "Regular expression for Thermolysin." [BRENDA:3.4.24.27, DOI:10.1007/978-3-642-48380-6]
 is_a: MS:1001180 ! Cleavage agent regular expression
 
 [Term]
 id: MS:1003979
 name: Thermolysin
-def: "Thermostable extracellular metalloendopeptidase containing four calcium ions" [https://enzyme.expasy.org/EC/3.4.24.27, DOI:10.1007/978-3-642-48380-6]
+def: "Thermostable extracellular metalloendopeptidase containing four calcium ions" [BRENDA:3.4.24.27, DOI:10.1007/978-3-642-48380-6]
 synonym: "Bacillus thermoproteolyticus neutral proteinase" EXACT []
 is_a: MS:1001045 ! cleavage agent name
-relationship: has_regexp MS:100398 ! (?<=[^DE])(?=[AFILMV][^P])
+relationship: has_regexp MS:1003978 ! (?<=[^DE])(?=[AFILMV][^P])
 
 [Term]
 id: MS:1003980
 name: (?=[AEFILTVWY])
-def: "Regular expression for peptidase K." [https://enzyme.expasy.org/EC/3.4.21.64, DOI:10.1007/978-3-642-48380-6]
+def: "Regular expression for peptidase K." [BRENDA:3.4.21.64, DOI:10.1007/978-3-642-48380-6]
 is_a: MS:1001180 ! Cleavage agent regular expression
 
 [Term]
 id: MS:1003981
 name: peptidase K
-def: "Peptidase from the mold Tritirachium album Limber" [https://enzyme.expasy.org/EC/3.4.21.64, DOI:10.1007/978-3-642-48380-6]
+def: "Peptidase from the mold Tritirachium album Limber" [BRENDA:3.4.21.64, DOI:10.1007/978-3-642-48380-6]
 synonym: "endopeptidase K" EXACT []
 synomym: "proteinase K" EXACT []
 synonym: "Tritirachium album proteinase K" EXACT []
 synonym: "Tritirachium alkaline proteinase" EXACT []
 is_a: MS:1001045 ! cleavage agent name
-relationship: has_regexp MS:100400 ! (?=[AEFILTVWY])
+relationship: has_regexp MS:1003980 ! (?=[AEFILTVWY])
 
 [Term]
 id: MS:1003982
 name: (?<=N)(?=G)
-def: "Regular expression for hydroxylamine." [https://web.expasy.org/peptide_cutter/, DOI:10.1016/0076-6879(77)47016-2]
+def: "Regular expression for hydroxylamine." [https://web.expasy.org/peptide_cutter/peptidecutter_enzymes.html#Hydro, DOI:10.1016/0076-6879(77)47016-2]
 is_a: MS:1001180 ! Cleavage agent regular expression
 
 [Term]
 id: MS:1003983
 name: hydroxylamine
-def: "NH2OH" [https://web.expasy.org/peptide_cutter/, DOI:10.1016/0076-6879(77)47016-2]
+def: "NH2OH" [https://web.expasy.org/peptide_cutter/peptidecutter_enzymes.html#Hydro, DOI:10.1016/0076-6879(77)47016-2]
 is_a: MS:1001045 ! cleavage agent name
-relationship: has_regexp MS:100402 ! (?<=N)(?=G)
+relationship: has_regexp MS:1003982 ! (?<=N)(?=G)
 
 [Term]
 id: MS:4000000

--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -1,5 +1,5 @@
 format-version: 1.2
-data-version: 4.1.250
+data-version: 4.1.252
 date: 05:06:2026 15:22
 saved-by: Bruno Maestri Abrianos Becker
 default-namespace: MS

--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -1,6 +1,6 @@
 format-version: 1.2
 data-version: 4.1.250
-date: 04:06:2026 12:46
+date: 04:06:2026 17:12
 saved-by: Bruno Maestri Abrianos Becker
 default-namespace: MS
 namespace-id-rule: * MS:$sequence(7,0,9999999)$
@@ -26080,6 +26080,50 @@ relationship: has_units UO:0000031 ! minute
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
+id: MS:1003978
+name: (?<=[^DE])(?=[AFILMV][^P])
+def: "Regular expression for Thermolysin." [https://enzyme.expasy.org/EC/3.4.24.27, DOI:10.1007/978-3-642-48380-6]
+is_a: MS:1001180 ! Cleavage agent regular expression
+
+[Term]
+id: MS:1003979
+name: Thermolysin
+def: "Thermostable extracellular metalloendopeptidase containing four calcium ions" [https://enzyme.expasy.org/EC/3.4.24.27, DOI:10.1007/978-3-642-48380-6]
+synonym: "Bacillus thermoproteolyticus neutral proteinase" EXACT []
+is_a: MS:1001045 ! cleavage agent name
+relationship: has_regexp MS:100398 ! (?<=[^DE])(?=[AFILMV][^P])
+
+[Term]
+id: MS:1003980
+name: (?=[AEFILTVWY])
+def: "Regular expression for peptidase K." [https://enzyme.expasy.org/EC/3.4.21.64, DOI:10.1007/978-3-642-48380-6]
+is_a: MS:1001180 ! Cleavage agent regular expression
+
+[Term]
+id: MS:1003981
+name: peptidase K
+def: "Peptidase from the mold Tritirachium album Limber" [https://enzyme.expasy.org/EC/3.4.21.64, DOI:10.1007/978-3-642-48380-6]
+synonym: "endopeptidase K" EXACT []
+synomym: "proteinase K" EXACT []
+synonym: "Tritirachium album proteinase K" EXACT []
+synonym: "Tritirachium alkaline proteinase" EXACT []
+is_a: MS:1001045 ! cleavage agent name
+relationship: has_regexp MS:100400 ! (?=[AEFILTVWY])
+
+[Term]
+id: MS:1003982
+name: (?<=N)(?=G)
+def: "Regular expression for hydroxylamine." [https://web.expasy.org/peptide_cutter/, DOI:10.1016/0076-6879(77)47016-2]
+is_a: MS:1001180 ! Cleavage agent regular expression
+
+[Term]
+id: MS:1003983
+name: hydroxylamine
+def: "NH2OH" [https://web.expasy.org/peptide_cutter/, DOI:10.1016/0076-6879(77)47016-2]
+is_a: MS:1001045 ! cleavage agent name
+relationship: has_regexp MS:100402 ! (?<=N)(?=G)
+
+[Term]
 id: MS:4000000
 name: PSI-MS CV Quality Control Vocabulary
 def: "PSI Quality Control controlled vocabulary term." [PSI:MS]
@@ -29264,47 +29308,3 @@ synonym: "A^[2]" RELATED []
 is_a: UO:0000047
 created_by: gkoutos
 creation_date: 2013-06-27T05:06:40Z
-
-[Term]
-id: MS:100398
-name: (?<=[^DE])(?=[AFILMV][^P])
-def: "Regular expression for Thermolysin." [https://enzyme.expasy.org/EC/3.4.24.27, DOI:10.1007/978-3-642-48380-6]
-is_a: MS:1001180 ! Cleavage agent regular expression
-
-[Term]
-id: MS:100399
-name: Thermolysin
-def: "Thermostable extracellular metalloendopeptidase containing four calcium ions" [https://enzyme.expasy.org/EC/3.4.24.27, DOI:10.1007/978-3-642-48380-6]
-synonym: "Bacillus thermoproteolyticus neutral proteinase" EXACT []
-is_a: MS:1001045 ! cleavage agent name
-relationship: has_regexp MS:100398 ! (?<=[^DE])(?=[AFILMV][^P])
-
-[Term]
-id: MS:100400
-name: (?=[AEFILTVWY])
-def: "Regular expression for peptidase K." [https://enzyme.expasy.org/EC/3.4.21.64, DOI:10.1007/978-3-642-48380-6]
-is_a: MS:1001180 ! Cleavage agent regular expression
-
-[Term]
-id: MS:100401
-name: peptidase K
-def: "Peptidase from the mold Tritirachium album Limber" [https://enzyme.expasy.org/EC/3.4.21.64, DOI:10.1007/978-3-642-48380-6]
-synonym: "endopeptidase K" EXACT []
-synomym: "proteinase K" EXACT []
-synonym: "Tritirachium album proteinase K" EXACT []
-synonym: "Tritirachium alkaline proteinase" EXACT []
-is_a: MS:1001045 ! cleavage agent name
-relationship: has_regexp MS:100400 ! (?=[AEFILTVWY])
-
-[Term]
-id: MS:100402
-name: (?<=N)(?=G)
-def: "Regular expression for hydroxylamine." [https://web.expasy.org/peptide_cutter/, DOI:10.1016/0076-6879(77)47016-2]
-is_a: MS:1001180 ! Cleavage agent regular expression
-
-[Term]
-id: MS:100403
-name: hydroxylamine
-def: "NH2OH" [https://web.expasy.org/peptide_cutter/, DOI:10.1016/0076-6879(77)47016-2]
-is_a: MS:1001045 ! cleavage agent name
-relationship: has_regexp MS:100402 ! (?<=N)(?=G)

--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -1,6 +1,6 @@
 format-version: 1.2
 data-version: 4.1.250
-date: 05:06:2026 10:00
+date: 05:06:2026 15:22
 saved-by: Bruno Maestri Abrianos Becker
 default-namespace: MS
 namespace-id-rule: * MS:$sequence(7,0,9999999)$
@@ -26104,7 +26104,7 @@ id: MS:1003981
 name: peptidase K
 def: "Peptidase from the mold Tritirachium album Limber" [BRENDA:3.4.21.64, DOI:10.1007/978-3-642-48380-6]
 synonym: "endopeptidase K" EXACT []
-synomym: "proteinase K" EXACT []
+synonym: "proteinase K" EXACT []
 synonym: "Tritirachium album proteinase K" EXACT []
 synonym: "Tritirachium alkaline proteinase" EXACT []
 is_a: MS:1001045 ! cleavage agent name

--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -1,7 +1,7 @@
 format-version: 1.2
-data-version: 4.1.249
-date: 01:06:2026 12:00
-saved-by: Jannick Kappelmann
+data-version: 4.1.250
+date: 03:06:2026 17:45
+saved-by: Bruno Maestri Abrianos Becker
 default-namespace: MS
 namespace-id-rule: * MS:$sequence(7,0,9999999)$
 namespace-id-rule: * PEFF:$sequence(7,0,9999999)$
@@ -29264,3 +29264,47 @@ synonym: "A^[2]" RELATED []
 is_a: UO:0000047
 created_by: gkoutos
 creation_date: 2013-06-27T05:06:40Z
+
+[Term]
+id: MS:4000216
+name: (?<=[^DE])(?=[AFILMV][^P])
+def: "Regular expression for Thermolysin." [https://enzyme.expasy.org/EC/3.4.24.27, DOI:10.1007/978-3-642-48380-6]
+is_a: MS:1001180 ! Cleavage agent regular expression
+
+[Term]
+id: MS:4000217
+name: Thermolysin
+def: "Thermostable extracellular metalloendopeptidase containing four calcium ions" [https://enzyme.expasy.org/EC/3.4.24.27, DOI:10.1007/978-3-642-48380-6]
+synonym: "Bacillus thermoproteolyticus neutral proteinase" EXACT []
+is_a: MS:1001045 ! cleavage agent name
+relationship: has_regexp MS:4000216 ! (?<=[^DE])(?=[AFILMV][^P])
+
+[Term]
+id: MS:4000218
+name: (?=[AEFILTVWY])
+def: "Regular expression for peptidase K." [https://enzyme.expasy.org/EC/3.4.21.64, DOI:10.1007/978-3-642-48380-6]
+is_a: MS:1001180 ! Cleavage agent regular expression
+
+[Term]
+id: MS:4000219
+name: peptidase K
+def: "Peptidase from the mold Tritirachium album Limber" [https://enzyme.expasy.org/EC/3.4.21.64, DOI:10.1007/978-3-642-48380-6]
+synonym: "endopeptidase K" EXACT []
+synomym: "proteinase K" EXACT []
+synonym: "Tritirachium album proteinase K" EXACT []
+synonym: "Tritirachium alkaline proteinase" EXACT []
+is_a: MS:1001045 ! cleavage agent name
+relationship: has_regexp MS:4000218 ! (?=[AEFILTVWY])
+
+[Term]
+id: MS:4000220
+name: (?<=N)(?=G)
+def: "Regular expression for hydroxylamine." [https://web.expasy.org/peptide_cutter/, DOI:10.1016/0076-6879(77)47016-2]
+is_a: MS:1001180 ! Cleavage agent regular expression
+
+[Term]
+id: MS:4000221
+name: hydroxylamine
+def: "NH2OH" [https://web.expasy.org/peptide_cutter/, DOI:10.1016/0076-6879(77)47016-2]
+is_a: MS:1001045 ! cleavage agent name
+relationship: has_regexp MS:4000220 ! (?<=N)(?=G)


### PR DESCRIPTION
Added the cleavage agents thermolysin, peptidase K and hydroxylamine, as well as the respective regexes, from [PeptideCutter at Expasy](https://www.expasy.org/resources/peptidecutter).

Updated data version and date and added contributor information.