### PR TITLE
Add Orbitrap Tribrid Apex instrument term (MS:1003987) Fixes #519

### DIFF
--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -1,7 +1,7 @@
 format-version: 1.2
-data-version: 4.1.249
-date: 01:06:2026 12:00
-saved-by: Jannick Kappelmann
+data-version: 4.1.250
+date: 08:06:2026 12:00
+saved-by: Jonathan Hunter
 default-namespace: MS
 namespace-id-rule: * MS:$sequence(7,0,9999999)$
 namespace-id-rule: * PEFF:$sequence(7,0,9999999)$

--- a/psi-ms.obo
+++ b/psi-ms.obo
@@ -26080,6 +26080,13 @@ relationship: has_units UO:0000031 ! minute
 relationship: has_value_type xsd:float ! The allowed value-type for this CV term
 
 [Term]
+id: MS:1003987
+name: Orbitrap Tribrid Apex
+def: "Thermo Scientific Orbitrap Tribrid Apex mass spectrometer with Tribrid architecture consisting of quadrupole mass filter, linear ion trap and Orbitrap mass analyzers." [PSI:MS]
+is_a: MS:1003770 ! quadrupole ion trap orbitrap instrument
+is_a: MS:1000494 ! Thermo Scientific instrument model
+
+[Term]
 id: MS:4000000
 name: PSI-MS CV Quality Control Vocabulary
 def: "PSI Quality Control controlled vocabulary term." [PSI:MS]


### PR DESCRIPTION
Adds a term for the Thermo Scientific Orbitrap Tribrid Apex mass spectrometer (Tribrid architecture: quadrupole mass filter, linear ion trap and Orbitrap mass analyzers) as requested in issue #519. Thank you, @vagisha.