### PR TITLE
Added some new terms for use in mzTab

### DIFF
--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -26080,6 +26080,29 @@ relationship: has_units UO:0000031 ! minute
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
+id: MS:1003984
+name: amino acid confidence level
+def: "The confidence level of the PSM assignment per amino acid, where 0 is not confident and 1 is maximally confident." [PSI:MS]
+is_a: MS:1002347 ! PSM-level identification statistic
+relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_value_type MS:1002713 ! The allowed value-type for this CV term
+
+[Term]
+id: MS:1003985
+name: token confidence level
+def: "The confidence level of the PSM assignment per token, so separately for each amino acid and modification, where 0 is not confident and 1 is maximally confident." [PSI:MS]
+is_a: MS:1002347 ! PSM-level identification statistic
+relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_value_type MS:1002713 ! The allowed value-type for this CV term
+
+[Term]
+id: MS:1003986
+name: protein sequence
+def: "The protein sequence of a protein in a database." [PSI:MS]
+is_a: MS:1000884 ! protein attribute
+relationship: has_value_type MS:1001344 ! AA sequence
+
+[Term]
 id: MS:4000000
 name: PSI-MS CV Quality Control Vocabulary
 def: "PSI Quality Control controlled vocabulary term." [PSI:MS]

--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -1,7 +1,7 @@
 format-version: 1.2
-data-version: 4.1.254
-date: 05:06:2026 15:22
-saved-by: Jonathan Hunter
+data-version: 4.1.255
+date: 11:06:2026 17:00
+saved-by: Douwe Schulte
 default-namespace: MS
 namespace-id-rule: * MS:$sequence(7,0,9999999)$
 namespace-id-rule: * PEFF:$sequence(7,0,9999999)$
@@ -26139,6 +26139,29 @@ is_a: MS:1001045 ! cleavage agent name
 relationship: has_regexp MS:1003982 ! (?<=N)(?=G)
 
 [Term]
+id: MS:1003984
+name: amino acid confidence level
+def: "The confidence level of the PSM assignment per amino acid, where 0 is not confident and 1 is maximally confident." [PSI:MS]
+is_a: MS:1002347 ! PSM-level identification statistic
+relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_value_type MS:1002713 ! The allowed value-type for this CV term
+
+[Term]
+id: MS:1003985
+name: peptidoform token confidence level
+def: "The confidence level of the PSM assignment per peptidoform token, so separately for each amino acid and modification, where 0 is not confident and 1 is maximally confident." [PSI:MS]
+is_a: MS:1002347 ! PSM-level identification statistic
+relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
+relationship: has_value_type MS:1002713 ! The allowed value-type for this CV term
+
+[Term]
+id: MS:1003986
+name: protein sequence
+def: "The protein sequence of a protein in a database." [PSI:MS]
+is_a: MS:1000884 ! protein attribute
+relationship: has_value_type MS:1001344 ! AA sequence
+
+[Term]
 id: MS:1003987
 name: Orbitrap Tribrid Apex
 def: "Thermo Scientific Orbitrap Tribrid Apex mass spectrometer with Tribrid architecture consisting of quadrupole mass filter, linear ion trap and Orbitrap mass analyzers." [PSI:MS]
@@ -26199,29 +26222,6 @@ name: timsMRMS
 def: "Bruker timsMRMS instrument combining trapped ion mobility spectrometry with magnetic resonance (FT-ICR) mass spectrometry." [PSI:MS]
 is_a: MS:1000122 ! Bruker Daltonics instrument model
 is_a: MS:1003994 ! ion mobility quadrupole FT-ICR instrument
-
-[Term]
-id: MS:1003984
-name: amino acid confidence level
-def: "The confidence level of the PSM assignment per amino acid, where 0 is not confident and 1 is maximally confident." [PSI:MS]
-is_a: MS:1002347 ! PSM-level identification statistic
-relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
-relationship: has_value_type MS:1002713 ! The allowed value-type for this CV term
-
-[Term]
-id: MS:1003985
-name: token confidence level
-def: "The confidence level of the PSM assignment per token, so separately for each amino acid and modification, where 0 is not confident and 1 is maximally confident." [PSI:MS]
-is_a: MS:1002347 ! PSM-level identification statistic
-relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
-relationship: has_value_type MS:1002713 ! The allowed value-type for this CV term
-
-[Term]
-id: MS:1003986
-name: protein sequence
-def: "The protein sequence of a protein in a database." [PSI:MS]
-is_a: MS:1000884 ! protein attribute
-relationship: has_value_type MS:1001344 ! AA sequence
 
 [Term]
 id: MS:4000000


### PR DESCRIPTION
These are some new terms for use in mzTab:
- Protein sequence: let me know if `MS:1001344|AA sequence` is not a good unit t use here, also if `has_value_type` is used correctly here.
- `amino acid`- and `token confidence level`: let me know if you have a better name, these should be fine but might not be  the easiest to gain the exact usage of based solely on the name, maybe something like `local PSM confidence level at the amino acid level` might be better but I did not manage to find something concise.

I though I would leave the version bump to somewhat later after the discussions are done.