### PR TITLE
Chrom. Columns PR2/2 - Add the repo-rt column generator, its checks and the weekly sync

### DIFF
--- a/.github/repo-rt/psi-ms-column-ids.tsv
+++ b/.github/repo-rt/psi-ms-column-ids.tsv
@@ -1,0 +1,1929 @@
+company	column	psi_ms_id
+ANPEL Laboratory Technologies Inc.		MS:5000000
+ANPEL Laboratory Technologies Inc.	Athena C18	MS:5001200
+ANPEL Laboratory Technologies Inc.	Athena C18-BIO	MS:5001201
+ANPEL Laboratory Technologies Inc.	Athena C18-WP	MS:5001202
+ANPEL Laboratory Technologies Inc.	Athena C30	MS:5001203
+ANPEL Laboratory Technologies Inc.	Athena C4	MS:5001204
+ANPEL Laboratory Technologies Inc.	Athena C8	MS:5001205
+ANPEL Laboratory Technologies Inc.	Athena CN	MS:5001206
+ANPEL Laboratory Technologies Inc.	Athena Diol	MS:5001207
+ANPEL Laboratory Technologies Inc.	Athena HILIC	MS:5001208
+ANPEL Laboratory Technologies Inc.	Athena HILIC(2)	MS:5001209
+ANPEL Laboratory Technologies Inc.	Athena NH2	MS:5001210
+ANPEL Laboratory Technologies Inc.	Athena PAHs	MS:5001211
+ANPEL Laboratory Technologies Inc.	Athena Phenyl	MS:5001212
+ANPEL Laboratory Technologies Inc.	Athena SCX	MS:5001213
+ANPEL Laboratory Technologies Inc.	Athena SCX(2)	MS:5001214
+ANPEL Laboratory Technologies Inc.	Athena Silica	MS:5001215
+Advanced Chromatography Technologies		MS:5000001
+Advanced Chromatography Technologies	ACE AQ	MS:5001014
+Advanced Chromatography Technologies	ACE C18	MS:5001015
+Advanced Chromatography Technologies	ACE C18-300	MS:5001016
+Advanced Chromatography Technologies	ACE C18-AR	MS:5001017
+Advanced Chromatography Technologies	ACE C18-Amide	MS:5001018
+Advanced Chromatography Technologies	ACE C18-HL	MS:5001019
+Advanced Chromatography Technologies	ACE C18-PFP	MS:5001020
+Advanced Chromatography Technologies	ACE C4	MS:5001021
+Advanced Chromatography Technologies	ACE C4-300	MS:5001022
+Advanced Chromatography Technologies	ACE C8	MS:5001023
+Advanced Chromatography Technologies	ACE C8-300	MS:5001024
+Advanced Chromatography Technologies	ACE CN	MS:5001025
+Advanced Chromatography Technologies	ACE CN-300	MS:5001026
+Advanced Chromatography Technologies	ACE CN-ES	MS:5001027
+Advanced Chromatography Technologies	ACE Excel AQ	MS:5001028
+Advanced Chromatography Technologies	ACE Excel C18	MS:5001029
+Advanced Chromatography Technologies	ACE Excel C18-AR	MS:5001030
+Advanced Chromatography Technologies	ACE Excel C18-Amide	MS:5001031
+Advanced Chromatography Technologies	ACE Excel C18-PFP	MS:5001032
+Advanced Chromatography Technologies	ACE Excel C4	MS:5001033
+Advanced Chromatography Technologies	ACE Excel C8	MS:5001034
+Advanced Chromatography Technologies	ACE Excel CN	MS:5001035
+Advanced Chromatography Technologies	ACE Excel CN-ES	MS:5001036
+Advanced Chromatography Technologies	ACE Excel NH2	MS:5001037
+Advanced Chromatography Technologies	ACE Excel Phenyl	MS:5001038
+Advanced Chromatography Technologies	ACE Excel SuperC18	MS:5001039
+Advanced Chromatography Technologies	ACE Phenyl	MS:5001040
+Advanced Chromatography Technologies	ACE Phenyl-300	MS:5001041
+Advanced Chromatography Technologies	ACE SIL	MS:5001042
+Advanced Chromatography Technologies	ACE SuperC18	MS:5001043
+Advanced Chromatography Technologies	ACE UltraCore SuperC18	MS:5001044
+Advanced Chromatography Technologies	ACE UltraCore SuperPhenylHexyl	MS:5001045
+Advanced Materials Technology		MS:5000002
+Advanced Materials Technology	HALO AQ-C18	MS:5001553
+Advanced Materials Technology	HALO Biphenyl	MS:5001554
+Advanced Materials Technology	HALO C18	MS:5001555
+Advanced Materials Technology	HALO C30	MS:5001556
+Advanced Materials Technology	HALO C8	MS:5001557
+Advanced Materials Technology	HALO ES-C18	MS:5001558
+Advanced Materials Technology	HALO ES-CN	MS:5001559
+Advanced Materials Technology	HALO HILIC	MS:5001560
+Advanced Materials Technology	HALO LPH-C18	MS:5001561
+Advanced Materials Technology	HALO PFP	MS:5001562
+Advanced Materials Technology	HALO Penta-HILIC	MS:5001563
+Advanced Materials Technology	HALO Phenyl-Hexyl	MS:5001564
+Advanced Materials Technology	HALO RP-Amide	MS:5001565
+Agilent		MS:5000003
+Agilent	InfinityLab Poroshell 120 Aq-C18	MS:5001677
+Agilent	InfinityLab Poroshell 120 Bonus-RP	MS:5001678
+Agilent	InfinityLab Poroshell 120 CS-C18	MS:5001679
+Agilent	InfinityLab Poroshell 120 EC-C18	MS:5001680
+Agilent	InfinityLab Poroshell 120 EC-C8	MS:5001681
+Agilent	InfinityLab Poroshell 120 EC-CN	MS:5001682
+Agilent	InfinityLab Poroshell 120 HILIC	MS:5001683
+Agilent	InfinityLab Poroshell 120 HILIC-OH5	MS:5001684
+Agilent	InfinityLab Poroshell 120 HILIC-Z	MS:5001685
+Agilent	InfinityLab Poroshell 120 HILIC-Z (PEEK-lined)	MS:5001686
+Agilent	InfinityLab Poroshell 120 HPH-C18	MS:5001687
+Agilent	InfinityLab Poroshell 120 HPH-C8	MS:5001688
+Agilent	InfinityLab Poroshell 120 PFP	MS:5001689
+Agilent	InfinityLab Poroshell 120 Phenyl-Hexyl	MS:5001690
+Agilent	InfinityLab Poroshell 120 SB-Aq	MS:5001691
+Agilent	InfinityLab Poroshell 120 SB-C18	MS:5001692
+Agilent	InfinityLab Poroshell 120 SB-C8	MS:5001693
+Agilent	Microsorb C18	MS:5001873
+Agilent	Microsorb C4	MS:5001874
+Agilent	Microsorb C8	MS:5001875
+Agilent	Microsorb CN	MS:5001876
+Agilent	Microsorb NH2	MS:5001877
+Agilent	Microsorb Phenyl	MS:5001878
+Agilent	Microsorb-MV CN	MS:5001879
+Agilent	Monochrom C18	MS:5001881
+Agilent	Monochrom CN	MS:5001882
+Agilent	Monochrom Diol	MS:5001883
+Agilent	Monochrom MS	MS:5001884
+Agilent	Monochrom Si	MS:5001885
+Agilent	OmniSpher C18	MS:5001960
+Agilent	Polaris Amide-C18	MS:5002076
+Agilent	Polaris C18	MS:5002077
+Agilent	Polaris C18-A	MS:5002078
+Agilent	Polaris C18-Ether	MS:5002079
+Agilent	Polaris C8-A	MS:5002080
+Agilent	Polaris C8-Ether	MS:5002081
+Agilent	Pursuit C18	MS:5002183
+Agilent	Pursuit C8	MS:5002184
+Agilent	Pursuit Diphenyl	MS:5002185
+Agilent	Pursuit PAH	MS:5002186
+Agilent	Pursuit PFP	MS:5002187
+Agilent	Pursuit Si	MS:5002188
+Agilent	Pursuit UPS 1.9 C18	MS:5002189
+Agilent	Pursuit UPS 1.9 Diphenyl	MS:5002190
+Agilent	Pursuit UPS 2.4 C18	MS:5002191
+Agilent	Pursuit UPS 2.4 Diphenyl	MS:5002192
+Agilent	Pursuit XRs C18	MS:5002193
+Agilent	Pursuit XRs C8	MS:5002194
+Agilent	Pursuit XRs Diphenyl	MS:5002195
+Agilent	Pursuit XRs Si	MS:5002196
+Agilent	ZORBAX 300 SB-C18	MS:5002754
+Agilent	ZORBAX 300 SB-C3	MS:5002755
+Agilent	ZORBAX 300 SB-CN	MS:5002756
+Agilent	ZORBAX 300SB-C18	MS:5002757
+Agilent	ZORBAX 300SB-CN	MS:5002758
+Agilent	ZORBAX Bonus-RP	MS:5002759
+Agilent	ZORBAX C18	MS:5002760
+Agilent	ZORBAX C8	MS:5002761
+Agilent	ZORBAX CN	MS:5002762
+Agilent	ZORBAX Eclipse PAH	MS:5002763
+Agilent	ZORBAX Eclipse Plus C18	MS:5002764
+Agilent	ZORBAX Eclipse Plus C8	MS:5002765
+Agilent	ZORBAX Eclipse XDB-C18	MS:5002766
+Agilent	ZORBAX Eclipse XDB-C8	MS:5002767
+Agilent	ZORBAX Eclipse XDB-CN	MS:5002768
+Agilent	ZORBAX Eclipse XDB-Phenyl	MS:5002769
+Agilent	ZORBAX Extend-C18	MS:5002770
+Agilent	ZORBAX HILIC Plus	MS:5002771
+Agilent	ZORBAX NH2	MS:5002772
+Agilent	ZORBAX ODS	MS:5002773
+Agilent	ZORBAX Original NH2	MS:5002774
+Agilent	ZORBAX Phenyl	MS:5002775
+Agilent	ZORBAX RR Bonus-RP	MS:5002776
+Agilent	ZORBAX RR Eclipse PAH	MS:5002777
+Agilent	ZORBAX RR Eclipse Plus C18	MS:5002778
+Agilent	ZORBAX RR Eclipse Plus C8	MS:5002779
+Agilent	ZORBAX RR Eclipse XDB-C18	MS:5002780
+Agilent	ZORBAX RR Eclipse XDB-C8	MS:5002781
+Agilent	ZORBAX RR Eclipse XDB-CN	MS:5002782
+Agilent	ZORBAX RR Eclipse XDB-Phenyl	MS:5002783
+Agilent	ZORBAX RR Extend-C18	MS:5002784
+Agilent	ZORBAX RR HILIC Plus	MS:5002785
+Agilent	ZORBAX RR Rx-C18	MS:5002786
+Agilent	ZORBAX RR Rx-C8	MS:5002787
+Agilent	ZORBAX RR SB-C18	MS:5002788
+Agilent	ZORBAX RRHD 300 SB Diphenyl	MS:5002789
+Agilent	ZORBAX RRHD 300 SB-C3	MS:5002790
+Agilent	ZORBAX RRHD 300-Diphenyl	MS:5002791
+Agilent	ZORBAX RRHD Bonus-RP	MS:5002792
+Agilent	ZORBAX RRHD Eclipse PAH	MS:5002793
+Agilent	ZORBAX RRHD Eclipse Plus C18	MS:5002794
+Agilent	ZORBAX RRHD Eclipse Plus C8	MS:5002795
+Agilent	ZORBAX RRHD Eclipse XDB-C18	MS:5002796
+Agilent	ZORBAX RRHD Extend-C18	MS:5002797
+Agilent	ZORBAX RRHD HILIC Plus	MS:5002798
+Agilent	ZORBAX RRHD SB-C18	MS:5002799
+Agilent	ZORBAX RRHD SB-CN	MS:5002800
+Agilent	ZORBAX RRHT Bonus-RP	MS:5002801
+Agilent	ZORBAX RRHT Eclipse Plus C18	MS:5002802
+Agilent	ZORBAX RRHT Eclipse Plus C8	MS:5002803
+Agilent	ZORBAX RRHT Eclipse XDB-C18	MS:5002804
+Agilent	ZORBAX RRHT Eclipse XDB-C8	MS:5002805
+Agilent	ZORBAX RRHT Extend-C18	MS:5002806
+Agilent	ZORBAX Rx-C18	MS:5002807
+Agilent	ZORBAX Rx-C8	MS:5002808
+Agilent	ZORBAX SB 300 C3	MS:5002809
+Agilent	ZORBAX SB-Aq	MS:5002810
+Agilent	ZORBAX SB-C18	MS:5002811
+Agilent	ZORBAX SB-C3	MS:5002812
+Agilent	ZORBAX SB-C8	MS:5002813
+Agilent	ZORBAX SB-CN	MS:5002814
+Agilent	ZORBAX SB-Phenyl	MS:5002815
+Agilent	ZORBAX Silica	MS:5002816
+Agilent	ZORBAX TMS	MS:5002817
+Agilent Technologies		MS:5000004
+Agilent Technologies	Metasil AQ	MS:5001857
+Agilent Technologies	Metasil Basic	MS:5001858
+Agilent Technologies	Metasil C1	MS:5001859
+Agilent Technologies	Metasil C6	MS:5001860
+Agilent Technologies	Metasil C8	MS:5001861
+Agilent Technologies	Metasil CN	MS:5001862
+Agilent Technologies	Metasil NH2	MS:5001863
+Agilent Technologies	Metasil ODS	MS:5001864
+Agilent Technologies	Metasil ODS-1	MS:5001865
+Agilent Technologies	Metasil Phenyl	MS:5001866
+Agilent Technologies	Metasil SAX	MS:5001867
+Agilent Technologies	Metasil SCX	MS:5001868
+Agilent Technologies	Metasil Si	MS:5001869
+Altmann Analytik		MS:5000005
+Altmann Analytik	Equisil BDS C18	MS:5001504
+Altmann Analytik	Equisil BDS C8	MS:5001505
+Altmann Analytik	Gold-Turbo 120 BS-C23	MS:5001537
+Altmann Analytik	Hypersil BDS C18	MS:5001606
+Altmann Analytik	Reprosil BDS C18	MS:5002210
+Altmann Analytik	Stability 100 BS-C17	MS:5002367
+Altmann Analytik	Stability 100 BS-C23	MS:5002368
+Altmann Analytik	Stability 120 BS-C23	MS:5002369
+Altmann Analytik	Stability 120 BS-C23e	MS:5002370
+Altmann Analytik	Stability 300 BS-C23	MS:5002371
+Analytical Sales & Services		MS:5000006
+Analytical Sales & Services	Armor C18	MS:5001179
+Analytical Sales & Services	Armor C8	MS:5001180
+Bischoff		MS:5000007
+Bischoff	ProntoPEARL sub2 NPP C18	MS:5002111
+Bischoff	ProntoPEARL sub2 TPP C18-EPS	MS:5002112
+Bischoff	ProntoPEARL sub2 TPP C8-EPS	MS:5002113
+Bischoff	ProntoPEARL sub2 TPP NH2	MS:5002114
+Bischoff	ProntoSIL 120 C1	MS:5002115
+Bischoff	ProntoSIL 120 C18 AQ	MS:5002116
+Bischoff	ProntoSIL 120 C18 AQ plus	MS:5002118
+Bischoff	ProntoSIL 120 C18 H	MS:5002119
+Bischoff	ProntoSIL 120 C18 SH	MS:5002120
+Bischoff	ProntoSIL 120 C18 ace-EPS	MS:5002121
+Bischoff	ProntoSIL 120 C18-EPS	MS:5002122
+Bischoff	ProntoSIL 120 C30	MS:5002123
+Bischoff	ProntoSIL 120 C4	MS:5002124
+Bischoff	ProntoSIL 120 C8 SH	MS:5002125
+Bischoff	ProntoSIL 120 C8 ace-EPS	MS:5002126
+Bischoff	ProntoSIL 120 CN	MS:5002127
+Bischoff	ProntoSIL 120 CN EC	MS:5002128
+Bischoff	ProntoSIL 120 Phenyl	MS:5002129
+Bischoff	ProntoSIL 200 C18 H	MS:5002133
+Bischoff	ProntoSIL 200 C18 ace-EPS	MS:5002134
+Bischoff	ProntoSIL 200 C30	MS:5002135
+Bischoff	ProntoSIL 200 C4	MS:5002136
+Bischoff	ProntoSIL 200 C8 SH	MS:5002137
+Bischoff	ProntoSIL 300 C18 H	MS:5002140
+Bischoff	ProntoSIL 300 C18 ace-EPS	MS:5002141
+Bischoff	ProntoSIL 300 C30	MS:5002142
+Bischoff	ProntoSIL 300 C30 EC	MS:5002143
+Bischoff	ProntoSIL 300 C4	MS:5002144
+Bischoff	ProntoSIL 300 C8 SH	MS:5002145
+Bischoff	ProntoSIL 300 C8 ace-EPS	MS:5002146
+Bischoff	ProntoSIL 60 C18 H	MS:5002147
+Bischoff	ProntoSIL 60 C4	MS:5002148
+Bischoff	ProntoSIL 60 C8 SH	MS:5002149
+Bischoff	ProntoSIL 60 Phenyl	MS:5002150
+Bischoff	ProntoSIL C1	MS:5002151
+Bischoff	ProntoSIL C18 300 H	MS:5002152
+Bischoff	ProntoSIL C18 AQ	MS:5002153
+Bischoff	ProntoSIL C18 AQ plus	MS:5002154
+Bischoff	ProntoSIL C18 SH	MS:5002155
+Bischoff	ProntoSIL C18 ace-EPS	MS:5002156
+Bischoff	ProntoSIL C18-EPS	MS:5002157
+Bischoff	ProntoSIL C30	MS:5002158
+Bischoff	ProntoSIL C30 EC	MS:5002159
+Bischoff	ProntoSIL C4 300	MS:5002160
+Bischoff	ProntoSIL C8 300 SH	MS:5002161
+Bischoff	ProntoSIL C8 SH	MS:5002162
+Bischoff	ProntoSIL C8 ace-EPS	MS:5002163
+Bischoff	ProntoSIL CN	MS:5002164
+Bischoff	ProntoSIL CN EC	MS:5002165
+Bischoff	ProntoSIL Phenyl	MS:5002166
+Bischoff	ProntoSIL Spheribond ODS1	MS:5002167
+Bischoff	ProntoSIL Spheribond ODS2	MS:5002168
+Bonna-Agela Technologies		MS:5000008
+Bonna-Agela Technologies	Bonshell C18	MS:5001259
+Bonna-Agela Technologies	Bonshell Phenyl-Hexyl	MS:5001260
+Bonna-Agela Technologies	Durashell C18	MS:5001488
+Bonna-Agela Technologies	Durashell C8	MS:5001489
+Bonna-Agela Technologies	Durashell NH2	MS:5001490
+Bonna-Agela Technologies	Durashell RP	MS:5001491
+Bonna-Agela Technologies	Innoval C18	MS:5001694
+Bonna-Agela Technologies	Innoval HLP	MS:5001695
+Bonna-Agela Technologies	Innoval PFP	MS:5001696
+Bonna-Agela Technologies	Promosil C18	MS:5002106
+Bonna-Agela Technologies	Promosil C8	MS:5002107
+Bonna-Agela Technologies	Promosil CN	MS:5002108
+Bonna-Agela Technologies	Promosil NH2	MS:5002109
+Bonna-Agela Technologies	Promosil Silica	MS:5002110
+Bonna-Agela Technologies	Unisol Amide	MS:5002561
+Bonna-Agela Technologies	Unisol C18	MS:5002562
+Bonna-Agela Technologies	Unisol C18 (L)	MS:5002563
+Bonna-Agela Technologies	Venusil AQ C18	MS:5002643
+Bonna-Agela Technologies	Venusil ASB C1	MS:5002644
+Bonna-Agela Technologies	Venusil ASB C18	MS:5002645
+Bonna-Agela Technologies	Venusil ASB C3	MS:5002646
+Bonna-Agela Technologies	Venusil ASB C8	MS:5002647
+Bonna-Agela Technologies	Venusil ASB Phenyl	MS:5002648
+Bonna-Agela Technologies	Venusil HILIC	MS:5002649
+Bonna-Agela Technologies	Venusil HLP	MS:5002650
+Bonna-Agela Technologies	Venusil MP 18	MS:5002651
+Bonna-Agela Technologies	Venusil PAH	MS:5002652
+Bonna-Agela Technologies	Venusil PFP	MS:5002653
+Bonna-Agela Technologies	Venusil SCX	MS:5002654
+Bonna-Agela Technologies	Venusil XBP C1	MS:5002655
+Bonna-Agela Technologies	Venusil XBP C18	MS:5002656
+Bonna-Agela Technologies	Venusil XBP C18 (2)	MS:5002657
+Bonna-Agela Technologies	Venusil XBP C18 (L)	MS:5002658
+Bonna-Agela Technologies	Venusil XBP C4	MS:5002659
+Bonna-Agela Technologies	Venusil XBP C8	MS:5002660
+Bonna-Agela Technologies	Venusil XBP CN	MS:5002661
+Bonna-Agela Technologies	Venusil XBP COOH	MS:5002662
+Bonna-Agela Technologies	Venusil XBP Diol	MS:5002663
+Bonna-Agela Technologies	Venusil XBP NH2	MS:5002664
+Bonna-Agela Technologies	Venusil XBP Phenyl	MS:5002665
+Bonna-Agela Technologies	Venusil XBP Silica	MS:5002666
+ChromaNik Technologies Inc.		MS:5000009
+ChromaNik Technologies Inc.	SunShell 2-EP	MS:5002374
+ChromaNik Technologies Inc.	SunShell Biphenyl	MS:5002375
+ChromaNik Technologies Inc.	SunShell C18	MS:5002376
+ChromaNik Technologies Inc.	SunShell C18-WP	MS:5002377
+ChromaNik Technologies Inc.	SunShell C30	MS:5002378
+ChromaNik Technologies Inc.	SunShell C4-100	MS:5002379
+ChromaNik Technologies Inc.	SunShell C8	MS:5002380
+ChromaNik Technologies Inc.	SunShell C8-30HT	MS:5002381
+ChromaNik Technologies Inc.	SunShell HFC18-16	MS:5002382
+ChromaNik Technologies Inc.	SunShell HILIC-Amide	MS:5002383
+ChromaNik Technologies Inc.	SunShell HILIC-S	MS:5002384
+ChromaNik Technologies Inc.	SunShell PFP	MS:5002385
+ChromaNik Technologies Inc.	SunShell PFP&C18	MS:5002386
+ChromaNik Technologies Inc.	SunShell Phenyl	MS:5002387
+ChromaNik Technologies Inc.	SunShell RP-AQUA	MS:5002388
+ChromaNik Technologies Inc.	Sunniest Biphenyl	MS:5002389
+ChromaNik Technologies Inc.	Sunniest C18	MS:5002390
+ChromaNik Technologies Inc.	Sunniest C18-HT	MS:5002391
+ChromaNik Technologies Inc.	Sunniest C8	MS:5002392
+ChromaNik Technologies Inc.	Sunniest Cyano	MS:5002393
+ChromaNik Technologies Inc.	Sunniest PFP	MS:5002394
+ChromaNik Technologies Inc.	Sunniest PFP&C18	MS:5002395
+ChromaNik Technologies Inc.	Sunniest PhE	MS:5002396
+ChromaNik Technologies Inc.	Sunniest RP-AQUA	MS:5002397
+ChromaNik Technologies Inc.	Sunniest Silica	MS:5002398
+Chromatopak		MS:5000010
+Chromatopak	Peerless 120 AQ	MS:5002027
+Chromatopak	Peerless 120 C18	MS:5002028
+Chromatopak	Peerless 120 C8	MS:5002029
+Chromatopak	Peerless Amino	MS:5002030
+Chromatopak	Peerless Basic C18	MS:5002031
+Chromatopak	Peerless Basic C8	MS:5002032
+Chromatopak	Peerless Bio C18	MS:5002033
+Chromatopak	Peerless Bio C4	MS:5002034
+Chromatopak	Peerless Bio C8	MS:5002035
+Chromatopak	Peerless C18	MS:5002036
+Chromatopak	Peerless C4	MS:5002037
+Chromatopak	Peerless C8	MS:5002038
+Chromatopak	Peerless CN	MS:5002039
+Chromatopak	Peerless Diol	MS:5002040
+Chromatopak	Peerless HT-C18	MS:5002041
+Chromatopak	Peerless HT-C8	MS:5002042
+Chromatopak	Peerless LC Amino	MS:5002043
+Chromatopak	Peerless LC C18	MS:5002044
+Chromatopak	Peerless LC C8	MS:5002045
+Chromatopak	Peerless LC Diol	MS:5002046
+Chromatopak	Peerless LC Phenyl	MS:5002047
+Chromatopak	Peerless Phenyl	MS:5002048
+Chromatopak	Peerless Silica	MS:5002049
+Develosil		MS:5000011
+Develosil	HSR AQ C18-3	MS:5001577
+Develosil	HSR AQ C18-5	MS:5001578
+Develosil	HSR C18 Peptide	MS:5001579
+Develosil	HSR C18-3	MS:5001580
+Develosil	HSR C18-5	MS:5001581
+Develosil	ODS-3	MS:5001944
+Develosil	ODS-5	MS:5001945
+Develosil	ODS-7	MS:5001946
+Develosil	ODS-A-5	MS:5001947
+Develosil	ODS-K-5	MS:5001948
+Develosil	ODS-MG-3	MS:5001949
+Develosil	ODS-MG-5	MS:5001950
+Develosil	ODS-N-5	MS:5001951
+Develosil	ODS-P-5	MS:5001952
+Develosil	ODS-P-7	MS:5001953
+Develosil	ODS-SR-3	MS:5001954
+Develosil	ODS-SR-5	MS:5001955
+Develosil	ODS-T-5	MS:5001956
+Develosil	ODS-T-7	MS:5001957
+Develosil	ODS-UG-3	MS:5001958
+Develosil	ODS-UG-5	MS:5001959
+Develosil	XG-C18LC-3	MS:5002707
+Develosil	XG-C18LC-5	MS:5002708
+Develosil	XG-C18M-3	MS:5002709
+Develosil	XG-C18M-5	MS:5002710
+Dikma Technologies Inc.		MS:5000012
+Dikma Technologies Inc.	Bio-Bond C18	MS:5001243
+Dikma Technologies Inc.	Bio-Bond C4	MS:5001244
+Dikma Technologies Inc.	Bio-Bond C8	MS:5001245
+Dikma Technologies Inc.	Endeavorsil C18	MS:5001493
+Dikma Technologies Inc.	Endeavorsil C18-A	MS:5001494
+Dikma Technologies Inc.	Endeavorsil C18-B	MS:5001495
+Dikma Technologies Inc.	Endeavorsil C8	MS:5001496
+Dikma Technologies Inc.	Inspire C18	MS:5001697
+Dikma Technologies Inc.	Inspire C8	MS:5001698
+Dikma Technologies Inc.	Inspire DP	MS:5001699
+Dikma Technologies Inc.	Inspire Diol	MS:5001700
+Dikma Technologies Inc.	Inspire HILIC	MS:5001701
+Dikma Technologies Inc.	Inspire NH2	MS:5001702
+Dikma Technologies Inc.	Inspire PFP	MS:5001703
+Dikma Technologies Inc.	Inspire Phenyl	MS:5001704
+Dikma Technologies Inc.	Inspire Phenyl-hexyl	MS:5001705
+Dikma Technologies Inc.	Leapsil C18	MS:5001753
+Dikma Technologies Inc.	Spursil AQ	MS:5002363
+Dikma Technologies Inc.	Spursil C18	MS:5002364
+Dikma Technologies Inc.	Spursil C18-Amide	MS:5002365
+Dikma Technologies Inc.	Spursil C18-EP	MS:5002366
+Dr. Maisch		MS:5000013
+Dr. Maisch	Gromsil 100 ODS-0 AB	MS:5001539
+Dr. Maisch	Gromsil 100 ODS-2 FE	MS:5001540
+Dr. Maisch	Gromsil 120 ODS-4 HE	MS:5001541
+Dr. Maisch	Gromsil 80 ODS-7 pH	MS:5001542
+Dr. Maisch	Hypersil BDS C18	MS:5001607
+Dr. Maisch	ReproSil Gold 120 C18	MS:5002208
+Dr. Maisch	ReproSil-Pur Basic-C18	MS:5002209
+ES Industries		MS:5000014
+ES Industries	Chromegabond WR-C18	MS:5001358
+ES Industries	Chromegabond WR-C8	MS:5001359
+ES Industries	Epic C18	MS:5001497
+ES Industries	Epic C18-MS	MS:5001498
+ES Industries	Epic C18-SD	MS:5001499
+ES Industries	Epic C4-SD	MS:5001500
+ES Industries	Epic C8	MS:5001501
+ES Industries	Epic Phenyl Hexyl	MS:5001502
+ES Industries	Epic Polar	MS:5001503
+ES Industries	FluoroSep-RP Octyl	MS:5001511
+ES Industries	FluoroSep-RP Phenyl	MS:5001512
+ES Industries	FluoroSep-RP Phenyl HS	MS:5001513
+ES Industries	FluoroSep-RP Propyl	MS:5001514
+Eprogen / Promigen Life Sciences		MS:5000015
+Eprogen / Promigen Life Sciences	MICRA-Gold AX 100	MS:5001821
+Eprogen / Promigen Life Sciences	MICRA-Gold AX 1000	MS:5001822
+Eprogen / Promigen Life Sciences	MICRA-Gold CATSEC100	MS:5001823
+Eprogen / Promigen Life Sciences	MICRA-Gold CATSEC1000	MS:5001824
+Eprogen / Promigen Life Sciences	MICRA-Gold CATSEC300	MS:5001825
+Eprogen / Promigen Life Sciences	MICRA-Gold CATSEC4000	MS:5001826
+Eprogen / Promigen Life Sciences	MICRA-Gold CM 100	MS:5001827
+Eprogen / Promigen Life Sciences	MICRA-Gold GPC LINEAR	MS:5001828
+Eprogen / Promigen Life Sciences	MICRA-Gold GPC PEPTIDE	MS:5001829
+Eprogen / Promigen Life Sciences	MICRA-Gold GPC100	MS:5001830
+Eprogen / Promigen Life Sciences	MICRA-Gold GPC1000	MS:5001831
+Eprogen / Promigen Life Sciences	MICRA-Gold GPC300	MS:5001832
+Eprogen / Promigen Life Sciences	MICRA-Gold GPC4000	MS:5001833
+Eprogen / Promigen Life Sciences	MICRA-Gold GPC500	MS:5001834
+Eprogen / Promigen Life Sciences	MICRA-Gold Q 100	MS:5001835
+Eprogen / Promigen Life Sciences	MICRA-Gold RP4-300	MS:5001836
+Eprogen / Promigen Life Sciences	MICRA-Gold RP4-4000	MS:5001837
+Eprogen / Promigen Life Sciences	MICRA-Gold S 1000	MS:5001838
+Eprogen / Promigen Life Sciences	MICRA-Gold SCD-100	MS:5001839
+Eprogen / Promigen Life Sciences	MICRA-Paltinum NPS ODS-Sil	MS:5001840
+Eprogen / Promigen Life Sciences	MICRA-Platinum NPS ODS-I	MS:5001841
+Eprogen / Promigen Life Sciences	MICRA-Platinum NPS ODS-I PAH	MS:5001842
+Eprogen / Promigen Life Sciences	MICRA-Platinum NPS ODS-II (HPRP)	MS:5001843
+Eprogen / Promigen Life Sciences	MICRA-Platinum NPS ODS-IIIE	MS:5001844
+Eprogen / Promigen Life Sciences	MICRA-Platinum NPS ODS-TAS	MS:5001845
+Eprogen / Promigen Life Sciences	MICRA-Platinum SCD-MS	MS:5001846
+Eprogen / Promigen Life Sciences	MICRA-Silver AX300	MS:5001847
+Eprogen / Promigen Life Sciences	MICRA-Silver CM300	MS:5001848
+Eprogen / Promigen Life Sciences	MICRA-Silver Q300	MS:5001849
+Eprogen / Promigen Life Sciences	MICRA-Silver RP8	MS:5001850
+Eprogen / Promigen Life Sciences	MICRA-Silver S300	MS:5001851
+FUJIFILM Wako Pure Chemical Corporation		MS:5000016
+FUJIFILM Wako Pure Chemical Corporation	Wakopak Wakosil C18	MS:5002680
+FUJIFILM Wako Pure Chemical Corporation	Wakopak Wakosil C18 AR	MS:5002681
+FUJIFILM Wako Pure Chemical Corporation	Wakopak Wakosil C18-200	MS:5002682
+FUJIFILM Wako Pure Chemical Corporation	Wakopak Wakosil C18-200N	MS:5002683
+FUJIFILM Wako Pure Chemical Corporation	Wakopak Wakosil C18-200T	MS:5002684
+FUJIFILM Wako Pure Chemical Corporation	Wakopak Wakosil C18N	MS:5002685
+FUJIFILM Wako Pure Chemical Corporation	Wakopak Wakosil C18T	MS:5002686
+FUJIFILM Wako Pure Chemical Corporation	Wakopak Wakosil C4	MS:5002687
+FUJIFILM Wako Pure Chemical Corporation	Wakopak Wakosil C4-200	MS:5002688
+FUJIFILM Wako Pure Chemical Corporation	Wakopak Wakosil C8	MS:5002689
+FUJIFILM Wako Pure Chemical Corporation	Wakopak Wakosil-II C18 AR	MS:5002690
+FUJIFILM Wako Pure Chemical Corporation	Wakopak Wakosil-II C18 HG	MS:5002691
+FUJIFILM Wako Pure Chemical Corporation	Wakopak Wakosil-II C18 RS	MS:5002692
+FUJIFILM Wako Pure Chemical Corporation	Wakopak Wakosil-II C8 HG	MS:5002693
+FUJIFILM Wako Pure Chemical Corporation	Wakopak Wakosil-II C8 RS	MS:5002694
+Fortis Technologies		MS:5000017
+Fortis Technologies	Fortis Amino	MS:5001518
+Fortis Technologies	Fortis C18	MS:5001519
+Fortis Technologies	Fortis C8	MS:5001520
+Fortis Technologies	Fortis Cyano	MS:5001521
+Fortis Technologies	Fortis Diphenyl	MS:5001522
+Fortis Technologies	Fortis H2o	MS:5001523
+Fortis Technologies	Fortis HILIC	MS:5001524
+Fortis Technologies	Fortis HILIC DIOL	MS:5001525
+Fortis Technologies	UniverSil C18	MS:5002566
+Fortis Technologies	UniverSil C8	MS:5002567
+Fortis Technologies	UniverSil Cyano	MS:5002568
+Fortis Technologies	UniverSil HS C18	MS:5002569
+Fortis Technologies	UniverSil HS C8	MS:5002570
+Fortis Technologies	UniverSil HS Cyano	MS:5002571
+Fortis Technologies	UniverSil HS Phenyl	MS:5002572
+Fortis Technologies	UniverSil Phenyl	MS:5002573
+GL Sciences		MS:5000018
+GL Sciences	InertSustain AQ-C18	MS:5001641
+GL Sciences	InertSustain AX-C18	MS:5001642
+GL Sciences	InertSustain Amide	MS:5001643
+GL Sciences	InertSustain C18	MS:5001644
+GL Sciences	InertSustain C8	MS:5001645
+GL Sciences	InertSustain Cyano	MS:5001646
+GL Sciences	InertSustain PFP	MS:5001647
+GL Sciences	InertSustain Phenyl	MS:5001648
+GL Sciences	InertSustain Phenylhexyl	MS:5001649
+GL Sciences	InertSustainBio C18	MS:5001650
+GL Sciences	InertSustainSwift C18	MS:5001651
+GL Sciences	InertSustainSwift C8	MS:5001652
+GL Sciences	Inertsil AX	MS:5001653
+GL Sciences	Inertsil C4	MS:5001654
+GL Sciences	Inertsil C8	MS:5001655
+GL Sciences	Inertsil C8-3	MS:5001656
+GL Sciences	Inertsil C8-4	MS:5001657
+GL Sciences	Inertsil CN-3	MS:5001658
+GL Sciences	Inertsil CX	MS:5001659
+GL Sciences	Inertsil Diol	MS:5001660
+GL Sciences	Inertsil ODS	MS:5001661
+GL Sciences	Inertsil ODS-2	MS:5001662
+GL Sciences	Inertsil ODS-3	MS:5001663
+GL Sciences	Inertsil ODS-4	MS:5001664
+GL Sciences	Inertsil ODS-EP	MS:5001665
+GL Sciences	Inertsil ODS-HL	MS:5001666
+GL Sciences	Inertsil ODS-P	MS:5001667
+GL Sciences	Inertsil ODS-SP	MS:5001668
+GL Sciences	Inertsil Ph	MS:5001669
+GL Sciences	Inertsil Ph-3	MS:5001670
+GL Sciences	Inertsil SIL-150A	MS:5001671
+GL Sciences	Inertsil WP300 C18	MS:5001672
+GL Sciences	Inertsil WP300 C4	MS:5001673
+GL Sciences	Inertsil WP300 C8	MS:5001674
+GL Sciences	Inertsil WP300 Diol	MS:5001675
+GL Sciences	Inertsil WP300 SIL	MS:5001676
+Genius Technologies		MS:5000019
+Genius Technologies	Cosmicsil APT 300 C18	MS:5001396
+Genius Technologies	Cosmicsil APT C18	MS:5001397
+Genius Technologies	Cosmicsil APT C4	MS:5001398
+Genius Technologies	Cosmicsil APT C8	MS:5001399
+Genius Technologies	Cosmicsil APT CN	MS:5001400
+Genius Technologies	Cosmicsil APT NH2	MS:5001401
+Genius Technologies	Cosmicsil APT Ph	MS:5001402
+Genius Technologies	Cosmicsil APT Ph Plus	MS:5001403
+Genius Technologies	Cosmicsil APT Sil	MS:5001404
+Genius Technologies	Cosmicsil AQ 100 C18	MS:5001405
+Genius Technologies	Cosmicsil AQ 100 C19	MS:5001406
+Genius Technologies	Cosmicsil AQ 120 C18	MS:5001407
+Genius Technologies	Cosmicsil Abra C18	MS:5001408
+Genius Technologies	Cosmicsil Abra C8	MS:5001409
+Genius Technologies	Cosmicsil Adore 100 C18	MS:5001410
+Genius Technologies	Cosmicsil Adore 100 C4	MS:5001411
+Genius Technologies	Cosmicsil Adore 100 C6	MS:5001412
+Genius Technologies	Cosmicsil Adore 100 C8	MS:5001413
+Genius Technologies	Cosmicsil Adore 100 CN	MS:5001414
+Genius Technologies	Cosmicsil Adore 100 Diol	MS:5001415
+Genius Technologies	Cosmicsil Adore 100 NH2	MS:5001416
+Genius Technologies	Cosmicsil Adore 100 SAX	MS:5001417
+Genius Technologies	Cosmicsil Adore 100 SCX	MS:5001418
+Genius Technologies	Cosmicsil Adore 100 Sil	MS:5001419
+Genius Technologies	Cosmicsil Adore Ph	MS:5001420
+Genius Technologies	Cosmicsil Adore Ph Plus	MS:5001421
+Genius Technologies	Cosmicsil Adore TMS	MS:5001422
+Genius Technologies	Cosmicsil Adze C18	MS:5001423
+Genius Technologies	Cosmicsil Adze C8	MS:5001424
+Genius Technologies	Cosmicsil Adze CN	MS:5001425
+Genius Technologies	Cosmicsil Adze Ph	MS:5001426
+Genius Technologies	Cosmicsil Agate 100 C18	MS:5001427
+Genius Technologies	Cosmicsil Agate 100 C8	MS:5001428
+Genius Technologies	Cosmicsil Agate 100 Sil	MS:5001429
+Genius Technologies	Cosmicsil Agate HA C18	MS:5001430
+Genius Technologies	Cosmicsil Agate HK C18	MS:5001431
+Genius Technologies	Cosmicsil Agate HN C18	MS:5001432
+Genius Technologies	Cosmicsil Agate HP C18	MS:5001433
+Genius Technologies	Cosmicsil Agate HS C18	MS:5001434
+Genius Technologies	Cosmicsil Agate HT C18	MS:5001435
+Genius Technologies	Cosmicsil Agate HU C18	MS:5001436
+Genius Technologies	Cosmicsil Agate PRP C18	MS:5001437
+Genius Technologies	Cosmicsil Agate RP C18	MS:5001438
+Genius Technologies	Cosmicsil Agate RP C18-E	MS:5001439
+Genius Technologies	Cosmicsil Agate RP C4	MS:5001440
+Genius Technologies	Cosmicsil Agate RP C8	MS:5001441
+Genius Technologies	Cosmicsil Agate RP CN	MS:5001442
+Genius Technologies	Cosmicsil Agate RP Nh2	MS:5001443
+Genius Technologies	Cosmicsil Agate RP Ph	MS:5001444
+Genius Technologies	Cosmicsil Agate RP Si	MS:5001445
+Genius Technologies	Cosmicsil Agate SB C18	MS:5001446
+Genius Technologies	Cosmicsil Aura 120 Ph	MS:5001447
+Genius Technologies	Cosmicsil Aura C8	MS:5001448
+Genius Technologies	Cosmicsil Aura C8-2	MS:5001449
+Genius Technologies	Cosmicsil Aura CN	MS:5001450
+Genius Technologies	Cosmicsil Aura ODS	MS:5001451
+Genius Technologies	Cosmicsil Aura Ph	MS:5001452
+Genius Technologies	Cosmicsil Aura SI	MS:5001453
+Genius Technologies	Cosmicsil BDS C18	MS:5001454
+Genius Technologies	Cosmicsil BDS C8	MS:5001455
+Genius Technologies	Cosmicsil C18 XD	MS:5001456
+Genius Technologies	Cosmicsil Glory C18	MS:5001457
+Genius Technologies	Cosmicsil Glory C30	MS:5001458
+Genius Technologies	Cosmicsil Glory CN	MS:5001459
+Genius Technologies	Cosmicsil Glory Ph	MS:5001460
+Grace		MS:5000020
+Grace	GraceSmart RP18	MS:5001538
+Grace Alltech		MS:5000021
+Grace Alltech	Adsorbosphere C18	MS:5001125
+Grace Alltech	Adsorbosphere C18-UHS	MS:5001126
+Grace Alltech	Allsphere Amino	MS:5001131
+Grace Alltech	Allsphere C6	MS:5001132
+Grace Alltech	Allsphere C8	MS:5001133
+Grace Alltech	Allsphere Cyano	MS:5001134
+Grace Alltech	Allsphere ODS-1	MS:5001135
+Grace Alltech	Allsphere ODS-2	MS:5001136
+Grace Alltech	Allsphere ODS-3	MS:5001137
+Grace Alltech	Allsphere Phenyl	MS:5001138
+Grace Alltech	Allsphere SAX	MS:5001139
+Grace Alltech	Allsphere SCX	MS:5001140
+Grace Alltech	Allsphere Silica	MS:5001141
+Grace Alltech	Brava Amino	MS:5001261
+Grace Alltech	Brava C18 BDS	MS:5001262
+Grace Alltech	Brava C18 ODS	MS:5001263
+Grace Alltech	Brava C8	MS:5001264
+Grace Alltech	Brava C8 BDS	MS:5001265
+Grace Alltech	Brava Cyano	MS:5001266
+Grace Alltech	Brava Cyano BDS	MS:5001267
+Grace Alltech	Brava Phenyl	MS:5001268
+Grace Alltech	Brava Silica	MS:5001269
+Grace Alltech	Denali C18	MS:5001466
+Grace Alltech	Econosphere C18	MS:5001492
+Grace Alltech	Platinum Amino	MS:5002067
+Grace Alltech	Platinum C18	MS:5002068
+Grace Alltech	Platinum C8	MS:5002069
+Grace Alltech	Platinum Cyano	MS:5002070
+Grace Alltech	Platinum EPS C18	MS:5002071
+Grace Alltech	Platinum EPS C8	MS:5002072
+Grace Alltech	Platinum Phenyl	MS:5002073
+Grace Alltech	Platinum SAX	MS:5002074
+Grace Alltech	Platinum Silica	MS:5002075
+Grace Alltech	VisionHT C18	MS:5002667
+Grace Alltech	VisionHT C18-B	MS:5002668
+Grace Alltech	VisionHT C18-HL	MS:5002669
+Grace Alltech	VisionHT C18-P	MS:5002670
+Grace Grom		MS:5000022
+Grace Grom	Sapphire C18	MS:5002251
+Grace Grom	Sapphire C8	MS:5002252
+Grace Grom	Sil Amino-2 PA	MS:5002332
+Grace Grom	Sil Cyano-3 CP	MS:5002333
+Grace Grom	Sil Diol	MS:5002334
+Grace Grom	Sil ODS-3 CP	MS:5002335
+Grace Grom	Sil ODS-4 HE	MS:5002336
+Grace Grom	Sil ODS-5 ST	MS:5002337
+Grace Grom	Sil ODS-7 pH	MS:5002338
+Grace Grom	Sil Octyl-5 CP	MS:5002339
+Grace Grom	Sil Octyl-5 HE	MS:5002340
+Grace Grom	Sil Octyl-6 MB	MS:5002341
+Grace Grom	Sil Phenyl-1 FE	MS:5002342
+Grace Grom	Sil Phenyl-2 CP	MS:5002343
+Grace Jones		MS:5000023
+Grace Jones	Apex Amino	MS:5001167
+Grace Jones	Apex Amino II	MS:5001168
+Grace Jones	Apex C8	MS:5001169
+Grace Jones	Apex C8(EC)	MS:5001170
+Grace Jones	Apex Cyano	MS:5001171
+Grace Jones	Apex Cyano II	MS:5001172
+Grace Jones	Apex Diol	MS:5001173
+Grace Jones	Apex ODS	MS:5001174
+Grace Jones	Apex ODS II	MS:5001175
+Grace Jones	Apex Phenyl	MS:5001176
+Grace Jones	Apex Silica	MS:5001177
+Grace Jones	Genesis AQ	MS:5001531
+Grace Jones	Genesis C18	MS:5001532
+Grace Jones	Genesis C8	MS:5001533
+Grace Jones	Genesis C8(EC)	MS:5001534
+Grace Jones	Genesis CN	MS:5001535
+Grace Jones	Genesis Phenyl	MS:5001536
+Grace Vydac		MS:5000024
+Grace Vydac	201TP C18	MS:5001000
+Grace Vydac	202TP C18	MS:5001001
+Grace Vydac	208MS C8	MS:5001002
+Grace Vydac	208TP C8	MS:5001003
+Grace Vydac	214ATP C4	MS:5001004
+Grace Vydac	214MS C4	MS:5001005
+Grace Vydac	214TP C4	MS:5001006
+Grace Vydac	218MS C18	MS:5001007
+Grace Vydac	218MS Polymeric C18	MS:5001008
+Grace Vydac	218TP C18	MS:5001009
+Grace Vydac	219MS Diphenyl	MS:5001010
+Grace Vydac	219TP Diphenyl	MS:5001011
+Grace Vydac	238MS Monomeric C18	MS:5001012
+Grace Vydac	238TP C18	MS:5001013
+Grace Vydac	Denali C18	MS:5001467
+Grace Vydac	Everest 238EV C18	MS:5001506
+HILICON		MS:5000025
+HILICON	iHILIC-(P) Classic, HILIC, Peek	MS:5002844
+HILICON	iHILIC-(P) Classic, HILIC, Peek-SS	MS:5002845
+HILICON	iHILIC-(P) Classic, HILIC, SS	MS:5002846
+HILICON	iHILIC-Fusion PEEK	MS:5002847
+HILICON	iHILIC-Fusion PEEK-SS	MS:5002848
+HILICON	iHILIC-Fusion SS	MS:5002849
+HILICON	iHILIC-Fusion(+) PEEK	MS:5002850
+HILICON	iHILIC-Fusion(+) PEEK-SS	MS:5002851
+HILICON	iHILIC-Fusion(+) SS	MS:5002852
+HILICON	iHILIC-Fusion(P) Classic PEEK	MS:5002853
+HILICON	iHILIC-Fusion(P) Classic PEEK-SS	MS:5002854
+HILICON	iHILIC-Fusion(P) Classic SS	MS:5002855
+HILICON	iHILIC-Fusion(P) PEEK	MS:5002856
+HILICON	iHILIC-Fusion(P) PEEK-SS	MS:5002857
+HILICON	iHILIC-Fusion(P) SS	MS:5002858
+Hamilton Company		MS:5000026
+Hamilton Company	HxSil C18	MS:5001587
+Hamilton Company	HxSil C18 Stainless Steel	MS:5001588
+Hamilton Company	HxSil C8	MS:5001589
+Hamilton Company	HxSil C8 Stainless Steel	MS:5001590
+Hamilton Company	PRP-1 PEEK	MS:5001976
+Hamilton Company	PRP-1 Stainless Steel	MS:5001977
+Hamilton Company	PRP-3 PEEK	MS:5001978
+Hamilton Company	PRP-3 Stainless Steel	MS:5001979
+Hamilton Company	PRP-C18 PEEK	MS:5001980
+Hamilton Company	PRP-C18 Sainless Steel	MS:5001981
+Hamilton Company	PRP-X100 PEEK	MS:5001982
+Hamilton Company	PRP-X100 Stainless Steel	MS:5001983
+Hamilton Company	PRP-X110 PEEK	MS:5001984
+Hamilton Company	PRP-X110 Stainless Steel	MS:5001985
+Hamilton Company	PRP-X110S PEEK	MS:5001986
+Hamilton Company	PRP-X110S Stainless Steel	MS:5001987
+Hamilton Company	PRP-X200 PEEK	MS:5001988
+Hamilton Company	PRP-X200 Stainless Steel	MS:5001989
+Hamilton Company	PRP-X300 PEEK	MS:5001990
+Hamilton Company	PRP-X300 Stainless Steel	MS:5001991
+Hamilton Company	PRP-X400 PEEK	MS:5001992
+Hamilton Company	PRP-X400 Stainless Steel	MS:5001993
+Hamilton Company	PRP-X500 PEEK	MS:5001994
+Hamilton Company	PRP-X600 PEEK	MS:5001995
+Hamilton Company	PRP-X800 Stainless Steel	MS:5001996
+Hamilton Company	PRP-h5 Stainless Steel	MS:5001997
+Hamilton Company	RCX-10 PEEK	MS:5002197
+Hamilton Company	RCX-10 Stainless Steel	MS:5002198
+Hamilton Company	RCX-30 PEEK	MS:5002199
+Hamilton Company	RCX-30 Stainless Steel	MS:5002200
+Hichrom		MS:5000027
+Hichrom	Alltima AQ	MS:5001142
+Hichrom	Alltima Amino	MS:5001143
+Hichrom	Alltima C18	MS:5001144
+Hichrom	Alltima C18-LL	MS:5001145
+Hichrom	Alltima C8	MS:5001146
+Hichrom	Alltima Cyano	MS:5001147
+Hichrom	Alltima HP C18	MS:5001148
+Hichrom	Alltima HP C18-AQ	MS:5001149
+Hichrom	Alltima HP C18-Amide	MS:5001150
+Hichrom	Alltima HP C18-EPS	MS:5001151
+Hichrom	Alltima HP C18-HL	MS:5001152
+Hichrom	Alltima HP C8	MS:5001153
+Hichrom	Alltima HP CN	MS:5001154
+Hichrom	Alltima HP Cyano	MS:5001155
+Hichrom	Alltima HP HILIC	MS:5001156
+Hichrom	Alltima HP Silica	MS:5001157
+Hichrom	Alltima Phenyl	MS:5001158
+Hichrom	Alltima Silica	MS:5001159
+Hichrom	CLIPEUS C18	MS:5001302
+Hichrom	CLIPEUS C8	MS:5001304
+Hichrom	CLIPEUS Cyano	MS:5001306
+Hichrom	CLIPEUS Phenyl	MS:5001308
+Hichrom	CLIPEUS Silica	MS:5001310
+Hichrom	HAISIL 100 C18	MS:5001543
+Hichrom	HAISIL 100 C8	MS:5001545
+Hichrom	HAISIL 100 Silica	MS:5001547
+Hichrom	HAISIL 300 C18	MS:5001549
+Hichrom	HAISIL HL C18	MS:5001551
+Hichrom	Hichrom C18	MS:5001583
+Hichrom	Hichrom C8	MS:5001584
+Hichrom	Hichrom PAH2	MS:5001585
+Hichrom	Hichrom RPB	MS:5001586
+Hichrom	PHALANX C18	MS:5001966
+Hichrom	PROTO 200 C18	MS:5001968
+Hichrom	PROTO 200 C4	MS:5001970
+Hichrom	PROTO 300 C18	MS:5001972
+Hichrom	PROTO 300 C4	MS:5001974
+Hichrom	Prevail Amide	MS:5002082
+Hichrom	Prevail C18	MS:5002083
+Hichrom	Prevail C18-Select	MS:5002084
+Hichrom	Prevail C8	MS:5002085
+Hichrom	Prevail Cyano	MS:5002086
+Hichrom	Prevail Organic acid	MS:5002087
+Hichrom	Prevail Phenyl	MS:5002088
+Hichrom	Prevail Silica	MS:5002089
+Hichrom	Ultrasphere Cyano	MS:5002555
+Hichrom	Ultrasphere IP	MS:5002556
+Hichrom	Ultrasphere ODS	MS:5002557
+Hichrom	Ultrasphere ODS-DABS	MS:5002558
+Hichrom	Ultrasphere Octyl	MS:5002559
+Hichrom	Ultrasphere SI	MS:5002560
+Hichrom	Wakopak Fluofix 120E	MS:5002677
+Hichrom	Wakopak Fluofix 120N	MS:5002678
+Hichrom	Wakopak Fluofix-II 120E	MS:5002679
+Higgins Analytical		MS:5000028
+Higgins Analytical	CLIPEUS C18	MS:5001303
+Higgins Analytical	CLIPEUS C8	MS:5001305
+Higgins Analytical	CLIPEUS Cyano	MS:5001307
+Higgins Analytical	CLIPEUS Phenyl	MS:5001309
+Higgins Analytical	CLIPEUS Silica	MS:5001311
+Higgins Analytical	HAISIL 100 C18	MS:5001544
+Higgins Analytical	HAISIL 100 C8	MS:5001546
+Higgins Analytical	HAISIL 100 Silica	MS:5001548
+Higgins Analytical	HAISIL 300 C18	MS:5001550
+Higgins Analytical	HAISIL HL C18	MS:5001552
+Higgins Analytical	HEAVY C18	MS:5001566
+Higgins Analytical	PHALANX C18	MS:5001967
+Higgins Analytical	PROTO 200 C18	MS:5001969
+Higgins Analytical	PROTO 200 C4	MS:5001971
+Higgins Analytical	PROTO 300 C18	MS:5001973
+Higgins Analytical	PROTO 300 C4	MS:5001975
+Higgins Analytical	TARGA C18	MS:5002421
+Higgins Analytical	TARGA C8	MS:5002422
+Hitachi High-Tech		MS:5000029
+Hitachi High-Tech	HITACHI LaChrom C18	MS:5001567
+Hitachi High-Tech	HITACHI LaChrom C18-AQ	MS:5001568
+Hitachi High-Tech	HITACHI LaChrom C18-NE	MS:5001569
+Hitachi High-Tech	HITACHI LaChrom C18-PM	MS:5001570
+Hitachi High-Tech	HITACHI LaChrom C8	MS:5001571
+Hitachi High-Tech	HITACHI LaChrom CN	MS:5001572
+Hitachi High-Tech	HITACHI LaChrom Diol	MS:5001573
+Hitachi High-Tech	HITACHI LaChrom NH2	MS:5001574
+Hitachi High-Tech	HITACHI LaChrom Ph	MS:5001575
+Hitachi High-Tech	HITACHI LaChrom SIL	MS:5001576
+Imtakt		MS:5000030
+Imtakt	Cadenza 5CD-C18	MS:5001344
+Imtakt	Cadenza 5CL-C18	MS:5001345
+Imtakt	Cadenza 5CW-C18	MS:5001346
+Imtakt	Cadenza 5CX-C18	MS:5001347
+Imtakt	Cadenza CD-C18	MS:5001348
+Imtakt	Cadenza CD-C18 HT	MS:5001349
+Imtakt	Cadenza CL-C18	MS:5001350
+Imtakt	Cadenza CL-C18 HT	MS:5001351
+Imtakt	Cadenza CL-C18 MF	MS:5001352
+Imtakt	Cadenza CW-C18	MS:5001353
+Imtakt	Cadenza CX-C18	MS:5001354
+Imtakt	Cadenza CX-C18 HT	MS:5001355
+Imtakt	Cadenza HS-C18	MS:5001356
+Imtakt	Unison UK-C18	MS:5002564
+Imtakt	Unison UK-C18 MF	MS:5002565
+Interchim Technology		MS:5000031
+Interchim Technology	Uptisphere C8	MS:5002574
+Interchim Technology	Uptisphere HDO	MS:5002575
+Interchim Technology	Uptisphere HSC	MS:5002576
+Interchim Technology	Uptisphere MM1	MS:5002577
+Interchim Technology	Uptisphere NEC	MS:5002578
+Interchim Technology	Uptisphere ODB	MS:5002579
+Interchim Technology	Uptisphere PLP	MS:5002580
+Interchim Technology	Uptisphere Strategy C18-2	MS:5002581
+Interchim Technology	Uptisphere Strategy C18-3	MS:5002582
+Interchim Technology	Uptisphere Strategy C8-2	MS:5002583
+Interchim Technology	Uptisphere Strategy RP	MS:5002584
+Interchim Technology	Uptisphere Strategy SI	MS:5002585
+Interchim Technology	Uptisphere TF	MS:5002586
+KYA TECH Corporation		MS:5000032
+KYA TECH Corporation	HiQ Sil C18HS-100	MS:5001582
+Knauer		MS:5000033
+Knauer	ProntoSIL 120 C18 AQ	MS:5002117
+Knauer	ProntoSIL 120-3 C18 AQ	MS:5002130
+Knauer	ProntoSIL 120-5 C18 AQ	MS:5002131
+Knauer	ProntoSIL 200 C18 AQ	MS:5002132
+Knauer	ProntoSIL 200-3 C18 AQ	MS:5002138
+Knauer	ProntoSIL 200-5 C18 AQ	MS:5002139
+Macherey-Nagel		MS:5000034
+Macherey-Nagel	NUCLEODUR C18 Gravity	MS:5001886
+Macherey-Nagel	NUCLEODUR C18 Gravity-SB	MS:5001887
+Macherey-Nagel	NUCLEODUR C18 HTec	MS:5001888
+Macherey-Nagel	NUCLEODUR C18 Isis	MS:5001889
+Macherey-Nagel	NUCLEODUR C18 PAH	MS:5001890
+Macherey-Nagel	NUCLEODUR C18 Pyramid	MS:5001891
+Macherey-Nagel	NUCLEODUR C18 ec	MS:5001892
+Macherey-Nagel	NUCLEODUR C8 Gravity	MS:5001893
+Macherey-Nagel	NUCLEODUR C8 ec	MS:5001894
+Macherey-Nagel	NUCLEODUR CN	MS:5001895
+Macherey-Nagel	NUCLEODUR CN-RP	MS:5001896
+Macherey-Nagel	NUCLEODUR HILIC	MS:5001897
+Macherey-Nagel	NUCLEODUR Isis	MS:5001898
+Macherey-Nagel	NUCLEODUR NH2	MS:5001899
+Macherey-Nagel	NUCLEODUR NH2-RP	MS:5001900
+Macherey-Nagel	NUCLEODUR PFP	MS:5001901
+Macherey-Nagel	NUCLEODUR Phenyl-Hexyl	MS:5001902
+Macherey-Nagel	NUCLEODUR PolarTec	MS:5001903
+Macherey-Nagel	NUCLEODUR SiOH	MS:5001904
+Macherey-Nagel	NUCLEODUR Sphinx RP	MS:5001905
+Macherey-Nagel	NUCLEODUR π²	MS:5001906
+Macherey-Nagel	NUCLEOSHELL Biphenyl	MS:5001907
+Macherey-Nagel	NUCLEOSHELL Bluebird RP 18	MS:5001908
+Macherey-Nagel	NUCLEOSHELL HILIC	MS:5001909
+Macherey-Nagel	NUCLEOSHELL PFP	MS:5001910
+Macherey-Nagel	NUCLEOSHELL Phenyl-Hexyl	MS:5001911
+Macherey-Nagel	NUCLEOSHELL RP18	MS:5001912
+Macherey-Nagel	NUCLEOSHELL RP18 plus	MS:5001913
+Macherey-Nagel	NUCLEOSIL 100 C18	MS:5001914
+Macherey-Nagel	NUCLEOSIL 100 C18 AB	MS:5001915
+Macherey-Nagel	NUCLEOSIL 100 C8	MS:5001916
+Macherey-Nagel	NUCLEOSIL 100 CN	MS:5001917
+Macherey-Nagel	NUCLEOSIL 100 NH2	MS:5001918
+Macherey-Nagel	NUCLEOSIL 100 NO2	MS:5001919
+Macherey-Nagel	NUCLEOSIL 100 SA	MS:5001920
+Macherey-Nagel	NUCLEOSIL 100 SB	MS:5001921
+Macherey-Nagel	NUCLEOSIL 100 Silica	MS:5001922
+Macherey-Nagel	NUCLEOSIL 120 C18	MS:5001923
+Macherey-Nagel	NUCLEOSIL 120 C8	MS:5001924
+Macherey-Nagel	NUCLEOSIL 120 Silica	MS:5001925
+Macherey-Nagel	NUCLEOSIL 300 C18	MS:5001926
+Macherey-Nagel	NUCLEOSIL 300 C4	MS:5001927
+Macherey-Nagel	NUCLEOSIL 300 C8	MS:5001928
+Macherey-Nagel	NUCLEOSIL C18 HD	MS:5001929
+Macherey-Nagel	NUCLEOSIL C18 Nautilus	MS:5001930
+Macherey-Nagel	NUCLEOSIL C8 HD	MS:5001931
+Macherey-Nagel	NUCLEOSIL Protect I	MS:5001932
+Merck		MS:5000035
+Merck	Chromolith CN	MS:5001360
+Merck	Chromolith Diol	MS:5001361
+Merck	Chromolith HighResolution RP-18 endcapped	MS:5001362
+Merck	Chromolith HighResolution RP-8 endcapped	MS:5001363
+Merck	Chromolith NH2	MS:5001364
+Merck	Chromolith Phenyl	MS:5001374
+Merck	Chromolith RP-18 endcapped	MS:5001375
+Merck	Chromolith RP-8 endcapped	MS:5001376
+Merck	Chromolith Si	MS:5001377
+Merck	Discovery C18	MS:5001481
+Merck	Discovery C8	MS:5001482
+Merck	Discovery Cyano	MS:5001483
+Merck	Discovery HS C18	MS:5001484
+Merck	Discovery HS F5 (PFP)	MS:5001485
+Merck	Discovery HS PEG	MS:5001486
+Merck	Discovery RP-AmideC16	MS:5001487
+Merck	LiChrosorb CN	MS:5001755
+Merck	LiChrosorb DIOL	MS:5001757
+Merck	LiChrosorb NH2	MS:5001759
+Merck	LiChrosorb RP Select B	MS:5001761
+Merck	LiChrosorb RP-18	MS:5001763
+Merck	LiChrosorb RP-8	MS:5001765
+Merck	LiChrosorb Si-100	MS:5001767
+Merck	LiChrosorb Silica	MS:5001769
+Merck	LiChrosper Si-60	MS:5001771
+Merck	LiChrospher 100CN	MS:5001773
+Merck	LiChrospher 100DIOL	MS:5001775
+Merck	LiChrospher 100NH2	MS:5001777
+Merck	LiChrospher 100RP-18	MS:5001779
+Merck	LiChrospher 100RP-18e	MS:5001781
+Merck	LiChrospher 100RP-8	MS:5001783
+Merck	LiChrospher 100RP-8e	MS:5001785
+Merck	LiChrospher 60RP-Select B	MS:5001787
+Merck	LiChrospher Amino	MS:5001789
+Merck	LiChrospher RP-18	MS:5001791
+Merck	LiChrospher RP-18 EC	MS:5001793
+Merck	LiChrospher RP-8	MS:5001796
+Merck	LiChrospher RP-8 EC	MS:5001798
+Merck	LiChrospher RP-Select B	MS:5001800
+Merck	LiChrospher Si 100	MS:5001802
+Merck	LiChrospher Si 60	MS:5001804
+Merck SeQuant		MS:5000036
+Merck SeQuant	ZIC-HILIC	MS:5002751
+Merck SeQuant	ZIC-cHILIC	MS:5002752
+Merck SeQuant	ZIC-pHILIC	MS:5002753
+Merck Supelco		MS:5000037
+Merck Supelco	Ascentis C18	MS:5001181
+Merck Supelco	Ascentis C8	MS:5001182
+Merck Supelco	Ascentis ES Cyano	MS:5001183
+Merck Supelco	Ascentis Express AQ-C18	MS:5001184
+Merck Supelco	Ascentis Express Biphenyl	MS:5001185
+Merck Supelco	Ascentis Express C18	MS:5001186
+Merck Supelco	Ascentis Express C30	MS:5001187
+Merck Supelco	Ascentis Express C8	MS:5001188
+Merck Supelco	Ascentis Express ES-Cyano	MS:5001189
+Merck Supelco	Ascentis Express F5 (PFP)	MS:5001190
+Merck Supelco	Ascentis Express HILIC	MS:5001191
+Merck Supelco	Ascentis Express HILIC (Si)	MS:5001192
+Merck Supelco	Ascentis Express OH5	MS:5001193
+Merck Supelco	Ascentis Express Peptide ES-C18	MS:5001194
+Merck Supelco	Ascentis Express Phenyl-Hexyl	MS:5001195
+Merck Supelco	Ascentis Express RP-Amide	MS:5001196
+Merck Supelco	Ascentis Phenyl	MS:5001197
+Merck Supelco	Ascentis RP-Amide	MS:5001198
+Merck Supelco	Ascentis Si	MS:5001199
+Merck Supelco	BIOshell A160 Peptide C18	MS:5001223
+Merck Supelco	BIOshell A160 Peptide CN	MS:5001224
+Merck Supelco	BIOshell A160 Peptide Phenyl-Hexyl	MS:5001225
+Merck Supelco	BIOshell A400 Protein C18	MS:5001226
+Merck Supelco	BIOshell A400 Protein C4	MS:5001227
+Merck Supelco	BIOshell Peptide C18	MS:5001228
+Merck Supelco	Chromolith Performance CN	MS:5001365
+Merck Supelco	Chromolith Performance Diol	MS:5001366
+Merck Supelco	Chromolith Performance HR RP-18e	MS:5001367
+Merck Supelco	Chromolith Performance HR RP-8e	MS:5001368
+Merck Supelco	Chromolith Performance NH2	MS:5001369
+Merck Supelco	Chromolith Performance Phenyl	MS:5001370
+Merck Supelco	Chromolith Performance RP-18e	MS:5001371
+Merck Supelco	Chromolith Performance RP-8e	MS:5001372
+Merck Supelco	Chromolith Performance Si	MS:5001373
+Merck Supelco	Discovery BIO Wide Pore C18	MS:5001478
+Merck Supelco	Discovery BIO Wide Pore C5	MS:5001479
+Merck Supelco	Discovery BIO Wide Pore C8	MS:5001480
+Merck Supelco	LiChrosorb CN	MS:5001754
+Merck Supelco	LiChrosorb DIOL	MS:5001756
+Merck Supelco	LiChrosorb NH2	MS:5001758
+Merck Supelco	LiChrosorb RP Select B	MS:5001760
+Merck Supelco	LiChrosorb RP-18	MS:5001762
+Merck Supelco	LiChrosorb RP-8	MS:5001764
+Merck Supelco	LiChrosorb Si-100	MS:5001766
+Merck Supelco	LiChrosorb Silica	MS:5001768
+Merck Supelco	LiChrosper Si-60	MS:5001770
+Merck Supelco	LiChrospher 100CN	MS:5001772
+Merck Supelco	LiChrospher 100DIOL	MS:5001774
+Merck Supelco	LiChrospher 100NH2	MS:5001776
+Merck Supelco	LiChrospher 100RP-18	MS:5001778
+Merck Supelco	LiChrospher 100RP-18e	MS:5001780
+Merck Supelco	LiChrospher 100RP-8	MS:5001782
+Merck Supelco	LiChrospher 100RP-8e	MS:5001784
+Merck Supelco	LiChrospher 60RP-Select B	MS:5001786
+Merck Supelco	LiChrospher Amino	MS:5001788
+Merck Supelco	LiChrospher RP-18	MS:5001790
+Merck Supelco	LiChrospher RP-18 EC	MS:5001792
+Merck Supelco	LiChrospher RP-18e	MS:5001794
+Merck Supelco	LiChrospher RP-8	MS:5001795
+Merck Supelco	LiChrospher RP-8 EC	MS:5001797
+Merck Supelco	LiChrospher RP-Select B	MS:5001799
+Merck Supelco	LiChrospher Si 100	MS:5001801
+Merck Supelco	LiChrospher Si 60	MS:5001803
+Merck Supelco	Purospher RP-18 LiChroCART	MS:5002169
+Merck Supelco	Purospher RP-18e Hibar	MS:5002170
+Merck Supelco	Purospher RP-18e LiChroCART	MS:5002171
+Merck Supelco	Purospher STAR NH2 Hibar	MS:5002172
+Merck Supelco	Purospher STAR NH2 LiChroCART	MS:5002173
+Merck Supelco	Purospher STAR Phenyl Hibar	MS:5002174
+Merck Supelco	Purospher STAR Phenyl LiChroCART	MS:5002175
+Merck Supelco	Purospher STAR RP-18e Hibar	MS:5002176
+Merck Supelco	Purospher STAR RP-18e LiChroCART	MS:5002177
+Merck Supelco	Purospher STAR RP-8 LiChroCART	MS:5002178
+Merck Supelco	Purospher STAR RP-8e Hibar	MS:5002179
+Merck Supelco	Purospher STAR RP-8e LiChroCART	MS:5002180
+Merck Supelco	Purospher STAR Si Hibar	MS:5002181
+Merck Supelco	Purospher STAR Si LiChroCART	MS:5002182
+Merck Supelco	SUPELCOSIL ABZ+Plus	MS:5002218
+Merck Supelco	SUPELCOSIL Hisep	MS:5002219
+Merck Supelco	SUPELCOSIL LC-1 methyl	MS:5002220
+Merck Supelco	SUPELCOSIL LC-18	MS:5002221
+Merck Supelco	SUPELCOSIL LC-18-DB	MS:5002222
+Merck Supelco	SUPELCOSIL LC-18-T	MS:5002223
+Merck Supelco	SUPELCOSIL LC-8	MS:5002224
+Merck Supelco	SUPELCOSIL LC-8-DB	MS:5002225
+Merck Supelco	SUPELCOSIL LC-ABZ	MS:5002226
+Merck Supelco	SUPELCOSIL LC-C18	MS:5002227
+Merck Supelco	SUPELCOSIL LC-C18-DB	MS:5002228
+Merck Supelco	SUPELCOSIL LC-C18-S	MS:5002229
+Merck Supelco	SUPELCOSIL LC-C18-T	MS:5002230
+Merck Supelco	SUPELCOSIL LC-C8	MS:5002231
+Merck Supelco	SUPELCOSIL LC-C8-DB	MS:5002232
+Merck Supelco	SUPELCOSIL LC-CN	MS:5002233
+Merck Supelco	SUPELCOSIL LC-DP Diphenyl	MS:5002234
+Merck Supelco	SUPELCOSIL LC-Diol	MS:5002235
+Merck Supelco	SUPELCOSIL LC-NH2	MS:5002236
+Merck Supelco	SUPELCOSIL LC-PAH	MS:5002237
+Merck Supelco	SUPELCOSIL LC-SCX	MS:5002238
+Merck Supelco	SUPELCOSIL LC-Si	MS:5002239
+Merck Supelco	SUPELCOSIL SAX1	MS:5002240
+Merck Supelco	SUPELCOSIL Suplex pkb-100	MS:5002241
+Merck Supelco	Superspher 100 RP-18 LiChroCART	MS:5002399
+Merck Supelco	Superspher 100 RP-18e LiChroCART	MS:5002400
+Merck Supelco	Titan C18	MS:5002442
+Merck Supelco	Titan HILIC	MS:5002443
+Merck Supelco	Titan PFP	MS:5002444
+Merck Supelco	apHera C18	MS:5002843
+MicroSolv Technology Corporation		MS:5000038
+MicroSolv Technology Corporation	Cogent Amide	MS:5001378
+MicroSolv Technology Corporation	Cogent Bidentate C18	MS:5001379
+MicroSolv Technology Corporation	Cogent Bidentate C8	MS:5001380
+MicroSolv Technology Corporation	Cogent Bidentate C8 300	MS:5001381
+MicroSolv Technology Corporation	Cogent Diamond Hydride	MS:5001382
+MicroSolv Technology Corporation	Cogent Diamond Hydride 2.0	MS:5001383
+MicroSolv Technology Corporation	Cogent Diol	MS:5001384
+MicroSolv Technology Corporation	Cogent HPS Amino	MS:5001385
+MicroSolv Technology Corporation	Cogent HPS C18	MS:5001386
+MicroSolv Technology Corporation	Cogent HPS C8	MS:5001387
+MicroSolv Technology Corporation	Cogent HPS Cyano	MS:5001388
+MicroSolv Technology Corporation	Cogent HPS Phenyl	MS:5001389
+MicroSolv Technology Corporation	Cogent Phenyl Hydride	MS:5001390
+MicroSolv Technology Corporation	Cogent Silica	MS:5001391
+MicroSolv Technology Corporation	Cogent Silica-C	MS:5001392
+MicroSolv Technology Corporation	Cogent Silica-C 300	MS:5001393
+MicroSolv Technology Corporation	Cogent UDA (wcx)	MS:5001394
+MicroSolv Technology Corporation	Cogent UDC Cholesterol	MS:5001395
+Nacalai Tesque		MS:5000039
+Nacalai Tesque	COSMOSIL C18-AR-II	MS:5001326
+Nacalai Tesque	COSMOSIL C18-EB	MS:5001327
+Nacalai Tesque	COSMOSIL C18-MS-II	MS:5001328
+Nacalai Tesque	COSMOSIL C18-PAQ	MS:5001329
+Nacalai Tesque	COSMOSIL C22-AR-II	MS:5001330
+Nacalai Tesque	COSMOSIL C4-MS	MS:5001331
+Nacalai Tesque	COSMOSIL C8-MS	MS:5001332
+Nacalai Tesque	COSMOSIL CN-MS	MS:5001333
+Nacalai Tesque	COSMOSIL Cholester	MS:5001334
+Nacalai Tesque	COSMOSIL HILIC	MS:5001335
+Nacalai Tesque	COSMOSIL NPE	MS:5001336
+Nacalai Tesque	COSMOSIL PBr	MS:5001337
+Nacalai Tesque	COSMOSIL PE-MS	MS:5001338
+Nacalai Tesque	COSMOSIL PFP	MS:5001339
+Nacalai Tesque	COSMOSIL PYE	MS:5001340
+Nacalai Tesque	COSMOSIL SL-II	MS:5001341
+Nacalai Tesque	COSMOSIL TMS	MS:5001342
+Nacalai Tesque	COSMOSIL πNAP	MS:5001343
+Nanghavi Chromatography Solutions		MS:5000040
+Nanghavi Chromatography Solutions	Kanak C18	MS:5001710
+Nanghavi Chromatography Solutions	Kanak C18 Plus	MS:5001711
+Nanghavi Chromatography Solutions	Kanak C4	MS:5001712
+Nanghavi Chromatography Solutions	Kanak C8	MS:5001713
+Nanghavi Chromatography Solutions	Kanak Core C18 Plus	MS:5001714
+Nanghavi Chromatography Solutions	Kanak Core Phenyl Hexyl	MS:5001715
+Nanghavi Chromatography Solutions	Kanak Cyano	MS:5001716
+Nanghavi Chromatography Solutions	Kanak PFP	MS:5001717
+Nanghavi Chromatography Solutions	Kanak Phenyl Hexyl	MS:5001718
+Nanologica		MS:5000041
+Nanologica	SVEA C18 Gold	MS:5002242
+Nanologica	SVEA C18 Opal	MS:5002243
+Nanologica	SVEA C4	MS:5002244
+Nanologica	SVEA C8	MS:5002245
+Nanologica	SVEA Core C18	MS:5002246
+Nanologica	SVEA Core Phenyl Hexyl	MS:5002247
+Nanologica	SVEA Cyano	MS:5002248
+Nanologica	SVEA PFP	MS:5002249
+Nanologica	SVEA Phenyl Hexyl	MS:5002250
+Nomura Chemical		MS:5000042
+Nomura Chemical	Develosil C30-UG	MS:5001468
+Nomura Chemical	Develosil Combi-RP	MS:5001469
+Nomura Chemical	Develosil ODS-HG	MS:5001470
+Nomura Chemical	Develosil ODS-MG	MS:5001471
+Nomura Chemical	Develosil ODS-SR	MS:5001472
+Nomura Chemical	Develosil ODS-UG	MS:5001473
+Nomura Chemical	Develosil RPAQUEOUS	MS:5001474
+Nomura Chemical	Develosil RPAQUEOUS-AR	MS:5001475
+Nouryon-Kromasil		MS:5000043
+Nouryon-Kromasil	Kromasil C18	MS:5001731
+Nouryon-Kromasil	Kromasil C4	MS:5001732
+Nouryon-Kromasil	Kromasil C8	MS:5001733
+Nouryon-Kromasil	Kromasil CN	MS:5001734
+Nouryon-Kromasil	Kromasil Classic C1	MS:5001735
+Nouryon-Kromasil	Kromasil Classic C18	MS:5001736
+Nouryon-Kromasil	Kromasil Classic C4	MS:5001737
+Nouryon-Kromasil	Kromasil Classic C8	MS:5001738
+Nouryon-Kromasil	Kromasil Classic CN	MS:5001739
+Nouryon-Kromasil	Kromasil Classic Diol	MS:5001740
+Nouryon-Kromasil	Kromasil Classic HILIC-D	MS:5001741
+Nouryon-Kromasil	Kromasil Classic NH2	MS:5001742
+Nouryon-Kromasil	Kromasil Classic Phenyl	MS:5001743
+Nouryon-Kromasil	Kromasil Classic SIL	MS:5001744
+Nouryon-Kromasil	Kromasil Classic diC4	MS:5001745
+Nouryon-Kromasil	Kromasil Diol	MS:5001746
+Nouryon-Kromasil	Kromasil Eternity C18	MS:5001747
+Nouryon-Kromasil	Kromasil Eternity PhenylHexyl	MS:5001748
+Nouryon-Kromasil	Kromasil HILIC-D	MS:5001749
+Nouryon-Kromasil	Kromasil NH2	MS:5001750
+Nouryon-Kromasil	Kromasil Phenyl	MS:5001751
+Nouryon-Kromasil	Kromasil SIL	MS:5001752
+Orochem		MS:5000044
+Orochem	Gazelle C18	MS:5001526
+Orochem	Gazelle C18-Polar	MS:5001527
+Orochem	Matrix C18	MS:5001854
+Orochem	Matrix C18-AQ	MS:5001855
+Orochem	Matrix C8	MS:5001856
+Orochem	Monitor C18	MS:5001880
+Orochem	Orosil C18	MS:5001964
+Orochem	Orosil C18-Polar	MS:5001965
+Orochem	Reliasil C18	MS:5002206
+Orochem	Reliasil ODS-1	MS:5002207
+Osaka Soda (Shiseido)		MS:5000045
+Osaka Soda (Shiseido)	CAPCELL CORE C18	MS:5001270
+Osaka Soda (Shiseido)	CAPCELL CORE C18 MG	MS:5001271
+Osaka Soda (Shiseido)	CAPCELL CORE C18 MP	MS:5001272
+Osaka Soda (Shiseido)	CAPCELL CORE C27 AQ	MS:5001273
+Osaka Soda (Shiseido)	CAPCELL PAK ADME-HR	MS:5001274
+Osaka Soda (Shiseido)	CAPCELL PAK C1 UG120	MS:5001275
+Osaka Soda (Shiseido)	CAPCELL PAK C18 ACR	MS:5001276
+Osaka Soda (Shiseido)	CAPCELL PAK C18 AG	MS:5001277
+Osaka Soda (Shiseido)	CAPCELL PAK C18 AQ	MS:5001278
+Osaka Soda (Shiseido)	CAPCELL PAK C18 BB	MS:5001279
+Osaka Soda (Shiseido)	CAPCELL PAK C18 BB-H	MS:5001280
+Osaka Soda (Shiseido)	CAPCELL PAK C18 IF	MS:5001281
+Osaka Soda (Shiseido)	CAPCELL PAK C18 IF2	MS:5001282
+Osaka Soda (Shiseido)	CAPCELL PAK C18 MG	MS:5001283
+Osaka Soda (Shiseido)	CAPCELL PAK C18 MGII	MS:5001284
+Osaka Soda (Shiseido)	CAPCELL PAK C18 MGIII	MS:5001285
+Osaka Soda (Shiseido)	CAPCELL PAK C18 SG120	MS:5001286
+Osaka Soda (Shiseido)	CAPCELL PAK C18 SG300	MS:5001287
+Osaka Soda (Shiseido)	CAPCELL PAK C18 UG120	MS:5001288
+Osaka Soda (Shiseido)	CAPCELL PAK C18 UG80	MS:5001289
+Osaka Soda (Shiseido)	CAPCELL PAK C8 AG120	MS:5001290
+Osaka Soda (Shiseido)	CAPCELL PAK C8 DD	MS:5001291
+Osaka Soda (Shiseido)	CAPCELL PAK C8 SG120	MS:5001292
+Osaka Soda (Shiseido)	CAPCELL PAK C8 SG300	MS:5001293
+Osaka Soda (Shiseido)	CAPCELL PAK C8 UG120	MS:5001294
+Osaka Soda (Shiseido)	CAPCELL PAK CR	MS:5001295
+Osaka Soda (Shiseido)	CAPCELL PAK MF C8 SG	MS:5001296
+Osaka Soda (Shiseido)	CAPCELL PAK MF Ph-1	MS:5001297
+Osaka Soda (Shiseido)	CAPCELL PAK MGIII-H	MS:5001298
+Osaka Soda (Shiseido)	CAPCELL PAK PC HILIC	MS:5001299
+Osaka Soda (Shiseido)	CAPCELL PAK Proteonavi (C4)	MS:5001300
+Osaka Soda (Shiseido)	CAPCELL PK C8 DD	MS:5001301
+Phase Analytical Technology, LLC		MS:5000046
+Phase Analytical Technology, LLC	ACME Amide/C18	MS:5001046
+Phase Analytical Technology, LLC	ACME BIPHENYL	MS:5001047
+Phase Analytical Technology, LLC	ACME C18	MS:5001048
+Phase Analytical Technology, LLC	ACME C8	MS:5001049
+Phase Analytical Technology, LLC	ACME CN	MS:5001050
+Phase Analytical Technology, LLC	ACME Cannabis	MS:5001051
+Phase Analytical Technology, LLC	ACME F5/C18	MS:5001052
+Phase Analytical Technology, LLC	ACME PAH	MS:5001053
+Phase Analytical Technology, LLC	ACME PLUS	MS:5001054
+Phase Analytical Technology, LLC	ACME Ph	MS:5001055
+Phase Analytical Technology, LLC	ACME XCEED	MS:5001056
+Phenomenex		MS:5000047
+Phenomenex	Acclaim Mixed Mode HILIC-1	MS:5001092
+Phenomenex	Acclaim Mixed Mode WAX-1	MS:5001094
+Phenomenex	Acclaim Mixed Mode WCX-1	MS:5001096
+Phenomenex	Aeris PEPTIDE XB-C18	MS:5001127
+Phenomenex	Aeris WIDEPORE C4	MS:5001128
+Phenomenex	Aeris WIDEPORE XB-C18	MS:5001129
+Phenomenex	Aeris WIDEPORE XB-C8	MS:5001130
+Phenomenex	Aqua C18	MS:5001178
+Phenomenex	Bondclone C18	MS:5001254
+Phenomenex	Bondclone CN	MS:5001255
+Phenomenex	Bondclone NH2	MS:5001256
+Phenomenex	Bondclone Phenyl	MS:5001257
+Phenomenex	Bondclone Sil	MS:5001258
+Phenomenex	Curosil-PFP	MS:5001461
+Phenomenex	Gemini C18	MS:5001528
+Phenomenex	Gemini C6-Phenyl	MS:5001529
+Phenomenex	Gemini NX-C18	MS:5001530
+Phenomenex	HyperClone BDS C18	MS:5001598
+Phenomenex	HyperClone BDS C8	MS:5001599
+Phenomenex	HyperClone CN (CPS)	MS:5001600
+Phenomenex	HyperClone MOS (C8)	MS:5001601
+Phenomenex	HyperClone ODS (C18)	MS:5001602
+Phenomenex	HyperClone Silica	MS:5001603
+Phenomenex	Jupiter C18	MS:5001709
+Phenomenex	Kinetex Biphenyl	MS:5001719
+Phenomenex	Kinetex C18	MS:5001720
+Phenomenex	Kinetex C8	MS:5001721
+Phenomenex	Kinetex EVO C18	MS:5001722
+Phenomenex	Kinetex F5	MS:5001723
+Phenomenex	Kinetex HILIC	MS:5001724
+Phenomenex	Kinetex PAH	MS:5001725
+Phenomenex	Kinetex PFP	MS:5001726
+Phenomenex	Kinetex PS C18	MS:5001727
+Phenomenex	Kinetex Phenyl-Hexyl	MS:5001728
+Phenomenex	Kinetex Polar C18	MS:5001729
+Phenomenex	Kinetex XB-C18	MS:5001730
+Phenomenex	Luna C18	MS:5001805
+Phenomenex	Luna C18(2)	MS:5001806
+Phenomenex	Luna C5	MS:5001807
+Phenomenex	Luna C8	MS:5001808
+Phenomenex	Luna C8(2)	MS:5001809
+Phenomenex	Luna CN	MS:5001810
+Phenomenex	Luna HILIC	MS:5001811
+Phenomenex	Luna NH2	MS:5001812
+Phenomenex	Luna Omega C18	MS:5001813
+Phenomenex	Luna Omega PS C18	MS:5001814
+Phenomenex	Luna Omega Polar C18	MS:5001815
+Phenomenex	Luna Omega SUGAR	MS:5001816
+Phenomenex	Luna PFP(2)	MS:5001817
+Phenomenex	Luna Phenyl-Hexyl	MS:5001818
+Phenomenex	Luna SCX	MS:5001819
+Phenomenex	Luna Silica (2)	MS:5001820
+Phenomenex	Onyx Monolithic C18	MS:5001961
+Phenomenex	Onyx Monolithic C8	MS:5001962
+Phenomenex	Onyx Monolithic HD-C18	MS:5001963
+Phenomenex	Partisil C8	MS:5002019
+Phenomenex	Partisil ODS (1)	MS:5002020
+Phenomenex	Partisil ODS (2)	MS:5002021
+Phenomenex	Partisil ODS (3)	MS:5002022
+Phenomenex	Partisil PAC	MS:5002023
+Phenomenex	Partisil SAX	MS:5002024
+Phenomenex	Partisil SCX	MS:5002025
+Phenomenex	Partisil Silica	MS:5002026
+Phenomenex	Prodigy C8	MS:5002099
+Phenomenex	Prodigy ODS-2	MS:5002100
+Phenomenex	Prodigy ODS-3	MS:5002101
+Phenomenex	Prodigy ODS-3V	MS:5002102
+Phenomenex	Prodigy Phenyl-3 (PH-3)	MS:5002103
+Phenomenex	Prodigy Silica	MS:5002104
+Phenomenex	Prodigy Silica-3	MS:5002105
+Phenomenex	SphereClone C6	MS:5002344
+Phenomenex	SphereClone C8	MS:5002345
+Phenomenex	SphereClone NH2	MS:5002346
+Phenomenex	SphereClone ODS(1)	MS:5002347
+Phenomenex	SphereClone ODS(2)	MS:5002348
+Phenomenex	SphereClone SAX	MS:5002349
+Phenomenex	SphereClone Silica	MS:5002350
+Phenomenex	Synergi Fusion-RP	MS:5002417
+Phenomenex	Synergi Hydro-RP	MS:5002418
+Phenomenex	Synergi Max-RP	MS:5002419
+Phenomenex	Synergi Polar-RP	MS:5002420
+Phenomenex	Ultracarb C8	MS:5002552
+Phenomenex	Ultracarb ODS (20)	MS:5002553
+Phenomenex	Ultracarb ODS (30)	MS:5002554
+Restek		MS:5000048
+Restek	Allure Aqueous C18	MS:5001160
+Restek	Allure Basix	MS:5001161
+Restek	Allure Biphenyl	MS:5001162
+Restek	Allure C18	MS:5001163
+Restek	Allure Organics Acids	MS:5001164
+Restek	Allure PFP Propyl	MS:5001165
+Restek	Allure Silica	MS:5001166
+Restek	Force Biphenyl	MS:5001515
+Restek	Force C18	MS:5001516
+Restek	Force FluoroPhenyl	MS:5001517
+Restek	Pinnacle DB Aqueous C18	MS:5002050
+Restek	Pinnacle DB Biphenyl	MS:5002051
+Restek	Pinnacle DB C18	MS:5002052
+Restek	Pinnacle DB C8	MS:5002053
+Restek	Pinnacle DB Cyano	MS:5002054
+Restek	Pinnacle DB PAH	MS:5002055
+Restek	Pinnacle DB PFP Propyl	MS:5002056
+Restek	Pinnacle DB Phenyl	MS:5002057
+Restek	Pinnacle DB Silica	MS:5002058
+Restek	Pinnacle II Biphenyl	MS:5002059
+Restek	Pinnacle II C18	MS:5002060
+Restek	Pinnacle II C8	MS:5002061
+Restek	Pinnacle II Cyano	MS:5002062
+Restek	Pinnacle II PAH	MS:5002063
+Restek	Pinnacle II Phenyl	MS:5002064
+Restek	Pinnacle SB IBD	MS:5002065
+Restek	Pinncale DB PAH	MS:5002066
+Restek	Raptor ARC-C18	MS:5002201
+Restek	Raptor Biphenyl	MS:5002202
+Restek	Raptor C18	MS:5002203
+Restek	Raptor FluoroPhenyl	MS:5002204
+Restek	Raptor HILIC-Si	MS:5002205
+Restek	Roc C18	MS:5002213
+Restek	Roc C8	MS:5002214
+Restek	Roc Cyano	MS:5002215
+Restek	Roc Phenyl-Hexyl	MS:5002216
+Restek	Roc Silica	MS:5002217
+Restek	Ultra Amino	MS:5002484
+Restek	Ultra Aqueous C18	MS:5002485
+Restek	Ultra Aromax	MS:5002486
+Restek	Ultra Biphenyl	MS:5002487
+Restek	Ultra C1	MS:5002488
+Restek	Ultra C18	MS:5002489
+Restek	Ultra C4	MS:5002490
+Restek	Ultra C8	MS:5002491
+Restek	Ultra Carbamate	MS:5002492
+Restek	Ultra Cyano	MS:5002493
+Restek	Ultra IBD	MS:5002494
+Restek	Ultra II Aqueous C18	MS:5002495
+Restek	Ultra II Aromax	MS:5002496
+Restek	Ultra II Biphenyl	MS:5002497
+Restek	Ultra II C18	MS:5002498
+Restek	Ultra II IBD	MS:5002499
+Restek	Ultra II PFP Propyl	MS:5002500
+Restek	Ultra PFP Propyl	MS:5002501
+Restek	Ultra PFPP	MS:5002502
+Restek	Ultra Phenyl	MS:5002503
+Restek	Ultra Quat	MS:5002504
+Restek	Ultra Silica	MS:5002505
+Restek	Viva Biphenyl	MS:5002671
+Restek	Viva C18	MS:5002672
+Restek	Viva C4	MS:5002673
+Restek	Viva C8	MS:5002674
+Restek	Viva PFP Propyl	MS:5002675
+Restek	Viva Silica	MS:5002676
+SEPSERV		MS:5000049
+SEPSERV	UltraSep ES ADC	MS:5002508
+SEPSERV	UltraSep ES AMID H RP18P	MS:5002509
+SEPSERV	UltraSep ES AMID H RP18PA	MS:5002510
+SEPSERV	UltraSep ES AMID RP18A	MS:5002511
+SEPSERV	UltraSep ES AMID RP18AM	MS:5002512
+SEPSERV	UltraSep ES AMINOPOLYOL G	MS:5002513
+SEPSERV	UltraSep ES AMINOPOLYOL H	MS:5002514
+SEPSERV	UltraSep ES AMINOTETRAOL	MS:5002515
+SEPSERV	UltraSep ES C1	MS:5002516
+SEPSERV	UltraSep ES C10 ω-COOH	MS:5002517
+SEPSERV	UltraSep ES C12 TA	MS:5002518
+SEPSERV	UltraSep ES C18	MS:5002519
+SEPSERV	UltraSep ES C30	MS:5002520
+SEPSERV	UltraSep ES C8	MS:5002521
+SEPSERV	UltraSep ES CHAIR	MS:5002522
+SEPSERV	UltraSep ES CN	MS:5002523
+SEPSERV	UltraSep ES D300 C30	MS:5002524
+SEPSERV	UltraSep ES DTA	MS:5002525
+SEPSERV	UltraSep ES NH2	MS:5002526
+SEPSERV	UltraSep ES OH	MS:5002527
+SEPSERV	UltraSep ES PEO	MS:5002528
+SEPSERV	UltraSep ES PFP	MS:5002529
+SEPSERV	UltraSep ES PHARM E RP18	MS:5002530
+SEPSERV	UltraSep ES PHARM E RP18 SUPER	MS:5002531
+SEPSERV	UltraSep ES PHARM E RP8	MS:5002532
+SEPSERV	UltraSep ES PHARM RP18	MS:5002533
+SEPSERV	UltraSep ES PHARM RP18 SUPER	MS:5002534
+SEPSERV	UltraSep ES PHARM RP8	MS:5002535
+SEPSERV	UltraSep ES PHARM SPEZIAL E RP18	MS:5002536
+SEPSERV	UltraSep ES PHARM SPEZIAL E RP8	MS:5002537
+SEPSERV	UltraSep ES PHARM SPEZIAL RP18	MS:5002538
+SEPSERV	UltraSep ES PHARM SPEZIAL RP8	MS:5002539
+SEPSERV	UltraSep ES Phenyl	MS:5002540
+SEPSERV	UltraSep ES Phenylhexyl	MS:5002541
+SEPSERV	UltraSep ES RP18 500	MS:5002542
+SEPSERV	UltraSep ES RP8F	MS:5002543
+SEPSERV	UltraSep ES Silica	MS:5002544
+SEPSERV	UltraSep ES TC	MS:5002545
+SEPSERV	UltraSep ES Tetraminool (TTA)	MS:5002546
+SEPSERV	UltraSep ES UREIDO	MS:5002547
+SEPSERV	UltraSep ESD PHARM E RP18	MS:5002548
+SEPSERV	UltraSep ESD PHARM E RP8	MS:5002549
+SEPSERV	UltraSep ESD PHARM RP18	MS:5002550
+SEPSERV	UltraSep ESD PHARM RP8	MS:5002551
+SIELC Technologies		MS:5000050
+SIELC Technologies	Primesep 100	MS:5002094
+SIELC Technologies	Primesep 200	MS:5002095
+SIELC Technologies	Primesep A	MS:5002096
+SIELC Technologies	Primesep B	MS:5002097
+SIELC Technologies	Primesep C	MS:5002098
+Sepax Technologies		MS:5000051
+Sepax Technologies	Sepax BR-C18	MS:5002259
+Sepax Technologies	Sepax Bio-C18	MS:5002260
+Sepax Technologies	Sepax Bio-C4	MS:5002261
+Sepax Technologies	Sepax Bio-C8	MS:5002262
+Sepax Technologies	Sepax GP-C18	MS:5002263
+Sepax Technologies	Sepax GP-C4	MS:5002264
+Sepax Technologies	Sepax GP-C8	MS:5002265
+Sepax Technologies	Sepax GP-Phenyl	MS:5002266
+Sepax Technologies	Sepax HP-Amino	MS:5002267
+Sepax Technologies	Sepax HP-C18	MS:5002268
+Sepax Technologies	Sepax HP-C18(2)	MS:5002269
+Sepax Technologies	Sepax HP-Cyano	MS:5002270
+Sepax Technologies	Sepax HP-Diol	MS:5002271
+Sepax Technologies	Sepax HP-SAX(II)	MS:5002272
+Sepax Technologies	Sepax HP-SCX	MS:5002273
+Sepax Technologies	Sepax HP-Silica	MS:5002274
+Sepax Technologies	Sepax Polar-Imidazole	MS:5002275
+Sepax Technologies	Sepax PolyRP-100	MS:5002276
+Sepax Technologies	Sepax PolyRP-1000	MS:5002277
+Sepax Technologies	Sepax PolyRP-300	MS:5002278
+Sepax Technologies	Sepax PolyRP-500	MS:5002279
+Sepax Technologies	Sepax PolyRP-NP1.7	MS:5002280
+Sepax Technologies	Sepax PolyRP-NP10	MS:5002281
+Sepax Technologies	Sepax PolyRP-NP3	MS:5002282
+Sepax Technologies	Sepax PolyRP-NP5	MS:5002283
+Shimadzu		MS:5000052
+Shimadzu	Mastro2 C18	MS:5001852
+Shimadzu	Mastro2 PFP	MS:5001853
+Shimadzu	Shim-pack Arata C18	MS:5002284
+Shimadzu	Shim-pack Arata Peptide C18	MS:5002285
+Shimadzu	Shim-pack Diol-HILIC	MS:5002286
+Shimadzu	Shim-pack FC-ODS	MS:5002287
+Shimadzu	Shim-pack GIS C18	MS:5002288
+Shimadzu	Shim-pack GIS C18-P	MS:5002289
+Shimadzu	Shim-pack GIS HILIC	MS:5002290
+Shimadzu	Shim-pack GIS RP-Shield	MS:5002291
+Shimadzu	Shim-pack GISS C18	MS:5002292
+Shimadzu	Shim-pack GIST Amide	MS:5002293
+Shimadzu	Shim-pack GIST C18	MS:5002294
+Shimadzu	Shim-pack GIST C18-AQ	MS:5002295
+Shimadzu	Shim-pack GIST C8	MS:5002296
+Shimadzu	Shim-pack GIST CN	MS:5002297
+Shimadzu	Shim-pack GIST NH2	MS:5002298
+Shimadzu	Shim-pack GIST PFPP	MS:5002299
+Shimadzu	Shim-pack GIST Phenyl	MS:5002300
+Shimadzu	Shim-pack GIST Phenyl-Hexyl	MS:5002301
+Shimadzu	Shim-pack GWS C18	MS:5002302
+Shimadzu	Shim-pack MAqC-ODS I	MS:5002303
+Shimadzu	Shim-pack PFPP	MS:5002304
+Shimadzu	Shim-pack Phenyl	MS:5002305
+Shimadzu	Shim-pack Scepter C18	MS:5002306
+Shimadzu	Shim-pack Scepter C4-300	MS:5002307
+Shimadzu	Shim-pack Scepter C8	MS:5002308
+Shimadzu	Shim-pack Scepter HD-C18	MS:5002309
+Shimadzu	Shim-pack VP-C8	MS:5002310
+Shimadzu	Shim-pack VP-ODS	MS:5002311
+Shimadzu	Shim-pack VP-Phenyl	MS:5002312
+Shimadzu	Shim-pack Velox Biphenyl	MS:5002313
+Shimadzu	Shim-pack Velox C18	MS:5002314
+Shimadzu	Shim-pack Velox HILIC	MS:5002315
+Shimadzu	Shim-pack Velox PFPP	MS:5002316
+Shimadzu	Shim-pack Velox SP-C18	MS:5002317
+Shimadzu	Shim-pack XR-C8	MS:5002318
+Shimadzu	Shim-pack XR-ODS	MS:5002319
+Shimadzu	Shim-pack XR-ODS II	MS:5002320
+Shimadzu	Shim-pack XR-ODS III	MS:5002321
+Shimadzu	Shim-pack XR-Phenyl	MS:5002322
+Shimadzu	Shim-pack XR-Sil	MS:5002323
+Shodex		MS:5000053
+Shodex	ODP2 HP-2B	MS:5001939
+Shodex	ODP2 HP-2D	MS:5001940
+Shodex	ODP2 HP-4B	MS:5001941
+Shodex	ODP2 HP-4D	MS:5001942
+Shodex	ODP2 HP-4E	MS:5001943
+Showa Denko		MS:5000054
+Showa Denko	Shodex C18-4D	MS:5002324
+Showa Denko	Shodex C18-4E	MS:5002325
+Showa Denko	Shodex Silica C18M 2D	MS:5002326
+Showa Denko	Shodex Silica C18M 4D	MS:5002327
+Showa Denko	Shodex Silica C18M 4E	MS:5002328
+Showa Denko	Shodex Silica C18P 2D	MS:5002329
+Showa Denko	Shodex Silica C18P 4D	MS:5002330
+Showa Denko	Shodex Silica C18P 4E	MS:5002331
+Thermo Scientific		MS:5000055
+Thermo Scientific	AQUASIL C18	MS:5001085
+Thermo Scientific	Acclaim 120 C18	MS:5001087
+Thermo Scientific	Acclaim 120 C8	MS:5001088
+Thermo Scientific	Acclaim 300 C18	MS:5001089
+Thermo Scientific	Acclaim C30	MS:5001090
+Thermo Scientific	Acclaim HILIC-10	MS:5001091
+Thermo Scientific	Acclaim Mixed Mode HILIC-1	MS:5001093
+Thermo Scientific	Acclaim Mixed Mode WAX-1	MS:5001095
+Thermo Scientific	Acclaim Mixed Mode WCX-1	MS:5001097
+Thermo Scientific	Acclaim Organic Acid	MS:5001098
+Thermo Scientific	Acclaim PepMap C18	MS:5001099
+Thermo Scientific	Acclaim Phenyl-1	MS:5001100
+Thermo Scientific	Acclaim Polar Advantage	MS:5001101
+Thermo Scientific	Acclaim Polar Advantage II	MS:5001102
+Thermo Scientific	Acclaim RSLC 120 C18	MS:5001103
+Thermo Scientific	Acclaim RSLC 120 C8	MS:5001104
+Thermo Scientific	Acclaim RSLC Polar Advantage	MS:5001105
+Thermo Scientific	Acclaim RSLC Polar Advantage II	MS:5001106
+Thermo Scientific	Accucore 150-Amide-HILIC	MS:5001107
+Thermo Scientific	Accucore 150-C18	MS:5001108
+Thermo Scientific	Accucore 150-C4	MS:5001109
+Thermo Scientific	Accucore Biphenyl	MS:5001110
+Thermo Scientific	Accucore C18	MS:5001111
+Thermo Scientific	Accucore C30	MS:5001112
+Thermo Scientific	Accucore C8	MS:5001113
+Thermo Scientific	Accucore HILIC	MS:5001114
+Thermo Scientific	Accucore PFP	MS:5001115
+Thermo Scientific	Accucore Phenyl-Hexyl	MS:5001116
+Thermo Scientific	Accucore Phenyl-X	MS:5001117
+Thermo Scientific	Accucore Polar Premium	MS:5001118
+Thermo Scientific	Accucore RP-MS	MS:5001119
+Thermo Scientific	Accucore Urea HILIC	MS:5001120
+Thermo Scientific	Accucore Vanquish C18+	MS:5001121
+Thermo Scientific	Accucore XL C18	MS:5001122
+Thermo Scientific	Accucore XL C8	MS:5001123
+Thermo Scientific	Accucore aQ	MS:5001124
+Thermo Scientific	BETASIL Diol	MS:5001221
+Thermo Scientific	BETASIL Phenyl/Hexyl	MS:5001222
+Thermo Scientific	BetaBasic C18	MS:5001229
+Thermo Scientific	BetaBasic CN	MS:5001230
+Thermo Scientific	BetaBasic Phenyl	MS:5001231
+Thermo Scientific	BetaMax Acid	MS:5001232
+Thermo Scientific	BetaMax Base	MS:5001233
+Thermo Scientific	BetaMax Base Cyano	MS:5001234
+Thermo Scientific	BetaMax Neutral	MS:5001235
+Thermo Scientific	BetaSil C1	MS:5001236
+Thermo Scientific	BetaSil C18	MS:5001237
+Thermo Scientific	BetaSil C6	MS:5001238
+Thermo Scientific	BetaSil C8	MS:5001239
+Thermo Scientific	BetaSil Cyano	MS:5001240
+Thermo Scientific	BetaSil Phenyl	MS:5001241
+Thermo Scientific	BetaSil Silica	MS:5001242
+Thermo Scientific	BioBasic 18	MS:5001246
+Thermo Scientific	BioBasic 4	MS:5001247
+Thermo Scientific	BioBasic 8	MS:5001248
+Thermo Scientific	BioBasic AX	MS:5001249
+Thermo Scientific	BioBasic CN	MS:5001250
+Thermo Scientific	BioBasic Phenyl	MS:5001251
+Thermo Scientific	BioBasic SCX	MS:5001252
+Thermo Scientific	Dionex IonPac AS11-HC	MS:5001477
+Thermo Scientific	Fluophase PFP	MS:5001509
+Thermo Scientific	Fluophase RP	MS:5001510
+Thermo Scientific	HyPURITY AQUASTAR	MS:5001591
+Thermo Scientific	HyPURITY Advance	MS:5001592
+Thermo Scientific	HyPURITY C18	MS:5001593
+Thermo Scientific	HyPURITY C4	MS:5001594
+Thermo Scientific	HyPURITY C8	MS:5001595
+Thermo Scientific	HyPURITY Cyano	MS:5001596
+Thermo Scientific	Hypercarb	MS:5001604
+Thermo Scientific	Hypersil APS-2	MS:5001605
+Thermo Scientific	Hypersil BDS C18	MS:5001608
+Thermo Scientific	Hypersil BDS C8	MS:5001609
+Thermo Scientific	Hypersil BDS Cyano	MS:5001610
+Thermo Scientific	Hypersil BDS Phenyl	MS:5001611
+Thermo Scientific	Hypersil CPS (Cyano)	MS:5001612
+Thermo Scientific	Hypersil CPS-2	MS:5001613
+Thermo Scientific	Hypersil Elite C18	MS:5001614
+Thermo Scientific	Hypersil GOLD	MS:5001615
+Thermo Scientific	Hypersil GOLD AX	MS:5001616
+Thermo Scientific	Hypersil GOLD Amino	MS:5001617
+Thermo Scientific	Hypersil GOLD C4	MS:5001618
+Thermo Scientific	Hypersil GOLD C8	MS:5001619
+Thermo Scientific	Hypersil GOLD CN	MS:5001620
+Thermo Scientific	Hypersil GOLD HILIC	MS:5001621
+Thermo Scientific	Hypersil GOLD PFP	MS:5001622
+Thermo Scientific	Hypersil GOLD Phenyl	MS:5001623
+Thermo Scientific	Hypersil GOLD SAX	MS:5001624
+Thermo Scientific	Hypersil GOLD Silica	MS:5001625
+Thermo Scientific	Hypersil GOLD aQ	MS:5001626
+Thermo Scientific	Hypersil Green PAH	MS:5001627
+Thermo Scientific	Hypersil MOS (C8)	MS:5001628
+Thermo Scientific	Hypersil MOS-2 (C8)	MS:5001629
+Thermo Scientific	Hypersil ODS	MS:5001630
+Thermo Scientific	Hypersil ODS-2	MS:5001631
+Thermo Scientific	Hypersil PREP HS C18	MS:5001632
+Thermo Scientific	Hypersil Phenyl	MS:5001633
+Thermo Scientific	Hypersil Phenyl-2	MS:5001634
+Thermo Scientific	Hypersil Prism RP	MS:5001635
+Thermo Scientific	Hypersil Prism RPN	MS:5001636
+Thermo Scientific	Hypersil SAS (C1)	MS:5001637
+Thermo Scientific	Hypersil SAX	MS:5001638
+Thermo Scientific	Hypersil Silica	MS:5001639
+Thermo Scientific	Hypersil silica	MS:5001640
+Thermo Scientific	Syncronis C18	MS:5002413
+Thermo Scientific	Syncronis C8	MS:5002414
+Thermo Scientific	Syncronis Phenyl	MS:5002415
+Thermo Scientific	Syncronis aQ	MS:5002416
+Tosoh Bioscience		MS:5000056
+Tosoh Bioscience	TSKegl Phenyl-5PW RP	MS:5002423
+Tosoh Bioscience	TSKgel CN-80Ts	MS:5002424
+Tosoh Bioscience	TSKgel ODS-100S	MS:5002425
+Tosoh Bioscience	TSKgel ODS-100V	MS:5002426
+Tosoh Bioscience	TSKgel ODS-100Z	MS:5002427
+Tosoh Bioscience	TSKgel ODS-120A	MS:5002428
+Tosoh Bioscience	TSKgel ODS-120T	MS:5002429
+Tosoh Bioscience	TSKgel ODS-140HTP	MS:5002430
+Tosoh Bioscience	TSKgel ODS-80Tm	MS:5002431
+Tosoh Bioscience	TSKgel ODS-80Ts	MS:5002432
+Tosoh Bioscience	TSKgel ODS-80Ts QA	MS:5002433
+Tosoh Bioscience	TSKgel Octadecyl-2PW	MS:5002434
+Tosoh Bioscience	TSKgel Octadecyl-NFR non-porous	MS:5002435
+Tosoh Bioscience	TSKgel Octadeyl-4PW	MS:5002436
+Tosoh Bioscience	TSKgel Octyl-80Ts	MS:5002437
+Tosoh Bioscience	TSKgel OligoDNA-RP	MS:5002438
+Tosoh Bioscience	TSKgel Super-ODS	MS:5002439
+Tosoh Bioscience	TSKgel Super-Octyl	MS:5002440
+Tosoh Bioscience	TSKgel Super-Phenyl	MS:5002441
+United Chemical Technologies		MS:5000057
+United Chemical Technologies	Selectra Aqueous C18	MS:5002253
+United Chemical Technologies	Selectra C18	MS:5002254
+United Chemical Technologies	Selectra C8	MS:5002255
+United Chemical Technologies	Selectra DA	MS:5002256
+United Chemical Technologies	Selectra EtG	MS:5002257
+United Chemical Technologies	Selectra PFPP	MS:5002258
+VDS Optilab		MS:5000058
+VDS Optilab	VDSpher Classic C18-E	MS:5002587
+VDS Optilab	VDSpher Classic C18-H	MS:5002588
+VDS Optilab	VDSpher Classic C18-M	MS:5002589
+VDS Optilab	VDSpher Classic C18-M-E	MS:5002590
+VDS Optilab	VDSpher Classic C18-M-SE	MS:5002591
+VDS Optilab	VDSpher Classic C18-NE	MS:5002592
+VDS Optilab	VDSpher Classic C18-SE	MS:5002593
+VDS Optilab	VDSpher Classic C4-E	MS:5002594
+VDS Optilab	VDSpher Classic C4-SE	MS:5002595
+VDS Optilab	VDSpher Classic C8-E	MS:5002596
+VDS Optilab	VDSpher Classic C8-H	MS:5002597
+VDS Optilab	VDSpher Classic C8-M	MS:5002598
+VDS Optilab	VDSpher Classic C8-SB	MS:5002599
+VDS Optilab	VDSpher Classic C8-SE	MS:5002600
+VDS Optilab	VDSpher Classic CN	MS:5002601
+VDS Optilab	VDSpher Classic CN-RP	MS:5002602
+VDS Optilab	VDSpher Classic DAP	MS:5002603
+VDS Optilab	VDSpher Classic Diol	MS:5002604
+VDS Optilab	VDSpher Classic NH2	MS:5002605
+VDS Optilab	VDSpher Classic Phenyl-E	MS:5002606
+VDS Optilab	VDSpher Classic SIL	MS:5002607
+VDS Optilab	VDSpher OptiAqua 100 C18	MS:5002608
+VDS Optilab	VDSpher OptiAqua 100 C8	MS:5002609
+VDS Optilab	VDSpher OptiAqua PUR 100 C18	MS:5002610
+VDS Optilab	VDSpher OptiAqua PUR 100 C18-LL	MS:5002611
+VDS Optilab	VDSpher OptiAqua PUR 100 C4	MS:5002612
+VDS Optilab	VDSpher OptiAqua PUR 100 C8	MS:5002613
+VDS Optilab	VDSpher OptiAqua PUR 150 C18	MS:5002614
+VDS Optilab	VDSpher PUR 200 SIL	MS:5002615
+VDS Optilab	VDSpher PUR 300 SIL	MS:5002616
+VDS Optilab	VDSpher PUR C18-E	MS:5002617
+VDS Optilab	VDSpher PUR C18-H	MS:5002618
+VDS Optilab	VDSpher PUR C18-M	MS:5002619
+VDS Optilab	VDSpher PUR C18-M-E	MS:5002620
+VDS Optilab	VDSpher PUR C18-M-SE	MS:5002621
+VDS Optilab	VDSpher PUR C18-NE	MS:5002622
+VDS Optilab	VDSpher PUR C18-SE	MS:5002623
+VDS Optilab	VDSpher PUR C4-E	MS:5002624
+VDS Optilab	VDSpher PUR C4-SE	MS:5002625
+VDS Optilab	VDSpher PUR C8-E	MS:5002626
+VDS Optilab	VDSpher PUR C8-H	MS:5002627
+VDS Optilab	VDSpher PUR C8-M-E	MS:5002628
+VDS Optilab	VDSpher PUR C8-M-II	MS:5002629
+VDS Optilab	VDSpher PUR C8-M-SE	MS:5002630
+VDS Optilab	VDSpher PUR C8-NE	MS:5002631
+VDS Optilab	VDSpher PUR C8-SB	MS:5002632
+VDS Optilab	VDSpher PUR C8-SE	MS:5002633
+VDS Optilab	VDSpher PUR CN	MS:5002634
+VDS Optilab	VDSpher PUR CN-RP	MS:5002635
+VDS Optilab	VDSpher PUR CN-SE	MS:5002636
+VDS Optilab	VDSpher PUR CN-SE-RP	MS:5002637
+VDS Optilab	VDSpher PUR Diol	MS:5002638
+VDS Optilab	VDSpher PUR NH2	MS:5002639
+VDS Optilab	VDSpher PUR Phenyl-E	MS:5002640
+VDS Optilab	VDSpher PUR Phenyl-SE	MS:5002641
+VDS Optilab	VDSpher PUR SIL	MS:5002642
+Waters		MS:5000059
+Waters	ACQUITY Premier BEH C18	MS:5001057
+Waters	ACQUITY Premier BEH Shield RP18	MS:5001058
+Waters	ACQUITY Premier CSH C18	MS:5001059
+Waters	ACQUITY Premier CSH Phenyl-Hexyl	MS:5001060
+Waters	ACQUITY Premier Glycan BEH Amide	MS:5001061
+Waters	ACQUITY Premier Glycan BEH C18 AX	MS:5001062
+Waters	ACQUITY Premier Glycoprotein BEH Amide	MS:5001063
+Waters	ACQUITY Premier HSS T3	MS:5001064
+Waters	ACQUITY Premier Oligonucleotide C18	MS:5001065
+Waters	ACQUITY Premier Peptide BEH C18	MS:5001066
+Waters	ACQUITY Premier Peptide CSH C18	MS:5001067
+Waters	ACQUITY Premier Peptide HSS T3	MS:5001068
+Waters	ACQUITY Premier Protein BEH C4	MS:5001069
+Waters	ACQUITY UPLC BEH Amide	MS:5001070
+Waters	ACQUITY UPLC BEH C18	MS:5001071
+Waters	ACQUITY UPLC BEH C8	MS:5001072
+Waters	ACQUITY UPLC BEH HILIC	MS:5001073
+Waters	ACQUITY UPLC BEH Phenyl	MS:5001074
+Waters	ACQUITY UPLC BEH Shield RP18	MS:5001075
+Waters	ACQUITY UPLC CSH C18	MS:5001076
+Waters	ACQUITY UPLC CSH Fluoro-Phenyl	MS:5001077
+Waters	ACQUITY UPLC CSH Phenyl-Hexyl	MS:5001078
+Waters	ACQUITY UPLC HSS C18	MS:5001079
+Waters	ACQUITY UPLC HSS C18 SB	MS:5001080
+Waters	ACQUITY UPLC HSS CN	MS:5001081
+Waters	ACQUITY UPLC HSS PFP	MS:5001082
+Waters	ACQUITY UPLC HSS T3	MS:5001083
+Waters	ACQUITY UPLC Peptide BEH C18	MS:5001084
+Waters	AccQ-Tag Ultra	MS:5001086
+Waters	Atlantis HILIC Silica	MS:5001216
+Waters	Atlantis Premier BEH C18 AX	MS:5001217
+Waters	Atlantis Premier BEH Z-HILIC	MS:5001218
+Waters	Atlantis T3	MS:5001219
+Waters	Atlantis dC18	MS:5001220
+Waters	BioResolve RP mAb Polyphenyl	MS:5001253
+Waters	CORTECS C18	MS:5001312
+Waters	CORTECS C18+	MS:5001313
+Waters	CORTECS C8	MS:5001314
+Waters	CORTECS HILIC	MS:5001315
+Waters	CORTECS Phenyl	MS:5001316
+Waters	CORTECS Shield RP18	MS:5001317
+Waters	CORTECS T3	MS:5001318
+Waters	CORTECS UPLC C18	MS:5001319
+Waters	CORTECS UPLC C18+	MS:5001320
+Waters	CORTECS UPLC C8	MS:5001321
+Waters	CORTECS UPLC HILIC	MS:5001322
+Waters	CORTECS UPLC Phenyl	MS:5001323
+Waters	CORTECS UPLC Shield RP18	MS:5001324
+Waters	CORTECS UPLC T3	MS:5001325
+Waters	Delta-Pak 100 C18	MS:5001462
+Waters	Delta-Pak 300 C18	MS:5001463
+Waters	Delta-Pak 300C18	MS:5001464
+Waters	Delta-Pak C4	MS:5001465
+Waters	Nova-Pak C18	MS:5001933
+Waters	Nova-Pak C8	MS:5001934
+Waters	Nova-Pak CN HP	MS:5001935
+Waters	Nova-Pak Cyano (CN)	MS:5001936
+Waters	Nova-Pak Phenyl	MS:5001937
+Waters	Nova-Pak Silica	MS:5001938
+Waters	Resolve C18	MS:5002211
+Waters	Resolve Silica	MS:5002212
+Waters	Spherisorb C1	MS:5002351
+Waters	Spherisorb C6	MS:5002352
+Waters	Spherisorb C8	MS:5002353
+Waters	Spherisorb CN	MS:5002354
+Waters	Spherisorb NH2	MS:5002355
+Waters	Spherisorb ODS1	MS:5002356
+Waters	Spherisorb ODS2	MS:5002357
+Waters	Spherisorb ODSB	MS:5002358
+Waters	Spherisorb Phenyl	MS:5002359
+Waters	Spherisorb SAX	MS:5002360
+Waters	Spherisorb SCX	MS:5002361
+Waters	Spherisorb Silica	MS:5002362
+Waters	SunFire C18	MS:5002372
+Waters	SunFire C8	MS:5002373
+Waters	Symmetry 100 C18	MS:5002401
+Waters	Symmetry 100 C8	MS:5002402
+Waters	Symmetry 100 Shield RP18	MS:5002403
+Waters	Symmetry 100 Shield RP8	MS:5002404
+Waters	Symmetry 300 C18	MS:5002405
+Waters	Symmetry 300 C4	MS:5002406
+Waters	Symmetry C18	MS:5002407
+Waters	Symmetry C8	MS:5002408
+Waters	Symmetry Shield RP18	MS:5002409
+Waters	Symmetry Shield RP8	MS:5002410
+Waters	Symmetry300 C18	MS:5002411
+Waters	Symmetry300 C4	MS:5002412
+Waters	XBridge BEH Amide	MS:5002695
+Waters	XBridge BEH C18	MS:5002696
+Waters	XBridge BEH C18 XP	MS:5002697
+Waters	XBridge BEH C8	MS:5002698
+Waters	XBridge BEH HILIC	MS:5002699
+Waters	XBridge BEH Phenyl	MS:5002700
+Waters	XBridge BEH Shield RP18	MS:5002701
+Waters	XBridge C18	MS:5002702
+Waters	XBridge C8	MS:5002703
+Waters	XBridge Phenyl	MS:5002704
+Waters	XBridge Protein BEH C4	MS:5002705
+Waters	XBridge Shield RP18	MS:5002706
+Waters	XSelect CSH C18	MS:5002711
+Waters	XSelect CSH C18 XP	MS:5002712
+Waters	XSelect CSH Fluoro-Phenyl	MS:5002713
+Waters	XSelect CSH Fluoro-Phenyl XP	MS:5002714
+Waters	XSelect CSH Phenyl-Hexyl	MS:5002715
+Waters	XSelect CSH Phenyl-Hexyl XP	MS:5002716
+Waters	XSelect HSS C18	MS:5002717
+Waters	XSelect HSS C18 SB	MS:5002718
+Waters	XSelect HSS C18 SB XP	MS:5002719
+Waters	XSelect HSS C18 XP	MS:5002720
+Waters	XSelect HSS CN	MS:5002721
+Waters	XSelect HSS CN XP	MS:5002722
+Waters	XSelect HSS PFP	MS:5002723
+Waters	XSelect HSS PFP XP	MS:5002724
+Waters	XSelect HSS T3	MS:5002725
+Waters	XSelect HSS T3 XP	MS:5002726
+Waters	XSelect Peptide CSH C18	MS:5002727
+Waters	XSelect Peptide CSH C18 XP	MS:5002728
+Waters	XTerra MS C18	MS:5002729
+Waters	XTerra MS C8	MS:5002730
+Waters	XTerra Phenyl	MS:5002731
+Waters	XTerra Shield RP18	MS:5002732
+Waters	XTerra Shield RP18 IS	MS:5002733
+Waters	XTerra Shield RP8	MS:5002734
+Waters	µBondapak Amino (NH2)	MS:5002859
+Waters	µBondapak C18	MS:5002860
+Waters	µBondapak Cyano (CN)	MS:5002861
+Waters	µBondapak Phenyl	MS:5002862
+Welch Materials		MS:5000060
+Welch Materials	Topsil C18	MS:5002445
+Welch Materials	Topsil C8	MS:5002446
+Welch Materials	Topsil CN	MS:5002447
+Welch Materials	Topsil HILIC NH2	MS:5002448
+Welch Materials	Topsil NH2	MS:5002449
+Welch Materials	Topsil Phenyl-Hexyl	MS:5002450
+Welch Materials	Topsil Silica	MS:5002451
+Welch Materials	Ultisil ALK-C18	MS:5002460
+Welch Materials	Ultisil AQ-C18	MS:5002461
+Welch Materials	Ultisil Amino Acid	MS:5002462
+Welch Materials	Ultisil Amino Acid Plus	MS:5002463
+Welch Materials	Ultisil Diol	MS:5002464
+Welch Materials	Ultisil LP-C18	MS:5002465
+Welch Materials	Ultisil NH2	MS:5002466
+Welch Materials	Ultisil ODS-3	MS:5002467
+Welch Materials	Ultisil PAH	MS:5002468
+Welch Materials	Ultisil PFP	MS:5002469
+Welch Materials	Ultisil Phenyl-Ether	MS:5002470
+Welch Materials	Ultisil Plus C18	MS:5002471
+Welch Materials	Ultisil Polar-RP	MS:5002472
+Welch Materials	Ultisil SiO2	MS:5002473
+Welch Materials	Ultisil XB-C1	MS:5002474
+Welch Materials	Ultisil XB-C18	MS:5002475
+Welch Materials	Ultisil XB-C30	MS:5002476
+Welch Materials	Ultisil XB-C4	MS:5002477
+Welch Materials	Ultisil XB-C8	MS:5002478
+Welch Materials	Ultisil XB-CN	MS:5002479
+Welch Materials	Ultisil XB-Phenyl	MS:5002480
+Welch Materials	Ultisil XB-SAX	MS:5002481
+Welch Materials	Ultisil XB-SCX	MS:5002482
+Welch Materials	Ultisil XS-C18	MS:5002483
+Welch Materials	Xtimate C18	MS:5002735
+Welch Materials	Xtimate C4	MS:5002736
+Welch Materials	Xtimate C8	MS:5002737
+Welch Materials	Xtimate CN	MS:5002738
+Welch Materials	Xtimate PS/DVB	MS:5002739
+Welch Materials	Xtimate Phenyl-Hexyl	MS:5002740
+Welch Materials	Xtimate Polar-RP	MS:5002741
+Welch Materials	Xtimate SEC-1000	MS:5002742
+Welch Materials	Xtimate SEC-120	MS:5002743
+Welch Materials	Xtimate SEC-300	MS:5002744
+Welch Materials	Xtimate SEC-700	MS:5002745
+Welch Materials	Xtimate Sugar-Ca	MS:5002746
+Welch Materials	Xtimate Sugar-H	MS:5002747
+Welch Materials	Xtimate XB-SCX	MS:5002748
+Wesley Technologies Inc.		MS:5000061
+Wesley Technologies Inc.	Flowrosil C18	MS:5001507
+Wesley Technologies Inc.	Flowrosil C8	MS:5001508
+Wesley Technologies Inc.	PrimeSIL C18	MS:5002090
+Wesley Technologies Inc.	PrimeSIL C8	MS:5002091
+Wesley Technologies Inc.	PrimeSIL ODS 2	MS:5002092
+Wesley Technologies Inc.	PrimeSIL ODS P	MS:5002093
+YMC		MS:5000062
+YMC	Carotenoid	MS:5001357
+YMC	Hydrosphere C18	MS:5001597
+YMC	J'sphere ODS-H80	MS:5001706
+YMC	J'sphere ODS-L80	MS:5001707
+YMC	J'sphere ODS-M80	MS:5001708
+YMC	Meteoric Core C18	MS:5001870
+YMC	Meteoric Core C18 BIO	MS:5001871
+YMC	Meteoric Core C8	MS:5001872
+YMC	Pack C4	MS:5001998
+YMC	Pack C8	MS:5001999
+YMC	Pack CN	MS:5002000
+YMC	Pack Diol-NP	MS:5002001
+YMC	Pack NH2	MS:5002002
+YMC	Pack ODS-A	MS:5002003
+YMC	Pack ODS-AL	MS:5002004
+YMC	Pack ODS-AM	MS:5002005
+YMC	Pack ODS-AQ	MS:5002006
+YMC	Pack PA-G	MS:5002007
+YMC	Pack PROTEIN-RP	MS:5002008
+YMC	Pack PVA-Sil	MS:5002009
+YMC	Pack Ph	MS:5002010
+YMC	Pack Polyamine II	MS:5002011
+YMC	Pack PolymerC18	MS:5002012
+YMC	Pack Pro C18	MS:5002013
+YMC	Pack Pro C18 RS	MS:5002014
+YMC	Pack Pro C4	MS:5002015
+YMC	Pack Pro C8	MS:5002016
+YMC	Pack SIL-06	MS:5002017
+YMC	Pack TMS	MS:5002018
+YMC	Triart Bio C18	MS:5002452
+YMC	Triart Bio C4	MS:5002453
+YMC	Triart C18	MS:5002454
+YMC	Triart C18 ExRS	MS:5002455
+YMC	Triart C8	MS:5002456
+YMC	Triart Diol-HILIC	MS:5002457
+YMC	Triart PFP	MS:5002458
+YMC	Triart Phenyl	MS:5002459
+YMC	UltraHT Hydrosphere C18	MS:5002506
+YMC	UltraHT Pro C18	MS:5002507
+YMC	YMC Pack SIL	MS:5002749
+YMC	YMCbasic	MS:5002750
+ZirChrom		MS:5000063
+ZirChrom	DiamondBond-C18	MS:5001476
+ZirChrom	ZirChrom-CARB	MS:5002818
+ZirChrom	ZirChrom-EZ	MS:5002819
+ZirChrom	ZirChrom-MS	MS:5002820
+ZirChrom	ZirChrom-NP	MS:5002821
+ZirChrom	ZirChrom-PBD	MS:5002822
+ZirChrom	ZirChrom-PEZ	MS:5002823
+ZirChrom	ZirChrom-PHASE	MS:5002824
+ZirChrom	ZirChrom-PS	MS:5002825
+ZirChrom	ZirChrom-RP	MS:5002826
+ZirChrom	ZirChrom-SAX	MS:5002827
+ZirChrom	ZirChrom-SHAX	MS:5002828
+ZirChrom	ZirChrom-WAX	MS:5002829
+ZirChrom	ZirChrom-WCX	MS:5002830
+Zodiac Life Sciences		MS:5000064
+Zodiac Life Sciences	Zodiac Amino	MS:5002831
+Zodiac Life Sciences	Zodiac C18	MS:5002832
+Zodiac Life Sciences	Zodiac C18(1)	MS:5002833
+Zodiac Life Sciences	Zodiac C18(AQ)	MS:5002834
+Zodiac Life Sciences	Zodiac C8	MS:5002835
+Zodiac Life Sciences	Zodiac C8(1)	MS:5002836
+Zodiac Life Sciences	Zodiac C8(AQ)	MS:5002837
+Zodiac Life Sciences	Zodiac CN	MS:5002838
+Zodiac Life Sciences	Zodiac Phenyl	MS:5002839
+Zodiac Life Sciences	Zodiac Phenyl (1)	MS:5002840
+Zodiac Life Sciences	Zodiac Silica	MS:5002841
+Zodiac Life Sciences	ZodiacSIL 120 C18H	MS:5002842

--- a/.github/workflows/chrom_columns_sync_repo-rt.yml
+++ b/.github/workflows/chrom_columns_sync_repo-rt.yml
@@ -1,0 +1,150 @@
+name: chrom columns – sync from repo-rt
+
+# Polls the upstream repo-rt column database, regenerates psi-ms-columns.obo-fragment with
+# stable term IDs, and opens a PR when anything changed. No PR is opened when the
+# regenerated outputs are identical to the committed ones.
+#
+# Identity and ids live in the .github/repo-rt/psi-ms-column-ids.tsv LEDGER, keyed on
+# (company, column): the generator reads it before minting, keeps a row for every key
+# ever seen (a retired id is never reused; a returning model reclaims its id), and
+# rewrites it alongside the fragment. The fragment carries display labels only.
+#
+# Loop closure is cross-repo: the same ledger is consumed by a repo-rt-side script
+# (add_psi_ms_id.py) that writes the assigned MS:IDs back into the catalog's psi_ms_id
+# column. That back-propagation is a separate repo-rt-repo step, so a newly minted id
+# stays blank in the catalog for one cycle (the generator treats a blank psi_ms_id as
+# a new model, not a drift error).
+
+on:
+  schedule:
+    - cron: "0 6 * * 1"   # weekly, Monday 06:00 UTC
+  workflow_dispatch: {}    # allow manual runs
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: chrom-columns-sync-repo-rt
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        # Pinned so a pandas/fastobo release cannot silently change generated output
+        # or validation behaviour between weekly runs.
+        run: python -m pip install "pandas==3.0.3" "fastobo==0.14.1"
+
+      - name: Download repo-rt column database
+        run: |
+          curl -fsSL --retry 3 --connect-timeout 30 --max-time 300 -o column_database.tsv \
+            https://raw.githubusercontent.com/michaelwitting/RepoRT/master/resources/column_database/column_database.tsv
+
+      - name: Regenerate psi-ms-columns.obo-fragment (stable IDs)
+        # Reads the committed id ledger (.github/repo-rt/psi-ms-column-ids.tsv) first to
+        # preserve existing IDs -- identity is the (company, column) key, so a label
+        # change never moves an id and a retired id is never reused -- then rewrites the
+        # fragment and the ledger; only genuinely new vendors/models mint fresh IDs.
+        # Aborts if the catalog's psi_ms_id mirror disagrees with the ledger.
+        run: |
+          python scripts/chrom_columns/generate_psi_ms_columns.py \
+            --input column_database.tsv \
+            --output psi-ms-columns.obo-fragment \
+            --mapping .github/repo-rt/psi-ms-column-ids.tsv \
+            --report sync-report.md
+
+      - name: Validate generated fragment
+        # fastobo.load + check_sorted do not catch duplicate ids (and the runner has
+        # no fastobo-validator), so assert id uniqueness and mapping consistency too.
+        # The splice proves the fragment still lands cleanly in core and that every
+        # cross-file reference resolves in the file that would actually be released.
+        run: |
+          python -c "import fastobo; fastobo.load('psi-ms-columns.obo-fragment')"
+          python scripts/check_sorted.py psi-ms-columns.obo-fragment
+          python scripts/chrom_columns/check_no_duplicate_ids.py psi-ms-columns.obo-fragment
+          python scripts/chrom_columns/check_column_mapping.py .github/repo-rt/psi-ms-column-ids.tsv psi-ms-columns.obo-fragment
+          python scripts/build_release_obo.py --output /tmp/psi-ms.obo
+          python scripts/check_sorted.py /tmp/psi-ms.obo
+          python scripts/check_aggregate.py /tmp/psi-ms.obo
+
+      - name: Bump data-version and date when the fragment changed
+        # check-version.yml requires psi-ms-core.obo's data-version to exceed master's
+        # on any PR touching it, and the release is stamped from that header, so a sync
+        # that only rewrites the fragment still needs the bump to ship. Computed against
+        # the base checkout, so a PR left open across an unrelated release needs a
+        # rebase (the next weekly run rebuilds the branch from master and clears it).
+        run: |
+          git diff --quiet -- psi-ms-columns.obo-fragment && exit 0
+          CURRENT=$(sed -n 's/^data-version: //p' psi-ms-core.obo | head -1)
+          NEXT=$(echo "$CURRENT" | awk -F. -v OFS=. '{$NF = $NF + 1; print}')
+          sed -i "s/^data-version: .*/data-version: ${NEXT}/" psi-ms-core.obo
+          sed -i "s/^date: .*/date: $(date -u '+%d:%m:%Y %H:%M')/" psi-ms-core.obo
+          echo "data-version bumped ${CURRENT} -> ${NEXT}"
+
+      - name: Build PR body
+        # Compose the PR body from a static intro, the generator's sync report (every
+        # id-ledger change: minted / renames / retired / resurrected, plus data-quality
+        # deviations to fix upstream), and the raw ledger diff, so a reviewer sees all
+        # id movements in the PR body itself without digging through the Actions log.
+        id: prbody
+        run: |
+          {
+            echo "body<<PRBODY_EOF"
+            echo 'Automated regeneration of `psi-ms-columns.obo-fragment` from the upstream'
+            echo '[repo-rt column database](https://github.com/michaelwitting/RepoRT/blob/master/resources/column_database/column_database.tsv).'
+            echo ''
+            echo 'Term identity and IDs live in the id ledger `.github/repo-rt/psi-ms-column-ids.tsv`,'
+            echo 'keyed on (company, column): rows are append-only, a retired ID is never reused,'
+            echo 'and only genuinely new vendors/models mint fresh IDs. **Review the ledger diff'
+            echo 'below alongside the fragment diff before merging** — every ID change is listed there.'
+            echo 'When the fragment changed, `psi-ms-core.obo`s `data-version` is patch-bumped'
+            echo 'and its `date` refreshed in this PR automatically.'
+            echo ''
+            echo '## Sync report'
+            echo ''
+            cat sync-report.md
+            echo ''
+            echo '## Id ledger changes (`.github/repo-rt/psi-ms-column-ids.tsv`)'
+            echo ''
+            if git diff --quiet -- .github/repo-rt/psi-ms-column-ids.tsv; then
+              echo '(unchanged)'
+            else
+              echo '```diff'
+              git diff -- .github/repo-rt/psi-ms-column-ids.tsv | tail -n +5 | head -200
+              echo '```'
+              git diff --stat -- .github/repo-rt/psi-ms-column-ids.tsv | tail -1
+              echo '_(first 200 lines shown; the Files tab has the full diff)_'
+            fi
+            echo 'PRBODY_EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Remove generated scratch files
+        run: rm -f column_database.tsv sync-report.md
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.PSI_MS_CV_GITHUB_TOKEN }}
+          add-paths: |
+            psi-ms-columns.obo-fragment
+            .github/repo-rt/psi-ms-column-ids.tsv
+            psi-ms-core.obo
+          branch: sync/repo-rt-column-models
+          delete-branch: true
+          commit-message: |
+            Sync chromatographic column models from repo-rt
+
+            Co-authored-by: Jonathan Hunter <137391756+jonathan-hunter@users.noreply.github.com>
+            Co-authored-by: Michael Witting <2734706+michaelwitting@users.noreply.github.com>
+          title: "Sync chromatographic column models from repo-rt"
+          body: ${{ steps.prbody.outputs.body }}

--- a/.github/workflows/chrom_columns_sync_repo-rt.yml
+++ b/.github/workflows/chrom_columns_sync_repo-rt.yml
@@ -98,6 +98,19 @@ jobs:
         # id movements in the PR body itself without digging through the Actions log.
         id: prbody
         run: |
+          MAX_LINES=200
+          RUN_LOG='${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+          git diff -- .github/repo-rt/psi-ms-column-ids.tsv | tail -n +5 > ledger.diff
+
+          # Say what was cut, and only when something actually was.
+          note_if_truncated() {   # note_if_truncated <file> <what> <where-to-find-it>
+            total=$(wc -l < "$1")
+            if [ "$total" -gt "$MAX_LINES" ]; then
+              echo ''
+              echo "_($2 truncated: first ${MAX_LINES} of ${total} lines — $3.)_"
+            fi
+          }
+
           {
             echo "body<<PRBODY_EOF"
             echo 'Automated regeneration of `psi-ms-columns.obo-fragment` from the upstream'
@@ -112,7 +125,8 @@ jobs:
             echo ''
             echo '## Sync report'
             echo ''
-            cat sync-report.md
+            head -n "$MAX_LINES" sync-report.md
+            note_if_truncated sync-report.md 'report' "the full report is in the [Actions log]($RUN_LOG)"
             echo ''
             echo '## Id ledger changes (`.github/repo-rt/psi-ms-column-ids.tsv`)'
             echo ''
@@ -120,16 +134,16 @@ jobs:
               echo '(unchanged)'
             else
               echo '```diff'
-              git diff -- .github/repo-rt/psi-ms-column-ids.tsv | tail -n +5 | head -200
+              head -n "$MAX_LINES" ledger.diff
               echo '```'
               git diff --stat -- .github/repo-rt/psi-ms-column-ids.tsv | tail -1
-              echo '_(first 200 lines shown; the Files tab has the full diff)_'
+              note_if_truncated ledger.diff 'diff' 'the Files tab has it in full'
             fi
             echo 'PRBODY_EOF'
           } >> "$GITHUB_OUTPUT"
 
       - name: Remove generated scratch files
-        run: rm -f column_database.tsv sync-report.md
+        run: rm -f column_database.tsv sync-report.md ledger.diff
 
       - name: Create pull request
         uses: peter-evans/create-pull-request@v6

--- a/scripts/check_aggregate.py
+++ b/scripts/check_aggregate.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Fail if the spliced release OBO has unresolved references or unnamed terms.
+
+The two source files cannot be checked for reference integrity on their own:
+psi-ms-columns.obo-fragment deliberately points at core terms (MS:1004011, MS:1003921
+and the separation-mode terms), so a per-file validator sees dangling ids it must
+tolerate. Nothing downstream closes the gap either -- the splice is a text insertion
+that cannot know a target is missing, and obo2owl then declares an unlabelled class,
+so the breakage reaches the release as a term with no name rather than a failed build.
+
+This runs against the spliced psi-ms.obo and asserts what only the merged file can
+prove: every MS:/PEFF: id referenced by a term is defined in the file, and every term
+carries a name. Ids in other namespaces (UO:, PATO:, NCIT:) are imported and are not
+expected to be defined here.
+
+Related but narrower: `generate_psi_ms_columns.py --check-core-refs` checks the same
+cross-file targets by id *and name*, so it also catches a rename -- which resolves
+fine here, leaving only the `! label` comments silently wrong.
+
+Usage:
+    python scripts/check_aggregate.py <merged.obo>
+"""
+import re
+import sys
+
+LOCAL_PREFIXES = ("MS:", "PEFF:")
+# Clauses whose value is a bare term id, and relationship/intersection_of clauses
+# where the id is the last whitespace-separated token before any trailing comment.
+ID_CLAUSE = re.compile(r"^(?:is_a|union_of|disjoint_from): (\S+)")
+TYPED_CLAUSE = re.compile(r"^(?:relationship|intersection_of): \S+ (\S+)")
+
+
+def scan(path):
+    """Return (defined ids, named ids, referenced ids) across [Term] stanzas."""
+    defined, named, refs = set(), set(), set()
+    in_term, current = False, None
+    for line in open(path, encoding="utf-8"):
+        line = line.rstrip("\n")
+        if line.startswith("[") and line.endswith("]"):
+            in_term, current = line == "[Term]", None
+            continue
+        if not in_term:
+            continue
+        if line.startswith("id: "):
+            current = line[4:].strip()
+            defined.add(current)
+        elif line.startswith("name: ") and current:
+            named.add(current)
+        else:
+            m = ID_CLAUSE.match(line) or TYPED_CLAUSE.match(line)
+            if m:
+                refs.add(m.group(1))
+    return defined, named, refs
+
+
+def check(path):
+    defined, named, refs = scan(path)
+    local = {i for i in refs if i.startswith(LOCAL_PREFIXES)}
+    errors = []
+    unresolved = sorted(local - defined)
+    if unresolved:
+        errors.append(f"referenced but not defined: {unresolved[:10]}"
+                      f"{' ...' if len(unresolved) > 10 else ''}")
+    unnamed = sorted(defined - named)
+    if unnamed:
+        errors.append(f"terms without a name: {unnamed[:10]}"
+                      f"{' ...' if len(unnamed) > 10 else ''}")
+    return errors, len(defined), len(local)
+
+
+def self_test():
+    import tempfile
+    good = "[Term]\nid: MS:1\nname: a\n\n[Term]\nid: MS:2\nname: b\nis_a: MS:1\n"
+    bad_ref = good + "\n[Term]\nid: MS:3\nname: c\nrelationship: part_of MS:9\n"
+    unnamed = good + "\n[Term]\nid: MS:4\n"
+    imported = good + "\n[Term]\nid: MS:5\nname: e\nrelationship: has_units UO:7\n"
+    with tempfile.TemporaryDirectory() as d:
+        def run(text):
+            p = f"{d}/t.obo"
+            open(p, "w", encoding="utf-8").write(text)
+            return check(p)[0]
+        assert run(good) == [], run(good)
+        assert "MS:9" in run(bad_ref)[0]
+        assert "MS:4" in run(unnamed)[0]
+        assert run(imported) == [], "imported UO: ids must not be required locally"
+    print("self-test OK")
+    return 0
+
+
+def main(argv):
+    if len(argv) > 1 and argv[1] == "--self-test":
+        return self_test()
+    if len(argv) < 2:
+        print("usage: check_aggregate.py <merged.obo>", file=sys.stderr)
+        return 2
+    errors, terms, refs = check(argv[1])
+    if errors:
+        print(f"ERROR validating {argv[1]}:", file=sys.stderr)
+        for e in errors:
+            print(f"  {e}", file=sys.stderr)
+        return 1
+    print(f"{argv[1]}: {terms} terms, {refs} local references, all resolved and named")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/chrom_columns/check_column_mapping.py
+++ b/scripts/chrom_columns/check_column_mapping.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Validate .github/repo-rt/psi-ms-column-ids.tsv (the id ledger) against the fragment.
+
+The ledger is the sole authority for id assignment -- generate_psi_ms_columns.py reads
+it before minting -- and the cross-repo contract repo-rt joins on to back-propagate
+ids. Rows are append-only: a model that leaves the catalog keeps its row and its id is
+never reused, so the fragment's terms are a SUBSET of the ledger, not equal to it.
+Vendor terms have rows too, with an empty `column` field; vendor and retired rows can
+never match a catalog row (every catalog row has a non-empty column), so they are
+inert to repo-rt's join.
+
+This checks: an exact 3-column header; every data row has three tab-separated fields;
+vendor rows (empty column) carry in-band vendor ids and model rows in-band leaf ids;
+ids and (company, column) keys are unique; and every term id in the fragment has a
+ledger row -- an unledgered term would mean an id was minted outside the ledger.
+
+Usage:
+    python scripts/chrom_columns/check_column_mapping.py <mapping.tsv> <module.obo>
+"""
+import re
+import sys
+from collections import Counter
+
+HEADER = "company\tcolumn\tpsi_ms_id"
+# Must match generate_psi_ms_columns.py's VENDOR_BAND / LEAF_BAND and LEDGER_HEADER.
+# Kept as literals so this checker stays stdlib-only (the generator needs pandas);
+# if the bands or header ever change, update both files together.
+VENDOR_LO, VENDOR_HI = 5000000, 5000999
+LEAF_LO, LEAF_HI = 5001000, 5999999
+ID_RE = re.compile(r"^MS:(\d{7})$")
+
+
+def ids_in_obo(obo_path):
+    """(vendor_ids, leaf_ids, errors) from every `id: MS:` line of the fragment.
+    A malformed id line is reported through errors rather than crashing the run."""
+    vendors, leaves, errors = set(), set(), []
+    for n, line in enumerate(open(obo_path, encoding="utf-8"), start=1):
+        if not line.startswith("id: MS:"):
+            continue
+        m = ID_RE.match(line[len("id: "):].strip())
+        if not m:
+            errors.append(f"{obo_path} line {n}: malformed id line {line.strip()!r}")
+        elif VENDOR_LO <= int(m.group(1)) <= VENDOR_HI:
+            vendors.add(m.group(0))
+        elif LEAF_LO <= int(m.group(1)) <= LEAF_HI:
+            leaves.add(m.group(0))
+        else:
+            errors.append(f"{obo_path} line {n}: id {m.group(0)} outside the vendor/leaf bands")
+    return vendors, leaves, errors
+
+
+def validate(mapping_path, obo_path):
+    errors = []
+    lines = open(mapping_path, encoding="utf-8").read().split("\n")
+    if lines[0] != HEADER:
+        errors.append(f"header must be {HEADER!r}, got {lines[0]!r}")
+    keys, vendor_ids, leaf_ids = [], [], []
+    for n, line in enumerate(lines[1:], start=2):
+        if line == "":
+            continue
+        fields = line.split("\t")
+        if len(fields) != 3:
+            errors.append(f"line {n}: expected 3 tab-separated fields, got {len(fields)}")
+            continue
+        company, column, ms_id = fields
+        keys.append((company, column))
+        lo, hi, kind, bucket = ((VENDOR_LO, VENDOR_HI, "vendor", vendor_ids) if column == ""
+                                else (LEAF_LO, LEAF_HI, "leaf", leaf_ids))
+        m = ID_RE.match(ms_id)
+        if not m or not (lo <= int(m.group(1)) <= hi):
+            errors.append(f"line {n}: psi_ms_id {ms_id!r} is not an in-band {kind} id")
+        else:
+            bucket.append(ms_id)
+    for label, values in (("psi_ms_id", vendor_ids + leaf_ids), ("(company, column) key", keys)):
+        dupes = sorted(str(v) for v, c in Counter(values).items() if c > 1)
+        if dupes:
+            errors.append(f"duplicate {label} values: {dupes[:10]}"
+                          f"{' ...' if len(dupes) > 10 else ''}")
+
+    obo_vendors, obo_leaves, obo_errors = ids_in_obo(obo_path)
+    errors += obo_errors
+    for kind, missing in (("vendor", sorted(obo_vendors - set(vendor_ids))),
+                          ("leaf", sorted(obo_leaves - set(leaf_ids)))):
+        if missing:
+            errors.append(f"{kind} ids in {obo_path} absent from the ledger: {missing[:10]}"
+                          f"{' ...' if len(missing) > 10 else ''}")
+    return errors, len(keys)
+
+
+def main(argv):
+    if len(argv) < 3:
+        print("usage: check_column_mapping.py <mapping.tsv> <module.obo>", file=sys.stderr)
+        return 2
+    errors, count = validate(argv[1], argv[2])
+    if errors:
+        print(f"ERROR validating {argv[1]}:", file=sys.stderr)
+        for e in errors:
+            print(f"  {e}", file=sys.stderr)
+        return 1
+    print(f"{argv[1]}: {count} ledger rows, all valid; every id in {argv[2]} is ledgered")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/chrom_columns/check_no_duplicate_ids.py
+++ b/scripts/chrom_columns/check_no_duplicate_ids.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""Fail if an OBO file contains duplicate term ids.
+
+fastobo.load and check_sorted.py both accept duplicate ids (load does not enforce
+uniqueness; check_sorted only flags strictly-decreasing ids), and the duplicate-aware
+fastobo-validator is not installed on the bare-runner sync job. This stdlib-only check
+closes that gap for the auto-generated psi-ms-columns.obo-fragment before it is opened in a PR.
+
+Usage:
+    python scripts/chrom_columns/check_no_duplicate_ids.py [obo_file]
+"""
+import sys
+from collections import Counter
+
+
+def duplicate_ids(path):
+    ids = [line[len("id: "):].strip() for line in open(path, encoding="utf-8")
+           if line.startswith("id: ")]
+    return sorted(i for i, n in Counter(ids).items() if n > 1), len(ids)
+
+
+def main(argv):
+    path = argv[1] if len(argv) > 1 else "psi-ms-columns.obo-fragment"
+    dupes, total = duplicate_ids(path)
+    if dupes:
+        print(f"ERROR: duplicate ids in {path}: {dupes}", file=sys.stderr)
+        return 1
+    print(f"{path}: {total} ids, no duplicates")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/chrom_columns/generate_psi_ms_columns.py
+++ b/scripts/chrom_columns/generate_psi_ms_columns.py
@@ -1,0 +1,837 @@
+#!/usr/bin/env python3
+"""Generate psi-ms-columns.obo-fragment: model-level chromatographic column terms.
+
+Reads the repo-rt column catalog (a TSV) and writes an OBO *fragment* -- [Term]
+stanzas only, no header and no typedefs -- holding the vendor and model terms in
+the MS:5000000 namespace:
+
+    MS:5000000+  <vendor> chromatographic column model      (one per vendor)
+      MS:5001000+  <product>                                (one per model)
+        is_a <vendor> chromatographic column model
+        is_a MS:1003921 ! liquid chromatographic column
+        relationship: has_separation_mode ...               (when known)
+        property_value: usp_designation "..." xsd:string    (per USP code)
+
+The branch parent (MS:1004011 chromatographic column model) lives in psi-ms-core.obo,
+as do every typedef and the `columns` subsetdef these stanzas use. The fragment is
+deliberately not a standalone OBO document: scripts/build_release_obo.py splices it
+into psi-ms-core.obo to produce the psi-ms.obo release artefact, and a header clause
+appearing mid-file would be a syntax error there.
+
+This generator does not correct or infer data — it only
+verifies the input is valid UTF-8 and well-formed (correct field counts) and aborts
+otherwise. Separation mode is read from the "mode" column and USP designation from
+the "usp" column; each should be identical on every row of a model, so a field is
+emitted only when every row agrees — any within-model disagreement emits nothing for
+that field and is reported for upstream fixing (no majority guess is made).
+
+Every term this fragment references but does not define is listed in
+REQUIRED_CORE_TERMS and checked against psi-ms-core.obo before any output is written
+(also available standalone via --check-core-refs, which CI runs on PRs touching core).
+
+IDs are stable across runs: the committed .github/repo-rt/psi-ms-column-ids.tsv is
+the id LEDGER -- the sole authority binding (company, column) catalog keys to MS
+ids -- and is read back before any id is minted. Identity is the catalog key, never
+the displayed label, so a model gaining or losing a collision suffix (or any other
+label change) keeps its id. The ledger is append-only: a model that leaves the
+catalog keeps its row (its term is dropped from the fragment, but its id is never
+handed to another term) and a model that returns reclaims its original id. Vendor
+terms have ledger rows too, with an empty column field -- inert to repo-rt's join,
+since every real catalog row has a non-empty column.
+
+repo-rt mirrors each assigned id in a "psi_ms_id" catalog column (the ledger is the
+contract its add_psi_ms_id.py joins on to back-propagate ids). When present, the
+mirror is cross-validated against the ledger: a blank cell is a new model; a known
+key whose mirror disagrees aborts the run; a new key whose rows carry the id of a
+key that has left the catalog is a mirror-proven rename, and the id is transferred
+to the new key; a new key carrying any other id (live or never minted) aborts.
+--reset-ids ignores the committed ledger and assigns clean sequential ids (used once
+to mint the initial baseline). --allow-shrink acknowledges an intentional mass
+removal of models; no flag ever moves or reuses an id.
+
+This fragment is versioned by Git and carries no data-version of its own; the release
+version is psi-ms-core.obo's `data-version`, which the splice copies through.
+
+Usage:
+    python scripts/chrom_columns/generate_psi_ms_columns.py \\
+        --input column_database.tsv --output psi-ms-columns.obo-fragment
+    python scripts/chrom_columns/generate_psi_ms_columns.py --check-core-refs
+"""
+
+import argparse
+import csv
+import io
+import os
+import re
+from collections import Counter, defaultdict
+
+import pandas as pd
+
+OUTPUT_DEFAULT = "psi-ms-columns.obo-fragment"
+INPUT_DEFAULT = ".jeh-local/column_database_fixed.tsv"
+MAPPING_DEFAULT = ".github/repo-rt/psi-ms-column-ids.tsv"
+CORE_DEFAULT = "psi-ms-core.obo"
+
+# ID bands within the MS:5000000 namespace (kept separate so the file stays
+# grouped scaffold-then-leaves even as new terms are appended over time).
+# The vendor band opens at MS:5000000: that id previously held the branch parent,
+# which now lives in psi-ms-core.obo as MS:1004011. Id assignment is append-only:
+# retired keys keep their ledger rows, so max(used) covers every id ever minted and
+# a retired id is never handed to a different term. 5000000 is therefore only
+# reachable on a --reset-ids run, not by the next vendor to appear.
+VENDOR_BAND = (5000000, 5000999)
+LEAF_BAND = (5001000, 5999999)
+
+LEDGER_HEADER = "company\tcolumn\tpsi_ms_id"
+
+
+def ms_num(ms_id):
+    return int(ms_id.split(":")[1])
+
+
+# A regenerated catalog retaining fewer than this fraction of the prior model count
+# is treated as a truncated/corrupt download and aborts (guarded in build_columns_obo).
+MIN_RETAIN_FRACTION = 0.5
+
+# Subset carried by every term in this fragment, so consumers can include or exclude the
+# whole column branch. `subsetdef: columns` is declared once, in psi-ms-core.obo -- the
+# fragment has no header to declare it in, and after the splice there is only one document.
+SUBSET = "columns"
+
+# The branch parent, plus every other term these stanzas reference but do not define.
+# All live in psi-ms-core.obo. Checked before writing output (see check_core_refs): a
+# deletion breaks the release, and a rename leaves `! label` comments contradicting the
+# term they point at, which nothing downstream would flag.
+PARENT_ID = "MS:1004011"
+LIQUID_COLUMN = "MS:1003921"
+REQUIRED_CORE_TERMS = {
+    PARENT_ID: "chromatographic column model",
+    LIQUID_COLUMN: "liquid chromatographic column",
+    "MS:1003579": "ion-exchange chromatography",
+    "MS:1003580": "size-exclusion chromatography",
+    "MS:1003582": "reversed phase chromatography",
+    "MS:1003583": "normal phase chromatography",
+    "MS:1003584": "hydrophilic interaction liquid chromatography",
+    "MS:1003586": "mixed mode chromatography",
+}
+
+# Separation-mode key -> (technique term id, label, definition adjective).
+MODE_INFO = {
+    "RP": ("MS:1003582", "reversed phase chromatography", "reversed-phase"),
+    "NP": ("MS:1003583", "normal phase chromatography", "normal-phase"),
+    "HILIC": ("MS:1003584", "hydrophilic interaction liquid chromatography", "HILIC"),
+    "IEX": ("MS:1003579", "ion-exchange chromatography", "ion-exchange"),
+    "SEC": ("MS:1003580", "size-exclusion chromatography", "size-exclusion"),
+    "mixed": ("MS:1003586", "mixed mode chromatography", "mixed-mode"),
+}
+
+# repo-rt "mode" column value -> separation-mode key.
+# "other", "NA" and blank stay unmapped (no has_separation_mode emitted).
+TSV_MODE = {
+    "RP": "RP",
+    "NP": "NP",
+    "HILIC": "HILIC",
+    "IEX": "IEX",
+    "SEC": "SEC",
+    "mixed-Mode": "mixed",
+}
+
+# --- reading the catalog ----------------------------------------------------
+
+REQUIRED_COLUMNS = ("company", "column", "mode", "usp")
+
+
+def clean(text):
+    """Drop control characters that would break an OBO name/def line."""
+    return "".join(ch for ch in text if ch >= " ")
+
+
+def read_catalog(tsv_path):
+    """Load the pre-cleaned repo-rt catalog into a DataFrame, keeping every cell as
+    a literal string. The catalog must be valid UTF-8 (names and USP codes are
+    corrected upstream); a stray non-UTF-8 byte means the input skipped that fix,
+    so we abort rather than silently recover it. na_filter=False keeps 'NA' and
+    blanks as text; fillna covers cells missing from a short row.
+
+    An over-length row (more tab-separated fields than the header) ABORTS the run.
+    A TSV has no quoting, so a tab count is authoritative; pandas would otherwise
+    either treat the surplus field as a row index (silently shifting every column)
+    or drop/truncate the row, and a vanished or shifted model would silently lose its
+    stable id. Short rows are still tolerated (padded by fillna). index_col=False is
+    belt-and-braces against the index-shift heuristic, and quoting=QUOTE_NONE keeps a
+    stray double-quote from merging rows and matches the raw tab-count check above.
+
+    Because QUOTE_NONE does no quote processing, a field an upstream export wrapped in
+    double quotes (the CSV convention for a value containing a comma) keeps those quotes
+    as literal characters. In the identity columns they would leak into term names and
+    — since a quoted name differs from the previously assigned unquoted one — mint fresh
+    ids and churn the mapping, so a wrapped-quote identity field ABORTS the run."""
+    try:
+        text = open(tsv_path, "rb").read().decode("utf-8")
+    except UnicodeDecodeError as e:
+        raise ValueError(
+            f"{tsv_path} is not valid UTF-8 ({e}); the catalog must be pre-cleaned "
+        )
+    lines = text.split("\n")
+    ncols = len(lines[0].split("\t")) if lines and lines[0] else 0
+    overlong = [
+        i
+        for i, ln in enumerate(lines[1:], start=2)
+        if ln != "" and len(ln.split("\t")) > ncols
+    ]
+    if overlong:
+        raise ValueError(
+            f"{tsv_path} has over-length row(s) at line(s) "
+            f"{overlong[:10]}{' ...' if len(overlong) > 10 else ''} "
+            f"(more than {ncols} tab-separated fields); fix the field count upstream "
+            "rather than letting the row be dropped or shifted"
+        )
+    df = pd.read_csv(
+        io.StringIO(text),
+        sep="\t",
+        dtype=str,
+        na_filter=False,
+        index_col=False,
+        quoting=csv.QUOTE_NONE,
+    ).fillna("")
+    missing = [c for c in REQUIRED_COLUMNS if c not in df.columns]
+    if missing:
+        raise ValueError(f"catalog is missing required columns: {missing}")
+    # CSV-quoting guard (see docstring): a proper tab-delimited catalog wraps no field
+    # in quotes. Flag identity cells that arrive wrapped in a matched double-quote pair
+    # so the quoting is stripped upstream rather than silently corrupting names/ids.
+    quoted = sorted(
+        {
+            f"{col}={cell!r}"
+            for col in ("company", "column")
+            for cell in df[col].str.strip()
+            if len(cell) >= 2 and cell.startswith('"') and cell.endswith('"')
+        }
+    )
+    if quoted:
+        raise ValueError(
+            f"{tsv_path} has CSV-quoted identity field(s): "
+            f"{quoted[:10]}{' ...' if len(quoted) > 10 else ''}; a tab-delimited catalog "
+            "must not wrap fields in double quotes (strip the quoting upstream)"
+        )
+    return df
+
+
+def load_models(tsv_path):
+    """Return {(vendor, product): {"modes": Counter, "usps": Counter, "ms_ids": Counter}}.
+
+    A catalog has many rows per model (one per physical size); grouping by
+    (vendor, product) lets resolve_model vote over those rows. USP cells are
+    normalized before counting so representational variants ("L1/L11" vs "L11/L1")
+    aggregate instead of tying.
+
+    product is the model name read straight from the catalog's "column" field (e.g.
+    "ACE C18" for company "Advanced Chromatography Technologies") — the authoritative,
+    vendor-stripped model label. (vendor, product) is the model's identity throughout:
+    the grouping key, the leaf-label base, and the repo-rt mapping join key.
+    """
+    df = read_catalog(tsv_path)
+    # psi_ms_id is an optional mirror column (absent on the first catalog); default to
+    # an all-"" Series so the cross-check simply sees no ids rather than raising on a
+    # KeyError. Both branches yield a Series (never a bare scalar) so the column is a
+    # consistent type for static analysis as well as pandas' scalar broadcasting.
+    if "psi_ms_id" in df.columns:
+        ms_id = df["psi_ms_id"].str.strip()
+    else:
+        ms_id = pd.Series("", index=df.index, dtype=str)
+    # Whitespace is trimmed with the vectorized .str.strip() accessor rather than a
+    # per-element lambda: it is typed to return a string Series, so the callbacks below
+    # never touch .strip() on a cell the checker widens to NAType (read_catalog's
+    # dtype=str/na_filter=False guarantee a real str at runtime regardless).
+    df = df.assign(
+        vendor=df["company"].str.strip().map(clean),
+        product=df["column"].str.strip().map(clean),
+        # "" (not None) for unknown modes / no codes so the columns stay all-string
+        # (a None would become a truthy NaN and slip past the `if` filters below).
+        mode_key=df["mode"].str.strip().map(lambda m: TSV_MODE.get(str(m), "")),
+        usp_canon=df["usp"].map(
+            lambda u: "/".join(sorted(split_usp_codes(u), key=usp_sort_key))
+        ),
+        ms_id=ms_id,
+    )
+    df = df[(df["vendor"] != "") & (df["product"] != "")]
+
+    models = {}
+    for (vendor, product), group in df.groupby(["vendor", "product"], sort=False):
+        models[(vendor, product)] = {
+            "modes": Counter(m for m in group["mode_key"] if m),
+            "usps": Counter(u for u in group["usp_canon"] if u),
+            "ms_ids": Counter(i for i in group["ms_id"] if i),
+        }
+    return models
+
+
+# --- resolving a model's separation mode and USP designation ----------------
+
+
+def split_usp_codes(cell):
+    """Split a raw USP cell into atomic codes, e.g. 'L1/L11' or 'L20, L33'."""
+    codes = [c.strip() for c in re.split(r"[/,]", cell)]
+    return [c for c in codes if c and c != "NA"]
+
+
+def usp_sort_key(code):
+    # Numeric order so L9 sorts before L114 (plain string sort would invert them).
+    digits = re.sub(r"\D", "", code)
+    return int(digits) if digits else 0
+
+
+def resolve_usp(usp_counter):
+    """Resolve a model's USP designation from its per-row cells.
+
+    A column model should carry the same USP code (or combined cell) on every row, so
+    this returns (codes, deviated): when every row agrees, codes is that single value
+    and deviated is False; when the rows disagree at all, there is no trustworthy value
+    so codes is empty and deviated is True, flagging the model for an upstream fix. No
+    majority vote is taken — any inconsistency is surfaced rather than guessed through.
+    """
+    if len(usp_counter) == 1:
+        (value,) = usp_counter
+        return sorted(split_usp_codes(value), key=usp_sort_key), False
+    return [], len(usp_counter) > 1
+
+
+def resolve_mode(mode_counter):
+    """Resolve a model's separation mode from its per-row cells, like resolve_usp.
+
+    Returns (mode_key or None, deviated): a single agreed value is emitted, any
+    disagreement emits nothing and sets deviated for the report, and no-data emits
+    nothing without flagging."""
+    if len(mode_counter) == 1:
+        (value,) = mode_counter
+        return value, False
+    return None, len(mode_counter) > 1
+
+
+def resolve_model(entry):
+    """Resolve a model to (mode, usp_literals, deviations).
+
+    mode          separation-mode key for has_separation_mode, or None.
+    usp_literals  USP codes to emit as usp_designation (empty when unresolved).
+    deviations    {field: {value: count}} for every field (usp, mode) whose rows do
+                  not agree, surfaced in the report so the inconsistency is fixed
+                  upstream. A field whose rows disagree emits nothing (no majority
+                  guess); only a field on which every row agrees is emitted.
+    """
+    codes, usp_deviated = resolve_usp(entry["usps"])
+    mode, mode_deviated = resolve_mode(entry["modes"])
+    deviations = {}
+    if usp_deviated:
+        deviations["usp"] = dict(entry["usps"])
+    if mode_deviated:
+        deviations["mode"] = dict(entry["modes"])
+    return mode, codes, deviations
+
+
+# --- naming ------------------------------------------------------------------
+
+
+def colliding_names(models):
+    """Model names (the catalog "column" field) shared by more than one vendor and so
+    needing vendor disambiguation in the leaf label."""
+    vendors_by_name = defaultdict(set)
+    for vendor, product in models:
+        vendors_by_name[product].add(vendor)
+    return {name for name, vendors in vendors_by_name.items() if len(vendors) > 1}
+
+
+def leaf_label(product, vendor, colliding):
+    """Leaf term label: the model name, suffixed with the vendor only when that name is
+    shared across vendors (so the emitted labels stay unique)."""
+    return f"{product} ({vendor})" if product in colliding else product
+
+
+def with_period(sentence):
+    """End a sentence with a period unless it already does (vendors ending 'Inc.')."""
+    return sentence if sentence.endswith(".") else sentence + "."
+
+
+def escape_def(text):
+    """Escape a value for an OBO quoted def: string (upstream names may contain " or \\)."""
+    return text.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def escape_tag(text):
+    """Escape a value for an unquoted OBO tag line (name:). Backslash is the OBO escape
+    character, so it must be doubled; clean() already removes the newlines/tabs that
+    would otherwise need escaping in an unquoted value. Without this a trailing
+    backslash folds the next line into the name and a mid-string one deletes a char."""
+    return text.replace("\\", "\\\\")
+
+
+def leaf_definition(vendor, mode):
+    if not mode:
+        return with_period(
+            f"A liquid chromatographic column model manufactured by {vendor}"
+        )
+    adjective = MODE_INFO[mode][2]
+    article = "An" if adjective[0].lower() in "aeiou" else "A"
+    return with_period(
+        f"{article} {adjective} liquid chromatographic column model manufactured by {vendor}"
+    )
+
+
+# --- stanza builders (return text, no trailing blank line) ------------------
+
+
+def vendor_stanza(vendor, vendor_id):
+    definition = with_period(f"Chromatographic column model manufactured by {vendor}")
+    lines = [
+        "[Term]",
+        f"id: {vendor_id}",
+        f"name: {escape_tag(vendor)} chromatographic column model",
+        f'def: "{escape_def(definition)}" [PSI:MS]',
+        f"subset: {SUBSET}",
+        f"is_a: {PARENT_ID} ! chromatographic column model",
+    ]
+    return "\n".join(lines)
+
+
+def leaf_stanza(leaf_id, vendor, vendor_id, label, mode, usp_literals):
+    lines = [
+        "[Term]",
+        f"id: {leaf_id}",
+        f"name: {escape_tag(label)}",
+        f'def: "{escape_def(leaf_definition(vendor, mode))}" [PSI:MS]',
+        f"subset: {SUBSET}",
+        f"is_a: {vendor_id} ! {vendor} chromatographic column model",
+        f"is_a: {LIQUID_COLUMN} ! liquid chromatographic column",
+    ]
+    if mode:
+        mode_id, mode_label, _ = MODE_INFO[mode]
+        lines.append(f"relationship: has_separation_mode {mode_id} ! {mode_label}")
+    for code in usp_literals:
+        lines.append(f'property_value: usp_designation "{escape_def(code)}" xsd:string')
+    return "\n".join(lines)
+
+
+# --- cross-file reference check ----------------------------------------------
+
+
+def check_core_refs(core_path):
+    """Verify every REQUIRED_CORE_TERMS id is defined in core under the expected name.
+
+    The fragment references these but cannot define them, and no per-file validator can
+    see the mismatch: the fragment referencing core is legitimate by design. Names are
+    compared as well as ids because a rename is the likelier accident -- the id still
+    resolves after one, so the merged release ships silently wrong `! label` comments.
+
+    Raises ValueError listing every problem, rather than stopping at the first.
+    """
+    names = {}
+    current = None
+    with open(core_path, encoding="utf-8") as fh:
+        for line in fh:
+            if line.startswith("id: "):
+                current = line[len("id: ") :].strip()
+            elif line.startswith("name: ") and current:
+                names[current] = line[len("name: ") :].strip()
+                current = None
+
+    problems = []
+    for term_id, expected in sorted(REQUIRED_CORE_TERMS.items()):
+        actual = names.get(term_id)
+        if actual is None:
+            problems.append(
+                f"{term_id} is not defined in {core_path} (expected {expected!r})"
+            )
+        elif actual != expected:
+            problems.append(
+                f"{term_id} is named {actual!r} in {core_path}, expected {expected!r}"
+            )
+    if problems:
+        raise ValueError(
+            "psi-ms-core.obo no longer provides the terms this fragment references:\n  "
+            + "\n  ".join(problems)
+        )
+    return len(REQUIRED_CORE_TERMS)
+
+
+# --- stable id assignment (the ledger) ---------------------------------------
+
+
+def read_ledger(path):
+    """Read the committed id ledger: {(company, column): "MS:nnnnnnn"}.
+
+    The ledger is the sole authority for id assignment. column == "" marks a vendor
+    row. Rows whose key has left the catalog stay in the ledger permanently, so a
+    retired id is never re-minted and a model that returns reclaims its old id.
+    Identity lives here, not in the fragment: names there are display labels
+    (escaped, collision-suffixed) and are never read back.
+    """
+    if not os.path.exists(path):
+        raise FileNotFoundError(
+            f"{path} not found: the id ledger is required to preserve published ids. "
+            "Pass --reset-ids only to mint a fresh baseline (every id changes)."
+        )
+    ledger, bound = {}, {}
+    with open(path, encoding="utf-8") as fh:
+        lines = fh.read().split("\n")
+    if lines[0] != LEDGER_HEADER:
+        raise ValueError(f"{path}: header must be {LEDGER_HEADER!r}, got {lines[0]!r}")
+    for n, line in enumerate(lines[1:], start=2):
+        if line == "":
+            continue
+        fields = line.split("\t")
+        if len(fields) != 3:
+            raise ValueError(
+                f"{path} line {n}: expected 3 tab-separated fields, got {len(fields)}"
+            )
+        company, column, ms_id = fields
+        if not re.fullmatch(r"MS:\d{7}", ms_id):
+            raise ValueError(f"{path} line {n}: malformed psi_ms_id {ms_id!r}")
+        key = (company, column)
+        if key in ledger:
+            raise ValueError(f"{path} line {n}: duplicate key {key!r}")
+        if ms_id in bound:
+            raise ValueError(
+                f"{path} line {n}: id {ms_id} already bound to {bound[ms_id]!r}"
+            )
+        ledger[key] = ms_id
+        bound[ms_id] = key
+    return ledger
+
+
+def read_fragment_ids(path):
+    """Set of term ids in the previously generated fragment. Liveness only -- which
+    ledger rows had a term last run, for the shrink floor and the retired/resurrected
+    report. Identity never comes from here; a missing fragment just means no
+    liveness info (the ids themselves are safe in the ledger)."""
+    ids = set()
+    if not os.path.exists(path):
+        return ids
+    for line in open(path, encoding="utf-8"):
+        if line.startswith("id: MS:"):
+            ids.add(line[len("id: ") :].strip())
+    return ids
+
+
+def assign_ids(keys, ledger, band):
+    """Assign ids in [lo, hi]: reuse the ledger id for a known key, else the next free
+    id above the highest EVER used in the band -- retired keys keep their ledger rows,
+    so no id ever moves and no retired id is ever reassigned."""
+    lo, hi = band
+    used = [ms_num(i) for i in ledger.values()]
+    used = [n for n in used if lo <= n <= hi]
+    nxt = max(used) + 1 if used else lo
+    result = {}
+    for key in keys:
+        if key in ledger:
+            if not (lo <= ms_num(ledger[key]) <= hi):
+                raise RuntimeError(
+                    f"ledger id {ledger[key]} for {key!r} is outside band {band}"
+                )
+            result[key] = ledger[key]
+        else:
+            if nxt > hi:  # fail loudly rather than mint a colliding out-of-band id
+                raise RuntimeError(f"id band {band} exhausted; widen it")
+            result[key] = f"MS:{nxt}"
+            nxt += 1
+    return result
+
+
+# --- writing -----------------------------------------------------------------
+
+
+def apply_mirror(models, ledger):
+    """Reconcile the catalog's psi_ms_id mirror column with the ledger, BEFORE any id
+    is assigned. Returns (ledger, renames): the ledger with mirror-proven renames
+    rebound, and the (old_key, new_key, id) transfers for the report.
+
+    The ledger is authoritative; the mirror is cross-validation plus the one signal
+    that can prove a rename. Every disagreement is decidable, so nothing is warn-only:
+      - blank cell                        -> new model / not yet back-propagated (ok)
+      - id matches the key's ledger row   -> mirror agrees (ok)
+      - known key, id differs             -> drift, abort
+      - rows of one model disagree        -> corrupt mirror, abort
+      - new key carrying the id of a key that LEFT the catalog
+                                          -> rename: the id transfers to the new key
+      - new key carrying a live term's id -> copy-paste error upstream, abort
+      - new key carrying an id the ledger never minted -> corrupt mirror, abort
+    """
+    by_id = {i: k for k, i in ledger.items()}
+    drift, conflicts, corrupt, renames = [], [], [], []
+    for key, entry in sorted(models.items()):
+        col_ids = set(entry["ms_ids"])
+        if not col_ids:
+            continue
+        if len(col_ids) > 1:
+            conflicts.append((key, sorted(col_ids)))
+            continue
+        (col_id,) = col_ids
+        if key in ledger:
+            if col_id != ledger[key]:
+                drift.append((key, col_id, ledger[key]))
+            continue
+        holder = by_id.get(col_id)
+        if holder is None:
+            corrupt.append((key, col_id, "an id the ledger never minted"))
+        elif holder in models:
+            corrupt.append((key, col_id, f"the id of live model {holder!r}"))
+        elif holder[1] == "":
+            corrupt.append((key, col_id, f"the id of vendor row {holder[0]!r}"))
+        else:  # holder left the catalog and its id rides rows under a new key: a rename
+            del ledger[holder]
+            ledger[key] = col_id
+            by_id[col_id] = key
+            renames.append((holder, key, col_id))
+    if drift or conflicts or corrupt:
+        lines = ["psi_ms_id mirror disagrees with the id ledger (aborting sync):"]
+        lines += [f"  drift: {k!r} mirror={c} ledger={l}" for k, c, l in drift]
+        lines += [
+            f"  conflicting ids within model {k!r}: {ids}" for k, ids in conflicts
+        ]
+        lines += [
+            f"  new key {k!r} carries {why} (mirror={c})" for k, c, why in corrupt
+        ]
+        raise ValueError("\n".join(lines))
+    return ledger, renames
+
+
+def render_ledger(ledger):
+    """Serialize the id ledger: one (company, column, psi_ms_id) row per key, sorted by
+    key so a vendor row (empty column) leads its company block. This one file is both
+    the id authority read back next run and the cross-repo contract repo-rt joins on
+    (its add_psi_ms_id.py must join on the same company + column keys; vendor and
+    retired rows can never match a catalog row, so they are inert to that join).
+    Keys are the cleaned company / column; clean() drops the C0 control chars
+    (including tab and newline), so no value can contain a TSV delimiter and the rows
+    need no quoting."""
+    lines = [LEDGER_HEADER]
+    lines += [f"{c}\t{p}\t{i}" for (c, p), i in sorted(ledger.items())]
+    return "\n".join(lines) + "\n"
+
+
+def build_columns_obo(models, ledger, prior_ids=frozenset(), allow_shrink=False):
+    """Return (obo_text, ledger_text, report). Terms are emitted in id order so the
+    file stays sorted and stable.
+
+    `ledger` is the committed (company, column) -> id map, the sole id authority; it
+    is only ever extended (or rebound by a mirror-proven rename), never rewritten.
+    `prior_ids` are the ids present in the previously generated fragment -- liveness
+    only, feeding the shrink floor and the retired/resurrected report sections."""
+    if not models:
+        raise ValueError(
+            "catalog produced 0 column models; refusing to write an empty module"
+        )
+    prior_leaves = sum(
+        1 for i in prior_ids if LEAF_BAND[0] <= ms_num(i) <= LEAF_BAND[1]
+    )
+    if (
+        prior_leaves
+        and len(models) < prior_leaves * MIN_RETAIN_FRACTION
+        and not allow_shrink
+    ):
+        raise ValueError(
+            f"catalog shrank from {prior_leaves} to {len(models)} models "
+            f"(<{MIN_RETAIN_FRACTION:.0%} retained); aborting as a likely truncated "
+            "download. Re-run with --allow-shrink if the drop is intentional (no id "
+            "moves: the vanished models keep their ledger rows)."
+        )
+
+    ledger, renames = apply_mirror(models, dict(ledger))
+
+    colliding = colliding_names(models)
+    vendors = sorted({vendor for vendor, _ in models})
+    vendor_assign = assign_ids([(v, "") for v in vendors], ledger, VENDOR_BAND)
+    vendor_id = {v: vendor_assign[(v, "")] for v in vendors}
+
+    labels = {(v, p): leaf_label(p, v, colliding) for v, p in models}
+    # Each emitted leaf needs a unique label. leaf_label only disambiguates names
+    # shared ACROSS vendors, so guard against two products of one vendor reducing to
+    # the same label (e.g. an upstream whitespace variant), which would otherwise emit
+    # duplicate OBO terms. Fail loudly to fix upstream. (Labels are display-only:
+    # identity and ids key on (company, column), so a label change never moves an id.)
+    dupes = sorted(lbl for lbl, n in Counter(labels.values()).items() if n > 1)
+    if dupes:
+        raise ValueError(
+            f"non-unique leaf labels (fix in the upstream catalog): {dupes}"
+        )
+    leaf_ids = assign_ids(sorted(models), ledger, LEAF_BAND)
+
+    new_ledger = {**ledger, **vendor_assign, **leaf_ids}
+    # Defence in depth: read_ledger and assign_ids keep ids unique by construction,
+    # but refuse to emit a duplicate-id module rather than ship one in an auto-PR.
+    dup_ids = sorted(i for i, n in Counter(new_ledger.values()).items() if n > 1)
+    if dup_ids:
+        raise ValueError(f"duplicate ids generated (corrupt id ledger?): {dup_ids}")
+
+    current = set(vendor_assign) | set(leaf_ids)
+    report = {
+        "deviations": [],
+        "renames": renames,
+        "minted": sorted((k, new_ledger[k]) for k in current if k not in ledger),
+        # retired/resurrected need prior liveness: a ledger row is newly retired when
+        # its term was in the last fragment but its key has no catalog model now, and
+        # resurrected when the reverse holds. Without a prior fragment both are empty.
+        "retired": sorted(
+            (k, i) for k, i in ledger.items() if k not in current and i in prior_ids
+        ),
+        "resurrected": sorted(
+            (k, ledger[k])
+            for k in current
+            if k in ledger and prior_ids and ledger[k] not in prior_ids
+        ),
+    }
+
+    stanzas = []
+    for vendor in vendors:
+        vid = vendor_id[vendor]
+        stanzas.append((ms_num(vid), vendor_stanza(vendor, vid)))
+
+    for (vendor, product), entry in models.items():
+        mode, usp_literals, deviations = resolve_model(entry)
+        lid = leaf_ids[(vendor, product)]
+        stanzas.append(
+            (
+                ms_num(lid),
+                leaf_stanza(
+                    lid,
+                    vendor,
+                    vendor_id[vendor],
+                    labels[(vendor, product)],
+                    mode,
+                    usp_literals,
+                ),
+            )
+        )
+        if (
+            deviations
+        ):  # rows of this model disagree on usp/mode — flag for upstream fix
+            report["deviations"].append((product, deviations))
+
+    stanzas.sort(key=lambda pair: pair[0])
+    body_block = "\n\n".join(text for _, text in stanzas) + "\n"
+    return body_block, render_ledger(new_ledger), report
+
+
+def report_markdown(models, report):
+    """Markdown sync summary, printed to the Actions log and pasted into the PR body:
+    every id-ledger change (minted / renames / retired / resurrected) plus the
+    within-model data-quality deviations. One renderer so log and PR cannot drift."""
+
+    def key_str(key):
+        company, column = key
+        return f"{company} / {column}" if column else f"{company} (vendor)"
+
+    lines = [
+        f"- vendors: {len({v for v, _ in models})}",
+        f"- models: {len(models)}",
+        "",
+    ]
+    if report["minted"]:
+        lines.append(f"### New ids minted — {len(report['minted'])}")
+        lines += [f"- `{key_str(k)}` → {i}" for k, i in report["minted"]]
+        lines.append("")
+    if report["renames"]:
+        lines.append(
+            f"### Renames (id transferred, proven by the psi_ms_id mirror) — {len(report['renames'])}"
+        )
+        lines += [
+            f"- `{key_str(old)}` → `{key_str(new)}` (keeps {i})"
+            for old, new, i in report["renames"]
+        ]
+        lines.append("")
+    if report["retired"]:
+        lines.append(
+            f"### Retired (left the catalog; ledger row and id preserved) — {len(report['retired'])}"
+        )
+        lines.append(
+            "_Policy: columns are annotation targets in perpetuity and should not "
+            "leave repo-rt except error additions — before merging, check whether "
+            "these upstream deletions should instead be restored in repo-rt._"
+        )
+        lines += [f"- `{key_str(k)}` ({i})" for k, i in report["retired"]]
+        lines.append("")
+    if report["resurrected"]:
+        lines.append(
+            f"### Resurrected (returned to the catalog; original id restored) — {len(report['resurrected'])}"
+        )
+        lines += [f"- `{key_str(k)}` ({i})" for k, i in report["resurrected"]]
+        lines.append("")
+    if report["deviations"]:
+        lines.append(
+            f"### Within-model value deviations (fix upstream) — {len(report['deviations'])}"
+        )
+        for product, dev in report["deviations"]:
+            for field, counts in dev.items():
+                lines.append(f"- `{product}` — {field}={counts}")
+        lines.append("")
+    if len(lines) == 3:
+        lines.append("No id changes or within-model deviations.")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--input", default=INPUT_DEFAULT, help="repo-rt column TSV")
+    parser.add_argument("--output", default=OUTPUT_DEFAULT, help="OBO module to write")
+    parser.add_argument(
+        "--mapping",
+        default=MAPPING_DEFAULT,
+        help="the id ledger: company/column -> psi_ms_id TSV, read before "
+        "minting and rewritten (also the repo-rt back-prop contract)",
+    )
+    parser.add_argument(
+        "--reset-ids",
+        action="store_true",
+        help="ignore the committed id ledger and assign clean sequential ids",
+    )
+    parser.add_argument(
+        "--allow-shrink",
+        action="store_true",
+        help="accept a large drop in model count (no id is moved or reused)",
+    )
+    parser.add_argument(
+        "--report", help="write a Markdown data-quality summary to this path"
+    )
+    parser.add_argument(
+        "--core",
+        default=CORE_DEFAULT,
+        help="psi-ms-core.obo, checked for the terms this fragment references",
+    )
+    parser.add_argument(
+        "--check-core-refs",
+        action="store_true",
+        help="only verify --core provides REQUIRED_CORE_TERMS, then exit",
+    )
+    args = parser.parse_args()
+
+    if args.check_core_refs:
+        n = check_core_refs(args.core)
+        print(f"{args.core}: all {n} referenced terms present with expected names")
+        return
+
+    check_core_refs(args.core)
+    models = load_models(args.input)
+    ledger = (
+        {} if args.reset_ids else read_ledger(args.mapping)
+    )  # read before we overwrite it
+    prior_ids = read_fragment_ids(
+        args.output
+    )  # liveness only; identity is the ledger's
+    obo_text, ledger_text, report = build_columns_obo(
+        models, ledger, prior_ids, allow_shrink=args.allow_shrink
+    )
+    open(args.output, "w", encoding="utf-8").write(obo_text)
+    print(f"wrote {args.output}")
+
+    if os.path.dirname(args.mapping):
+        os.makedirs(os.path.dirname(args.mapping), exist_ok=True)
+    open(args.mapping, "w", encoding="utf-8").write(ledger_text)
+    print(f"wrote {args.mapping}")
+
+    text = report_markdown(models, report)
+    if args.report:
+        open(args.report, "w", encoding="utf-8").write(text)
+        print(f"wrote {args.report}")
+    print(text, end="")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/chrom_columns/generate_psi_ms_columns.py
+++ b/scripts/chrom_columns/generate_psi_ms_columns.py
@@ -35,19 +35,23 @@ ids -- and is read back before any id is minted. Identity is the catalog key, ne
 the displayed label, so a model gaining or losing a collision suffix (or any other
 label change) keeps its id. The ledger is append-only: a model that leaves the
 catalog keeps its row (its term is dropped from the fragment, but its id is never
-handed to another term) and a model that returns reclaims its original id. Vendor
-terms have ledger rows too, with an empty column field -- inert to repo-rt's join,
-since every real catalog row has a non-empty column.
+handed to another term) and a model that returns under the same key reclaims its
+original id. Vendor terms have ledger rows too, with an empty column field -- inert
+to repo-rt's join, since every real catalog row has a non-empty column.
 
 repo-rt mirrors each assigned id in a "psi_ms_id" catalog column (the ledger is the
 contract its add_psi_ms_id.py joins on to back-propagate ids). When present, the
 mirror is cross-validated against the ledger: a blank cell is a new model; a known
 key whose mirror disagrees aborts the run; a new key whose rows carry the id of a
 key that has left the catalog is a mirror-proven rename, and the id is transferred
-to the new key; a new key carrying any other id (live or never minted) aborts.
+to the new key; a new key carrying any other id (live or never minted) aborts. A
+rename consumes the old key's ledger row, so -- unlike a retirement -- reverting one
+upstream mints a second id for the same physical column.
 --reset-ids ignores the committed ledger and assigns clean sequential ids (used once
-to mint the initial baseline). --allow-shrink acknowledges an intentional mass
-removal of models; no flag ever moves or reuses an id.
+to mint the initial baseline; the mirror cross-check is skipped, having nothing to
+reconcile against). --allow-shrink acknowledges an intentional mass removal of
+models; --dry-run prints the report without writing either file. No flag ever moves
+or reuses an id.
 
 This fragment is versioned by Git and carries no data-version of its own; the release
 version is psi-ms-core.obo's `data-version`, which the splice copies through.
@@ -63,7 +67,9 @@ import csv
 import io
 import os
 import re
+import sys
 from collections import Counter, defaultdict
+from pathlib import Path
 
 import pandas as pd
 
@@ -98,23 +104,6 @@ MIN_RETAIN_FRACTION = 0.5
 # fragment has no header to declare it in, and after the splice there is only one document.
 SUBSET = "columns"
 
-# The branch parent, plus every other term these stanzas reference but do not define.
-# All live in psi-ms-core.obo. Checked before writing output (see check_core_refs): a
-# deletion breaks the release, and a rename leaves `! label` comments contradicting the
-# term they point at, which nothing downstream would flag.
-PARENT_ID = "MS:1004011"
-LIQUID_COLUMN = "MS:1003921"
-REQUIRED_CORE_TERMS = {
-    PARENT_ID: "chromatographic column model",
-    LIQUID_COLUMN: "liquid chromatographic column",
-    "MS:1003579": "ion-exchange chromatography",
-    "MS:1003580": "size-exclusion chromatography",
-    "MS:1003582": "reversed phase chromatography",
-    "MS:1003583": "normal phase chromatography",
-    "MS:1003584": "hydrophilic interaction liquid chromatography",
-    "MS:1003586": "mixed mode chromatography",
-}
-
 # Separation-mode key -> (technique term id, label, definition adjective).
 MODE_INFO = {
     "RP": ("MS:1003582", "reversed phase chromatography", "reversed-phase"),
@@ -125,8 +114,25 @@ MODE_INFO = {
     "mixed": ("MS:1003586", "mixed mode chromatography", "mixed-mode"),
 }
 
+# The branch parent, plus every other term these stanzas reference but do not define.
+# All live in psi-ms-core.obo. Checked before writing output (see check_core_refs): a
+# deletion breaks the release, and a rename leaves `! label` comments contradicting the
+# term they point at, which nothing downstream would flag.
+# The technique terms are derived from MODE_INFO rather than repeated, so a mode added
+# there cannot be left unchecked here.
+PARENT_ID = "MS:1004011"
+LIQUID_COLUMN = "MS:1003921"
+REQUIRED_CORE_TERMS = {
+    PARENT_ID: "chromatographic column model",
+    LIQUID_COLUMN: "liquid chromatographic column",
+    **{term_id: label for term_id, label, _ in MODE_INFO.values()},
+}
+
+# The typedefs the leaf stanzas use. Also core's, also unresolvable from this file
+# alone, and likelier than a term to be dropped unnoticed in a core edit.
+REQUIRED_CORE_TYPEDEFS = ("has_separation_mode", "usp_designation")
+
 # repo-rt "mode" column value -> separation-mode key.
-# "other", "NA" and blank stay unmapped (no has_separation_mode emitted).
 TSV_MODE = {
     "RP": "RP",
     "NP": "NP",
@@ -136,14 +142,39 @@ TSV_MODE = {
     "mixed-Mode": "mixed",
 }
 
+# Cells that legitimately carry no separation mode (compared casefolded). Any OTHER
+# unmapped value is upstream vocabulary drift -- a single casing change would strip
+# has_separation_mode from every affected term -- so it is counted and reported rather
+# than silently treated as "no mode".
+NON_MODES = {"", "na", "n/a", "other", "unknown"}
+
 # --- reading the catalog ----------------------------------------------------
 
 REQUIRED_COLUMNS = ("company", "column", "mode", "usp")
 
 
+# Invisible characters folded away by clean(). They are indistinguishable from a plain
+# space (or from nothing) in a rendered term label but distinct to ==, so two catalog
+# rows differing only by one would form two identity keys, mint two ids and emit two
+# terms with identical-looking names -- which the duplicate-label guard cannot see
+# either, because the strings genuinely differ.
+INVISIBLE = str.maketrans(
+    {
+        "\u00a0": " ",  # no-break space
+        "\u200b": "",  # zero-width space
+        "\u200c": "",  # zero-width non-joiner
+        "\u200d": "",  # zero-width joiner
+        "\u2060": "",  # word joiner
+        "\ufeff": "",  # zero-width no-break space / BOM
+    }
+)
+
+
 def clean(text):
-    """Drop control characters that would break an OBO name/def line."""
-    return "".join(ch for ch in text if ch >= " ")
+    """Normalize a catalog cell for use as an OBO name/def value and as an identity key:
+    drop control characters, fold invisible/non-breaking characters, collapse whitespace."""
+    text = "".join(ch for ch in text if ch >= " " and ch != "\x7f")
+    return re.sub(r"\s+", " ", text.translate(INVISIBLE)).strip()
 
 
 def read_catalog(tsv_path):
@@ -165,15 +196,20 @@ def read_catalog(tsv_path):
     double quotes (the CSV convention for a value containing a comma) keeps those quotes
     as literal characters. In the identity columns they would leak into term names and
     — since a quoted name differs from the previously assigned unquoted one — mint fresh
-    ids and churn the mapping, so a wrapped-quote identity field ABORTS the run."""
+    ids and churn the mapping; in the value columns they corrupt the emitted annotation
+    instead (a `usp` cell of '"L1, L11"' yields the codes '"L1' and 'L11"'). Either way
+    the file is not the tab-delimited catalog this reads, so a wrapped-quote cell in any
+    required column ABORTS the run."""
     try:
-        text = open(tsv_path, "rb").read().decode("utf-8")
+        text = Path(tsv_path).read_bytes().decode("utf-8")
     except UnicodeDecodeError as e:
         raise ValueError(
             f"{tsv_path} is not valid UTF-8 ({e}); the catalog must be pre-cleaned "
         )
     lines = text.split("\n")
     ncols = len(lines[0].split("\t")) if lines and lines[0] else 0
+    if ncols == 0:
+        raise ValueError(f"{tsv_path} is empty or has no header row")
     overlong = [
         i
         for i, ln in enumerate(lines[1:], start=2)
@@ -198,19 +234,20 @@ def read_catalog(tsv_path):
     if missing:
         raise ValueError(f"catalog is missing required columns: {missing}")
     # CSV-quoting guard (see docstring): a proper tab-delimited catalog wraps no field
-    # in quotes. Flag identity cells that arrive wrapped in a matched double-quote pair
-    # so the quoting is stripped upstream rather than silently corrupting names/ids.
+    # in quotes. Flag any required cell that arrives wrapped in a matched double-quote
+    # pair so the quoting is stripped upstream rather than silently corrupting the
+    # names and ids (company/column) or the emitted annotations (mode/usp).
     quoted = sorted(
         {
             f"{col}={cell!r}"
-            for col in ("company", "column")
+            for col in REQUIRED_COLUMNS
             for cell in df[col].str.strip()
             if len(cell) >= 2 and cell.startswith('"') and cell.endswith('"')
         }
     )
     if quoted:
         raise ValueError(
-            f"{tsv_path} has CSV-quoted identity field(s): "
+            f"{tsv_path} has CSV-quoted field(s): "
             f"{quoted[:10]}{' ...' if len(quoted) > 10 else ''}; a tab-delimited catalog "
             "must not wrap fields in double quotes (strip the quoting upstream)"
         )
@@ -218,7 +255,13 @@ def read_catalog(tsv_path):
 
 
 def load_models(tsv_path):
-    """Return {(vendor, product): {"modes": Counter, "usps": Counter, "ms_ids": Counter}}.
+    """Return (models, notes).
+
+    models  {(vendor, product): {"modes": Counter, "usps": Counter, "ms_ids": Counter}}
+    notes   input-quality counts for the report: rows dropped for a blank identity cell,
+            unmapped `mode` values, and `usp` tokens that are not USP packing codes.
+            All three are silent data loss otherwise -- the affected terms simply come
+            out missing a field -- so they are surfaced with the id changes.
 
     A catalog has many rows per model (one per physical size); grouping by
     (vendor, product) lets resolve_model vote over those rows. USP cells are
@@ -248,37 +291,80 @@ def load_models(tsv_path):
         product=df["column"].str.strip().map(clean),
         # "" (not None) for unknown modes / no codes so the columns stay all-string
         # (a None would become a truthy NaN and slip past the `if` filters below).
-        mode_key=df["mode"].str.strip().map(lambda m: TSV_MODE.get(str(m), "")),
+        mode_raw=df["mode"].str.strip(),
+        mode_key=df["mode"].str.strip().map(lambda m: TSV_MODE.get(m, "")),
         usp_canon=df["usp"].map(
             lambda u: "/".join(sorted(split_usp_codes(u), key=usp_sort_key))
         ),
         ms_id=ms_id,
     )
-    df = df[(df["vendor"] != "") & (df["product"] != "")]
+    named = df[(df["vendor"] != "") & (df["product"] != "")]
+
+    notes = {
+        "dropped_rows": len(df) - len(named),
+        "unmapped_modes": Counter(
+            raw
+            for raw, key in zip(named["mode_raw"], named["mode_key"])
+            if not key and raw.casefold() not in NON_MODES
+        ),
+        "rejected_usp": Counter(
+            token for cell in named["usp"] for token in usp_tokens(cell)[1]
+        ),
+    }
 
     models = {}
-    for (vendor, product), group in df.groupby(["vendor", "product"], sort=False):
+    for (vendor, product), group in named.groupby(["vendor", "product"], sort=False):
         models[(vendor, product)] = {
             "modes": Counter(m for m in group["mode_key"] if m),
             "usps": Counter(u for u in group["usp_canon"] if u),
             "ms_ids": Counter(i for i in group["ms_id"] if i),
         }
-    return models
+    return models, notes
 
 
 # --- resolving a model's separation mode and USP designation ----------------
 
 
+# Whole-cell "no value" spellings (compared casefolded), recognised BEFORE the cell is
+# split: 'N/A' shares its separator with a real multi-code cell, so splitting first would
+# turn it into the codes 'N' and 'A'. A USP packing code is a letter class plus a number.
+USP_PLACEHOLDERS = {"", "na", "n/a", "n.a.", "n.d.", "nd", "-", "--", "none", "null",
+                    "unknown", "?"}
+USP_CODE = re.compile(r"[LGS]\d{1,3}")
+
+
+def usp_tokens(cell):
+    """Split a raw USP cell into (codes, rejected), e.g. 'L1/L11' or 'L20, L33'.
+
+    A placeholder cell yields nothing and rejects nothing. Every other token must be a
+    USP packing code: these become permanent annotations on a published term, so an
+    unrecognised one is rejected and reported for upstream fixing rather than emitted."""
+    if cell.strip().casefold() in USP_PLACEHOLDERS:
+        return [], []
+    codes, rejected = [], []
+    for token in re.split(r"[/,;]", cell):
+        token = token.strip()
+        if not token:
+            continue
+        if USP_CODE.fullmatch(token.upper()):
+            codes.append(token.upper())
+        else:
+            rejected.append(token)
+    return codes, rejected
+
+
 def split_usp_codes(cell):
-    """Split a raw USP cell into atomic codes, e.g. 'L1/L11' or 'L20, L33'."""
-    codes = [c.strip() for c in re.split(r"[/,]", cell)]
-    return [c for c in codes if c and c != "NA"]
+    """The emittable codes of a raw USP cell (see usp_tokens)."""
+    return usp_tokens(cell)[0]
 
 
 def usp_sort_key(code):
-    # Numeric order so L9 sorts before L114 (plain string sort would invert them).
+    # Numeric order so L9 sorts before L114 (plain string sort would invert them), then
+    # the code itself so that L1/S1 and S1/L1 canonicalise to the same string: on the
+    # number alone they tie, Python's stable sort keeps input order, and one model's rows
+    # would read as two different values and be reported as a deviation.
     digits = re.sub(r"\D", "", code)
-    return int(digits) if digits else 0
+    return int(digits) if digits else 0, code
 
 
 def resolve_usp(usp_counter):
@@ -357,11 +443,16 @@ def escape_def(text):
 
 
 def escape_tag(text):
-    """Escape a value for an unquoted OBO tag line (name:). Backslash is the OBO escape
-    character, so it must be doubled; clean() already removes the newlines/tabs that
-    would otherwise need escaping in an unquoted value. Without this a trailing
-    backslash folds the next line into the name and a mid-string one deletes a char."""
-    return text.replace("\\", "\\\\")
+    """Escape a value for an unquoted OBO tag line (name:). Three characters are
+    structural in an unquoted value and each silently truncates or mangles the name:
+    backslash is the escape character (a trailing one folds the next line into the name,
+    a mid-string one deletes a character), `!` starts a comment the parser discards to
+    end of line, and `{`/`}` open a trailing-modifier block. clean() already removes the
+    newlines and tabs that would also need escaping. Backslash is doubled first, so the
+    escapes introduced below are not themselves escaped."""
+    for char in "\\", "!", "{", "}":
+        text = text.replace(char, "\\" + char)
+    return text
 
 
 def leaf_definition(vendor, mode):
@@ -414,28 +505,49 @@ def leaf_stanza(leaf_id, vendor, vendor_id, label, mode, usp_literals):
 
 
 def check_core_refs(core_path):
-    """Verify every REQUIRED_CORE_TERMS id is defined in core under the expected name.
+    """Verify core still provides every term and typedef the fragment references.
 
     The fragment references these but cannot define them, and no per-file validator can
-    see the mismatch: the fragment referencing core is legitimate by design. Names are
-    compared as well as ids because a rename is the likelier accident -- the id still
-    resolves after one, so the merged release ships silently wrong `! label` comments.
+    see the mismatch: the fragment referencing core is legitimate by design. Terms are
+    checked by name as well as id because a rename is the likelier accident -- the id
+    still resolves after one, so the merged release ships silently wrong `! label`
+    comments -- and obsoletion is likelier still in a CV maintained over years, leaving
+    the release pointing live axioms at a deprecated term.
 
     Raises ValueError listing every problem, rather than stopping at the first.
     """
-    names = {}
-    current = None
+    terms, typedefs, obsolete, replaced_by = {}, {}, set(), {}
+    table, current = None, None
     with open(core_path, encoding="utf-8") as fh:
         for line in fh:
-            if line.startswith("id: "):
-                current = line[len("id: ") :].strip()
-            elif line.startswith("name: ") and current:
-                names[current] = line[len("name: ") :].strip()
+            line = line.rstrip("\n")
+            if line.startswith("["):
+                table = {"[Term]": terms, "[Typedef]": typedefs}.get(line.strip())
                 current = None
+            elif table is None:  # header clauses, before the first stanza
+                continue
+            elif line.startswith("id: ") and current is None:
+                current = line[len("id: ") :].strip()
+            elif not current:
+                continue
+            elif line.startswith("name: "):
+                table[current] = line[len("name: ") :].strip()
+            elif line.startswith("is_obsolete: true"):
+                obsolete.add(current)
+            elif line.startswith("replaced_by: "):
+                replaced_by[current] = line[len("replaced_by: ") :].strip()
+
+    def obsolete_note(ref_id):
+        successor = replaced_by.get(ref_id)
+        return f"{ref_id} is obsolete in {core_path}" + (
+            f" (replaced_by {successor}; point the fragment at it)"
+            if successor
+            else " and has no replaced_by"
+        )
 
     problems = []
     for term_id, expected in sorted(REQUIRED_CORE_TERMS.items()):
-        actual = names.get(term_id)
+        actual = terms.get(term_id)
         if actual is None:
             problems.append(
                 f"{term_id} is not defined in {core_path} (expected {expected!r})"
@@ -444,25 +556,38 @@ def check_core_refs(core_path):
             problems.append(
                 f"{term_id} is named {actual!r} in {core_path}, expected {expected!r}"
             )
+        elif term_id in obsolete:
+            problems.append(obsolete_note(term_id))
+    for typedef_id in sorted(REQUIRED_CORE_TYPEDEFS):
+        if typedef_id not in typedefs:
+            problems.append(f"typedef {typedef_id} is not declared in {core_path}")
+        elif typedef_id in obsolete:
+            problems.append(obsolete_note(typedef_id))
     if problems:
         raise ValueError(
-            "psi-ms-core.obo no longer provides the terms this fragment references:\n  "
+            f"{core_path} no longer provides what this fragment references:\n  "
             + "\n  ".join(problems)
         )
-    return len(REQUIRED_CORE_TERMS)
+    return len(REQUIRED_CORE_TERMS) + len(REQUIRED_CORE_TYPEDEFS)
 
 
 # --- stable id assignment (the ledger) ---------------------------------------
 
 
-def read_ledger(path):
+def read_ledger(path: str) -> dict[tuple[str, str], str]:
     """Read the committed id ledger: {(company, column): "MS:nnnnnnn"}.
 
     The ledger is the sole authority for id assignment. column == "" marks a vendor
     row. Rows whose key has left the catalog stay in the ledger permanently, so a
-    retired id is never re-minted and a model that returns reclaims its old id.
-    Identity lives here, not in the fragment: names there are display labels
+    retired id is never re-minted and a model that returns under the same key reclaims
+    its old id. Identity lives here, not in the fragment: names there are display labels
     (escaped, collision-suffixed) and are never read back.
+
+    ponytail: a mirror-proven rename CONSUMES the old key's row (apply_mirror rebinds
+    it), so a rename reverted upstream mints a second id for the same physical column.
+    Retiring the old key instead needs a fourth ledger field, which is the cross-repo
+    contract repo-rt's add_psi_ms_id.py joins on -- add it there and here together, on
+    evidence that renames actually get reverted.
     """
     if not os.path.exists(path):
         raise FileNotFoundError(
@@ -470,8 +595,7 @@ def read_ledger(path):
             "Pass --reset-ids only to mint a fresh baseline (every id changes)."
         )
     ledger, bound = {}, {}
-    with open(path, encoding="utf-8") as fh:
-        lines = fh.read().split("\n")
+    lines = Path(path).read_text(encoding="utf-8").split("\n")
     if lines[0] != LEDGER_HEADER:
         raise ValueError(f"{path}: header must be {LEDGER_HEADER!r}, got {lines[0]!r}")
     for n, line in enumerate(lines[1:], start=2):
@@ -497,21 +621,23 @@ def read_ledger(path):
     return ledger
 
 
-def read_fragment_ids(path):
+def read_fragment_ids(path: str) -> set[str]:
     """Set of term ids in the previously generated fragment. Liveness only -- which
     ledger rows had a term last run, for the shrink floor and the retired/resurrected
     report. Identity never comes from here; a missing fragment just means no
     liveness info (the ids themselves are safe in the ledger)."""
-    ids = set()
     if not os.path.exists(path):
-        return ids
-    for line in open(path, encoding="utf-8"):
-        if line.startswith("id: MS:"):
-            ids.add(line[len("id: ") :].strip())
-    return ids
+        return set()
+    return {
+        line[len("id: ") :].strip()
+        for line in Path(path).read_text(encoding="utf-8").splitlines()
+        if line.startswith("id: MS:")
+    }
 
 
-def assign_ids(keys, ledger, band):
+def assign_ids(
+    keys, ledger: dict[tuple[str, str], str], band: tuple[int, int]
+) -> dict[tuple[str, str], str]:
     """Assign ids in [lo, hi]: reuse the ledger id for a known key, else the next free
     id above the highest EVER used in the band -- retired keys keep their ledger rows,
     so no id ever moves and no retired id is ever reassigned."""
@@ -538,7 +664,7 @@ def assign_ids(keys, ledger, band):
 # --- writing -----------------------------------------------------------------
 
 
-def apply_mirror(models, ledger):
+def apply_mirror(models, ledger: dict[tuple[str, str], str]):
     """Reconcile the catalog's psi_ms_id mirror column with the ledger, BEFORE any id
     is assigned. Returns (ledger, renames): the ledger with mirror-proven renames
     rebound, and the (old_key, new_key, id) transfers for the report.
@@ -622,6 +748,11 @@ def build_columns_obo(models, ledger, prior_ids=frozenset(), allow_shrink=False)
     prior_leaves = sum(
         1 for i in prior_ids if LEAF_BAND[0] <= ms_num(i) <= LEAF_BAND[1]
     )
+    if not prior_leaves:
+        print(
+            "no previously generated fragment: the "
+            f"{MIN_RETAIN_FRACTION:.0%} shrink floor is not enforced on this run"
+        )
     if (
         prior_leaves
         and len(models) < prior_leaves * MIN_RETAIN_FRACTION
@@ -634,7 +765,11 @@ def build_columns_obo(models, ledger, prior_ids=frozenset(), allow_shrink=False)
             "moves: the vanished models keep their ledger rows)."
         )
 
-    ledger, renames = apply_mirror(models, dict(ledger))
+    # An empty ledger (a --reset-ids baseline) has nothing to reconcile against: every
+    # model would look like "a new key carrying an id the ledger never minted" and abort
+    # the very run the flag exists for.
+    ledger = dict(ledger)
+    ledger, renames = apply_mirror(models, ledger) if ledger else (ledger, [])
 
     colliding = colliding_names(models)
     vendors = sorted({vendor for vendor, _ in models})
@@ -703,7 +838,9 @@ def build_columns_obo(models, ledger, prior_ids=frozenset(), allow_shrink=False)
         if (
             deviations
         ):  # rows of this model disagree on usp/mode — flag for upstream fix
-            report["deviations"].append((product, deviations))
+            # Keyed by (vendor, product), not the product name: two vendors selling the
+            # same model name would otherwise produce identical, unresolvable lines.
+            report["deviations"].append(((vendor, product), deviations))
 
     stanzas.sort(key=lambda pair: pair[0])
     body_block = "\n\n".join(text for _, text in stanzas) + "\n"
@@ -712,8 +849,9 @@ def build_columns_obo(models, ledger, prior_ids=frozenset(), allow_shrink=False)
 
 def report_markdown(models, report):
     """Markdown sync summary, printed to the Actions log and pasted into the PR body:
-    every id-ledger change (minted / renames / retired / resurrected) plus the
-    within-model data-quality deviations. One renderer so log and PR cannot drift."""
+    every id-ledger change (minted / renames / retired / resurrected), the within-model
+    data-quality deviations, and load_models' input-quality notes. One renderer so log
+    and PR cannot drift."""
 
     def key_str(key):
         company, column = key
@@ -758,13 +896,54 @@ def report_markdown(models, report):
         lines.append(
             f"### Within-model value deviations (fix upstream) — {len(report['deviations'])}"
         )
-        for product, dev in report["deviations"]:
+        for key, dev in report["deviations"]:
             for field, counts in dev.items():
-                lines.append(f"- `{product}` — {field}={counts}")
+                lines.append(f"- `{key_str(key)}` — {field}={counts}")
         lines.append("")
-    if len(lines) == 3:
-        lines.append("No id changes or within-model deviations.")
+    if report.get("unmapped_modes"):
+        lines.append(
+            f"### Unrecognised `mode` values (fix upstream) — {len(report['unmapped_modes'])}"
+        )
+        lines.append(
+            "_Not in the generator's mode vocabulary, so every term built from these "
+            "rows loses its `has_separation_mode` and its definition adjective. A whole "
+            "vocabulary drifting (e.g. a casing change) shows up here as one value with "
+            "a large count._"
+        )
+        lines += [
+            f"- `{value}` — {n} row(s)"
+            for value, n in sorted(report["unmapped_modes"].items())
+        ]
+        lines.append("")
+    if report.get("rejected_usp"):
+        lines.append(
+            f"### Unrecognised `usp` values (fix upstream) — {len(report['rejected_usp'])}"
+        )
+        lines.append(
+            "_Not USP packing codes, so they are dropped rather than published as "
+            "`usp_designation` annotations._"
+        )
+        lines += [
+            f"- `{value}` — {n} row(s)"
+            for value, n in sorted(report["rejected_usp"].items())
+        ]
+        lines.append("")
+    if report.get("dropped_rows"):
+        lines.append(
+            f"### Rows dropped for a blank company/column — {report['dropped_rows']}"
+        )
+        lines.append("")
+    if not any(report.values()):
+        lines.append("No id changes, input problems or within-model deviations.")
     return "\n".join(lines).rstrip() + "\n"
+
+
+def write_atomic(path, text):
+    """Write through a sibling temp file and os.replace, so a failed or killed run leaves
+    the previous file intact instead of a truncated one."""
+    tmp = f"{path}.tmp"
+    Path(tmp).write_text(text, encoding="utf-8")
+    os.replace(tmp, path)
 
 
 def main():
@@ -788,6 +967,12 @@ def main():
         help="accept a large drop in model count (no id is moved or reused)",
     )
     parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="run every check and print the report, but write neither the fragment "
+        "nor the id ledger",
+    )
+    parser.add_argument(
         "--report", help="write a Markdown data-quality summary to this path"
     )
     parser.add_argument(
@@ -804,11 +989,12 @@ def main():
 
     if args.check_core_refs:
         n = check_core_refs(args.core)
-        print(f"{args.core}: all {n} referenced terms present with expected names")
+        print(f"{args.core}: all {n} referenced terms and typedefs present, live, "
+              "and named as expected")
         return
 
     check_core_refs(args.core)
-    models = load_models(args.input)
+    models, notes = load_models(args.input)
     ledger = (
         {} if args.reset_ids else read_ledger(args.mapping)
     )  # read before we overwrite it
@@ -818,20 +1004,32 @@ def main():
     obo_text, ledger_text, report = build_columns_obo(
         models, ledger, prior_ids, allow_shrink=args.allow_shrink
     )
-    open(args.output, "w", encoding="utf-8").write(obo_text)
-    print(f"wrote {args.output}")
 
-    if os.path.dirname(args.mapping):
-        os.makedirs(os.path.dirname(args.mapping), exist_ok=True)
-    open(args.mapping, "w", encoding="utf-8").write(ledger_text)
-    print(f"wrote {args.mapping}")
+    if args.dry_run:
+        print(f"dry run: {args.mapping} and {args.output} left untouched")
+    else:
+        if os.path.dirname(args.mapping):
+            os.makedirs(os.path.dirname(args.mapping), exist_ok=True)
+        # The ledger lands FIRST. It is the identity authority, so a run that dies
+        # between the two writes must leave ids recorded-but-unpublished (harmless: the
+        # next run reuses them) rather than published-but-unrecorded, which would let
+        # the next run rebind published ids to different terms.
+        write_atomic(args.mapping, ledger_text)
+        print(f"wrote {args.mapping}")
+        write_atomic(args.output, obo_text)
+        print(f"wrote {args.output}")
 
-    text = report_markdown(models, report)
+    text = report_markdown(models, {**report, **notes})
     if args.report:
-        open(args.report, "w", encoding="utf-8").write(text)
+        write_atomic(args.report, text)
         print(f"wrote {args.report}")
     print(text, end="")
 
 
 if __name__ == "__main__":
-    main()
+    # These are upstream-data and cross-file problems, not bugs: report the message and
+    # exit 1 rather than dumping a traceback into the sync job's Actions log.
+    try:
+        main()
+    except (ValueError, RuntimeError, FileNotFoundError) as exc:
+        sys.exit(f"error: {exc}")


### PR DESCRIPTION
**Depends on #538 — merge that first and babysit the first obo merge and release.** Merging in order also means every future generator output is diffed against a validated initial state.

## What this adds
- `scripts/chrom_columns/generate_psi_ms_columns.py` — builds `psi-ms-columns.obo-fragment` from the [RepoRT column database](https://github.com/michaelwitting/RepoRT/blob/master/resources/column_database/column_database.tsv). Currently 65 vendors, 1863 models, 1928 terms, in the **MS:5000000–MS:5999999** band.
- `.github/repo-rt/psi-ms-column-ids.tsv` — the id ledger, committed here at its initial state. Keyed on `(company, column)` and append-only: a retired id is never reused, and a model returning to the catalog reclaims its original id.
  This is the two-way sync contract with RepoRT, which mirrors assigned ids back into a `psi_ms_id` catalog column — but **MS:ID authority stays here**.
- `.github/workflows/chrom_columns_sync_repo-rt.yml` — the weekly sync (Mondays 06:00 UTC, plus manual `workflow_dispatch`).
- `scripts/check_aggregate.py`, `scripts/chrom_columns/check_column_mapping.py`,`scripts/chrom_columns/check_no_duplicate_ids.py` — validation the sync job runs before it will open a PR.

## How the sync behaves
Each run regenerates the fragment and the ledger, validates them (fastobo parse, sort order, no duplicate ids, ledger/fragment consistency, and a trial splice into`psi-ms.obo` checked for unresolved references), patch-bumps `data-version` and refreshes `date` in `psi-ms-core.obo` when the fragment changed, and opens a PR.

**Nothing is committed to master automatically** — the PR must be reviewed, approved and merged by a human. When the regenerated files are identical to the committed ones, no PR is opened at all.

The PR body carries the full id-ledger change list (minted / renamed / retired / resurrected) plus any upstream data-quality problems to fix in RepoRT.

## Downstream
Once a sync PR is merged, the release chain follows automatically: `psi-ms.obo` is rebuilt, then `psi-ms.owl`, the tag, and the published release. For the initial roll-out #538 keeps a temporary human gate on the rebuilt `psi-ms.obo` as well; that gate is intended to be removed once the flow has proven itself.

This PR supersedes #530 and is _intended_ to be the "final" version, barring revisions.